### PR TITLE
fix: Sidebar logo homepage, LandingHeader blog/faq/avis, dropdown dark mode + hover fix

### DIFF
--- a/frontend-next/src/app/blog/page.tsx
+++ b/frontend-next/src/app/blog/page.tsx
@@ -8,6 +8,7 @@
 import { motion } from "framer-motion";
 import Link from "next/link";
 import { Calendar, Clock, ArrowRight } from "lucide-react";
+import { LandingHeader } from "@/components/landing-header";
 
 // Articles de blog (à terme, viendra d'une base de données ou CMS)
 const blogPosts = [
@@ -46,6 +47,7 @@ const blogPosts = [
 export default function BlogPage() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
+      <LandingHeader />
       {/* Header SEO optimisé */}
       <div className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 text-white pt-32 pb-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/frontend-next/src/app/faq/faq-client.tsx
+++ b/frontend-next/src/app/faq/faq-client.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown, Search, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import { InternalLinksFooter } from "@/components/seo/internal-links";
+import { LandingHeader } from "@/components/landing-header";
 import { faqCategories } from "./faq-data";
 
 export function FAQClient() {
@@ -22,7 +23,7 @@ export function FAQClient() {
       questions: category.questions.filter(
         (item) =>
           item.q.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          item.a.toLowerCase().includes(searchQuery.toLowerCase())
+          item.a.toLowerCase().includes(searchQuery.toLowerCase()),
       ),
     }))
     .filter((category) => category.questions.length > 0);
@@ -34,6 +35,7 @@ export function FAQClient() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
+      <LandingHeader />
       {/* Header */}
       <div className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 text-white pt-32 pb-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -47,9 +49,8 @@ export function FAQClient() {
               Questions Fréquentes
             </h1>
             <p className="text-xl text-gray-300 leading-relaxed mb-8">
-              Tout ce que vous devez savoir sur{" "}
-              <strong>HuntZen Jobs</strong>, la plateforme N°1 de recherche
-              d'emploi en France
+              Tout ce que vous devez savoir sur <strong>HuntZen Jobs</strong>,
+              la plateforme N°1 de recherche d'emploi en France
             </p>
 
             {/* Search bar */}

--- a/frontend-next/src/app/temoignages/testimonials-client.tsx
+++ b/frontend-next/src/app/temoignages/testimonials-client.tsx
@@ -11,6 +11,7 @@ import { Star, Search, Filter, ChevronDown } from "lucide-react";
 import Link from "next/link";
 import { Testimonial } from "./testimonials-data";
 import { InternalLinksFooter } from "@/components/seo/internal-links";
+import { LandingHeader } from "@/components/landing-header";
 
 interface TestimonialsClientProps {
   testimonials: Testimonial[];
@@ -71,6 +72,7 @@ export function TestimonialsClient({
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-white dark:from-gray-900 dark:to-gray-800">
+      <LandingHeader />
       {/* Header */}
       <div className="bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900 text-white pt-32 pb-20">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/frontend-next/src/components/landing-header.tsx
+++ b/frontend-next/src/components/landing-header.tsx
@@ -109,7 +109,10 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
           <div ref={outilsRef} className="relative">
             <button
               onClick={() => setOutilsOpen(!outilsOpen)}
-              onMouseEnter={() => setOutilsOpen(true)}
+              onMouseEnter={() => {
+                setOutilsOpen(true);
+                setRessourcesOpen(false);
+              }}
               className={`flex items-center gap-1 text-base font-bold transition-colors pb-1 ${shouldBeWhite ? "text-gray-900 hover:text-black" : "text-white/90 hover:text-white"}`}
             >
               Outils
@@ -136,7 +139,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setOutilsOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -147,7 +150,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setOutilsOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -162,7 +165,10 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
           <div ref={ressourcesRef} className="relative">
             <button
               onClick={() => setRessourcesOpen(!ressourcesOpen)}
-              onMouseEnter={() => setRessourcesOpen(true)}
+              onMouseEnter={() => {
+                setRessourcesOpen(true);
+                setOutilsOpen(false);
+              }}
               className={`flex items-center gap-1 text-base font-bold transition-colors pb-1 ${shouldBeWhite ? "text-gray-900 hover:text-black" : "text-white/90 hover:text-white"}`}
             >
               Ressources
@@ -189,7 +195,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -200,7 +206,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -211,7 +217,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >

--- a/frontend-next/src/components/layout/sidebar.tsx
+++ b/frontend-next/src/components/layout/sidebar.tsx
@@ -148,10 +148,7 @@ export function Sidebar({ className }: SidebarProps) {
         animate={{ opacity: 1, y: 0 }}
         className="sidebar-header flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700"
       >
-        <Link
-          href="/jobs"
-          className="sidebar-logo flex items-center gap-2.5 group"
-        >
+        <Link href="/" className="sidebar-logo flex items-center gap-2.5 group">
           <TextLogo
             isDark
             size="md"
@@ -235,7 +232,9 @@ export function Sidebar({ className }: SidebarProps) {
                       {item.badge}
                     </span>
                   )}
-                  {isLocked && <Lock className="w-4 h-4 text-gray-400 dark:text-gray-500" />}
+                  {isLocked && (
+                    <Lock className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+                  )}
                 </Link>
               </motion.div>
             );
@@ -315,7 +314,9 @@ export function Sidebar({ className }: SidebarProps) {
                     </span>
                   ) : null}
                 </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{user.email}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                  {user.email}
+                </p>
               </div>
             </Link>
           </motion.div>
@@ -366,7 +367,9 @@ export function Sidebar({ className }: SidebarProps) {
       <div className="sidebar-footer px-4 py-3 border-t border-gray-200 dark:border-gray-700">
         {/* Theme Toggle */}
         <div className="flex items-center justify-between px-4 py-2.5 mb-2">
-          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Thème</span>
+          <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            Thème
+          </span>
           <ThemeToggleSimple />
         </div>
 
@@ -422,10 +425,7 @@ export function Sidebar({ className }: SidebarProps) {
           <Menu className="w-6 h-6" />
         </button>
 
-        <Link
-          href="/jobs"
-          className="mobile-logo flex items-center gap-2 group"
-        >
+        <Link href="/" className="mobile-logo flex items-center gap-2 group">
           <TextLogo
             isDark
             size="sm"
@@ -482,7 +482,8 @@ export function Sidebar({ className }: SidebarProps) {
               Confirmer la déconnexion
             </AlertDialogTitle>
             <AlertDialogDescription className="text-gray-600 dark:text-gray-300">
-              Êtes-vous sûr de vouloir vous déconnecter ? Vos données sauvegardées seront conservées.
+              Êtes-vous sûr de vouloir vous déconnecter ? Vos données
+              sauvegardées seront conservées.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Fixes inclus (tâches #8, #9, #10)

### #8 - Logo sidebar → homepage
- Desktop sidebar logo: `href="/jobs"` → `href="/"`
- Mobile sidebar logo: `href="/jobs"` → `href="/"`

### #9 - LandingHeader sur pages publiques
- `blog/page.tsx` : ajout `<LandingHeader />`
- `faq/faq-client.tsx` : ajout `<LandingHeader />`
- `temoignages/testimonials-client.tsx` : ajout `<LandingHeader />`
- Le `pt-32` existant dans les headers de chaque page gère déjà l'espace sous la navbar fixe

### #10 - Dropdowns landing-header
- **Dark mode** : ajout `dark:text-gray-100` sur les liens dropdown (texte invisible avant sur `dark:bg-gray-800`)
- **Hover chevauchement** : exclusion mutuelle — hover sur "Outils" ferme "Ressources" et vice versa