### PR TITLE
fix(assistant): Fix infinite save loop - wrong auth provider in useCoachHistory

### DIFF
--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -110,6 +110,13 @@ export default function AssistantPage() {
     };
   }, [isCoachSessionActive, stopCoachSession]);
 
+  // Keep a stable ref to saveConversation to avoid re-triggering the auto-save
+  // effect every time saveMutation state changes (which would cause an infinite loop)
+  const saveConversationRef = useRef(saveConversation);
+  useEffect(() => {
+    saveConversationRef.current = saveConversation;
+  }, [saveConversation]);
+
   // Auto-save conversation (debounced)
   useEffect(() => {
     if (
@@ -119,20 +126,17 @@ export default function AssistantPage() {
     ) {
       const coachMessages = debouncedMessages.map(toCoachMessage);
 
-      saveConversation(
-        coachMessages,
-        sessionId,
-        currentConversationId || undefined,
-      ).then((id) => {
-        if (id && !currentConversationId) {
-          setCurrentConversationId(id);
-        }
-      });
+      saveConversationRef
+        .current(coachMessages, sessionId, currentConversationId || undefined)
+        .then((id) => {
+          if (id && !currentConversationId) {
+            setCurrentConversationId(id);
+          }
+        });
     }
   }, [
     debouncedMessages,
     loading,
-    saveConversation,
     sessionId,
     currentConversationId,
     hasFeature,

--- a/frontend-next/src/hooks/use-coach-history.ts
+++ b/frontend-next/src/hooks/use-coach-history.ts
@@ -4,33 +4,33 @@
  * Uses React Query for automatic cache management and optimistic updates
  */
 
-'use client'
+"use client";
 
-import { useState, useCallback, useEffect, useRef } from 'react'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { supabase } from '@/lib/supabase/client'
-import { useAuth } from '@/lib/auth/jwt-provider'
-import { useSubscription } from '@/contexts/subscription-context'
-import { toast } from 'sonner'
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase/client";
+import { useAuth } from "@/lib/auth/jwt-provider";
+import { useSubscription } from "@/contexts/subscription-context";
+import { toast } from "sonner";
 import type {
   CoachConversation,
   CoachMessage,
   ConversationMetadata,
   ConversationListFilters,
   UseCoachHistoryReturn,
-} from '@/types/coach-history'
+} from "@/types/coach-history";
 import {
   toConversationMetadata,
   generateSimpleTitle,
   CoachConversationSchema,
-} from '@/types/coach-history'
+} from "@/types/coach-history";
 
 // ============================================================================
 // CONSTANTS
 // ============================================================================
 
-const STORAGE_KEY = 'coach_conversations_fallback'
-const QUERY_KEY = 'coach-conversations'
+const STORAGE_KEY = "coach_conversations_fallback";
+const QUERY_KEY = "coach-conversations";
 
 // ============================================================================
 // HELPER FUNCTIONS
@@ -39,28 +39,32 @@ const QUERY_KEY = 'coach-conversations'
 /**
  * Fetch conversations from Supabase
  */
-async function fetchConversationsFromSupabase(userId: string): Promise<ConversationMetadata[]> {
+async function fetchConversationsFromSupabase(
+  userId: string,
+): Promise<ConversationMetadata[]> {
   const { data, error } = await supabase
-    .from('coach_conversations')
-    .select('*')
-    .eq('user_id', userId)
-    .order('last_message_at', { ascending: false })
-    .limit(100) // Reasonable limit for performance
+    .from("coach_conversations")
+    .select("*")
+    .eq("user_id", userId)
+    .order("last_message_at", { ascending: false })
+    .limit(100); // Reasonable limit for performance
 
-  if (error) throw error
+  if (error) throw error;
 
   // Validate and convert to metadata
-  const conversations = (data || []).map((conv) => {
-    try {
-      const validated = CoachConversationSchema.parse(conv)
-      return toConversationMetadata(validated)
-    } catch (e) {
-      console.error('Invalid conversation data:', conv, e)
-      return null
-    }
-  }).filter((c): c is ConversationMetadata => c !== null)
+  const conversations = (data || [])
+    .map((conv) => {
+      try {
+        const validated = CoachConversationSchema.parse(conv);
+        return toConversationMetadata(validated);
+      } catch (e) {
+        console.error("Invalid conversation data:", conv, e);
+        return null;
+      }
+    })
+    .filter((c): c is ConversationMetadata => c !== null);
 
-  return conversations
+  return conversations;
 }
 
 /**
@@ -68,18 +72,23 @@ async function fetchConversationsFromSupabase(userId: string): Promise<Conversat
  */
 function saveToLocalStorage(conversations: ConversationMetadata[]): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(conversations))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(conversations));
   } catch (e) {
-    console.warn('Failed to save to localStorage:', e)
+    console.warn("Failed to save to localStorage:", e);
     // If quota exceeded, try to clear old entries
-    if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+    if (e instanceof DOMException && e.name === "QuotaExceededError") {
       try {
-        const nonFavorites = conversations.filter((c) => !c.is_favorite)
-        const keepOnly = [...conversations.filter((c) => c.is_favorite), ...nonFavorites.slice(0, 10)]
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(keepOnly))
-        toast.warning('Espace de stockage limité - anciennes conversations supprimées')
+        const nonFavorites = conversations.filter((c) => !c.is_favorite);
+        const keepOnly = [
+          ...conversations.filter((c) => c.is_favorite),
+          ...nonFavorites.slice(0, 10),
+        ];
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(keepOnly));
+        toast.warning(
+          "Espace de stockage limité - anciennes conversations supprimées",
+        );
       } catch (retryError) {
-        console.error('Failed to save even after cleanup:', retryError)
+        console.error("Failed to save even after cleanup:", retryError);
       }
     }
   }
@@ -90,12 +99,12 @@ function saveToLocalStorage(conversations: ConversationMetadata[]): void {
  */
 function loadFromLocalStorage(): ConversationMetadata[] {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (!stored) return []
-    return JSON.parse(stored) as ConversationMetadata[]
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored) as ConversationMetadata[];
   } catch (e) {
-    console.error('Failed to load from localStorage:', e)
-    return []
+    console.error("Failed to load from localStorage:", e);
+    return [];
   }
 }
 
@@ -104,16 +113,18 @@ function loadFromLocalStorage(): ConversationMetadata[] {
 // ============================================================================
 
 export function useCoachHistory(): UseCoachHistoryReturn {
-  const { userId } = useAuth()
-  const { hasFeature } = useSubscription()
-  const queryClient = useQueryClient()
+  const { userId } = useAuth();
+  const { hasFeature } = useSubscription();
+  const queryClient = useQueryClient();
 
   // Local state
-  const [currentConversationId, setCurrentConversationId] = useState<string | null>(null)
-  const [error, setError] = useState<Error | null>(null)
+  const [currentConversationId, setCurrentConversationId] = useState<
+    string | null
+  >(null);
+  const [error, setError] = useState<Error | null>(null);
 
   // Check feature access
-  const canUseHistory = hasFeature('has_coach_history')
+  const canUseHistory = hasFeature("has_coach_history");
 
   // ============================================================================
   // FETCH CONVERSATIONS (React Query)
@@ -126,23 +137,26 @@ export function useCoachHistory(): UseCoachHistoryReturn {
   } = useQuery({
     queryKey: [QUERY_KEY, userId],
     queryFn: async () => {
-      if (!userId) return []
+      if (!userId) return [];
 
       try {
-        const data = await fetchConversationsFromSupabase(userId)
+        const data = await fetchConversationsFromSupabase(userId);
         // Sync to localStorage on successful fetch
-        saveToLocalStorage(data)
-        return data
+        saveToLocalStorage(data);
+        return data;
       } catch (err) {
-        console.error('Failed to fetch from Supabase, using localStorage fallback:', err)
-        toast.error('Mode hors ligne - utilisation du cache local')
-        return loadFromLocalStorage()
+        console.error(
+          "Failed to fetch from Supabase, using localStorage fallback:",
+          err,
+        );
+        toast.error("Mode hors ligne - utilisation du cache local");
+        return loadFromLocalStorage();
       }
     },
     enabled: !!userId && canUseHistory,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes (was cacheTime in v4)
-  })
+  });
 
   // ============================================================================
   // SAVE CONVERSATION (Mutation with optimistic update)
@@ -154,31 +168,33 @@ export function useCoachHistory(): UseCoachHistoryReturn {
       sessionId,
       conversationId,
     }: {
-      messages: CoachMessage[]
-      sessionId: string
-      conversationId?: string
+      messages: CoachMessage[];
+      sessionId: string;
+      conversationId?: string;
     }) => {
-      if (!userId) throw new Error('User not authenticated')
+      if (!userId) throw new Error("User not authenticated");
 
-      const title = conversationId ? undefined : generateSimpleTitle(messages, 60)
+      const title = conversationId
+        ? undefined
+        : generateSimpleTitle(messages, 60);
 
       if (conversationId) {
         // UPDATE existing conversation
         const { error: updateError } = await supabase
-          .from('coach_conversations')
+          .from("coach_conversations")
           .update({
             messages,
             updated_at: new Date().toISOString(),
           })
-          .eq('id', conversationId)
-          .eq('user_id', userId)
+          .eq("id", conversationId)
+          .eq("user_id", userId);
 
-        if (updateError) throw updateError
-        return conversationId
+        if (updateError) throw updateError;
+        return conversationId;
       } else {
         // INSERT new conversation
         const { data: newConv, error: insertError } = await supabase
-          .from('coach_conversations')
+          .from("coach_conversations")
           .insert({
             user_id: userId,
             session_id: sessionId,
@@ -186,65 +202,72 @@ export function useCoachHistory(): UseCoachHistoryReturn {
             title,
           })
           .select()
-          .single()
+          .single();
 
-        if (insertError) throw insertError
-        return newConv.id
+        if (insertError) throw insertError;
+        return newConv.id;
       }
     },
     onMutate: async ({ messages, conversationId }) => {
       // Cancel outgoing refetches
-      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] })
+      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] });
 
       // Snapshot previous value
-      const previousConversations = queryClient.getQueryData<ConversationMetadata[]>([
-        QUERY_KEY,
-        userId,
-      ])
+      const previousConversations = queryClient.getQueryData<
+        ConversationMetadata[]
+      >([QUERY_KEY, userId]);
 
       // Optimistic update
-      queryClient.setQueryData<ConversationMetadata[]>([QUERY_KEY, userId], (old = []) => {
-        if (conversationId) {
-          // Update existing
-          return old.map((c) =>
-            c.id === conversationId
-              ? {
-                  ...c,
-                  message_count: messages.length,
-                  last_message_at: new Date().toISOString(),
-                }
-              : c
-          )
-        } else {
-          // Add new (placeholder)
-          const newMetadata: ConversationMetadata = {
-            id: 'temp-' + Date.now(),
-            title: generateSimpleTitle(messages, 60),
-            is_favorite: false,
-            message_count: messages.length,
-            last_message_at: new Date().toISOString(),
-            created_at: new Date().toISOString(),
-            preview: messages.find((m) => m.role === 'user')?.content.slice(0, 100),
+      queryClient.setQueryData<ConversationMetadata[]>(
+        [QUERY_KEY, userId],
+        (old = []) => {
+          if (conversationId) {
+            // Update existing
+            return old.map((c) =>
+              c.id === conversationId
+                ? {
+                    ...c,
+                    message_count: messages.length,
+                    last_message_at: new Date().toISOString(),
+                  }
+                : c,
+            );
+          } else {
+            // Add new (placeholder)
+            const newMetadata: ConversationMetadata = {
+              id: "temp-" + Date.now(),
+              title: generateSimpleTitle(messages, 60),
+              is_favorite: false,
+              message_count: messages.length,
+              last_message_at: new Date().toISOString(),
+              created_at: new Date().toISOString(),
+              preview: messages
+                .find((m) => m.role === "user")
+                ?.content.slice(0, 100),
+            };
+            return [newMetadata, ...old];
           }
-          return [newMetadata, ...old]
-        }
-      })
+        },
+      );
 
-      return { previousConversations }
+      return { previousConversations };
     },
     onError: (err, variables, context) => {
       // Rollback on error
       if (context?.previousConversations) {
-        queryClient.setQueryData([QUERY_KEY, userId], context.previousConversations)
+        queryClient.setQueryData(
+          [QUERY_KEY, userId],
+          context.previousConversations,
+        );
       }
 
-      console.error('Save failed, trying localStorage fallback:', err)
-      setError(err as Error)
+      console.error("Save failed, trying localStorage fallback:", err);
+      setError(err as Error);
 
       // Fallback to localStorage
       try {
-        const { messages, sessionId, conversationId } = variables
-        const fallbackId = conversationId || `local_${Date.now()}`
+        const { messages, sessionId, conversationId } = variables;
+        const fallbackId = conversationId || `local_${Date.now()}`;
 
         const fallbackConv: ConversationMetadata = {
           id: fallbackId,
@@ -253,28 +276,30 @@ export function useCoachHistory(): UseCoachHistoryReturn {
           message_count: messages.length,
           last_message_at: new Date().toISOString(),
           created_at: new Date().toISOString(),
-          preview: messages.find((m) => m.role === 'user')?.content.slice(0, 100),
-        }
+          preview: messages
+            .find((m) => m.role === "user")
+            ?.content.slice(0, 100),
+        };
 
-        const stored = loadFromLocalStorage()
+        const stored = loadFromLocalStorage();
         const updated = conversationId
           ? stored.map((c) => (c.id === conversationId ? fallbackConv : c))
-          : [fallbackConv, ...stored]
+          : [fallbackConv, ...stored];
 
-        saveToLocalStorage(updated)
-        queryClient.setQueryData([QUERY_KEY, userId], updated)
+        saveToLocalStorage(updated);
+        queryClient.setQueryData([QUERY_KEY, userId], updated);
 
-        toast.warning('Sauvegarde locale - sera synchronisée plus tard')
+        toast.warning("Sauvegarde locale - sera synchronisée plus tard");
       } catch (fallbackErr) {
-        console.error('Fallback save also failed:', fallbackErr)
-        toast.error('Échec de la sauvegarde de la conversation')
+        console.error("Fallback save also failed:", fallbackErr);
+        toast.error("Échec de la sauvegarde de la conversation");
       }
     },
     onSuccess: () => {
       // Refetch to get computed fields from database
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, userId] })
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, userId] });
     },
-  })
+  });
 
   // ============================================================================
   // DELETE CONVERSATION
@@ -282,46 +307,52 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 
   const deleteMutation = useMutation({
     mutationFn: async (conversationId: string) => {
-      if (!userId) throw new Error('User not authenticated')
+      if (!userId) throw new Error("User not authenticated");
 
       const { error: deleteError } = await supabase
-        .from('coach_conversations')
+        .from("coach_conversations")
         .delete()
-        .eq('id', conversationId)
-        .eq('user_id', userId)
+        .eq("id", conversationId)
+        .eq("user_id", userId);
 
-      if (deleteError) throw deleteError
+      if (deleteError) throw deleteError;
     },
     onMutate: async (conversationId) => {
-      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] })
+      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] });
 
-      const previousConversations = queryClient.getQueryData<ConversationMetadata[]>([
-        QUERY_KEY,
-        userId,
-      ])
+      const previousConversations = queryClient.getQueryData<
+        ConversationMetadata[]
+      >([QUERY_KEY, userId]);
 
       // Optimistic update
-      queryClient.setQueryData<ConversationMetadata[]>([QUERY_KEY, userId], (old = []) =>
-        old.filter((c) => c.id !== conversationId)
-      )
+      queryClient.setQueryData<ConversationMetadata[]>(
+        [QUERY_KEY, userId],
+        (old = []) => old.filter((c) => c.id !== conversationId),
+      );
 
-      return { previousConversations }
+      return { previousConversations };
     },
     onError: (err, conversationId, context) => {
       if (context?.previousConversations) {
-        queryClient.setQueryData([QUERY_KEY, userId], context.previousConversations)
+        queryClient.setQueryData(
+          [QUERY_KEY, userId],
+          context.previousConversations,
+        );
       }
-      console.error('Delete failed:', err)
-      setError(err as Error)
-      toast.error('Échec de la suppression')
+      console.error("Delete failed:", err);
+      setError(err as Error);
+      toast.error("Échec de la suppression");
     },
     onSuccess: () => {
-      toast.success('Conversation supprimée')
+      toast.success("Conversation supprimée");
       // Sync to localStorage
-      const current = queryClient.getQueryData<ConversationMetadata[]>([QUERY_KEY, userId])
-      if (current) saveToLocalStorage(current)
+      const current = queryClient.getQueryData<ConversationMetadata[]>([
+        QUERY_KEY,
+        userId,
+      ]);
+      if (current) saveToLocalStorage(current);
     },
-  })
+  });
 
   // ============================================================================
   // TOGGLE FAVORITE
@@ -329,53 +360,60 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 
   const toggleFavoriteMutation = useMutation({
     mutationFn: async (conversationId: string) => {
-      if (!userId) throw new Error('User not authenticated')
+      if (!userId) throw new Error("User not authenticated");
 
-      const conversation = conversations.find((c) => c.id === conversationId)
-      if (!conversation) throw new Error('Conversation not found')
+      const conversation = conversations.find((c) => c.id === conversationId);
+      if (!conversation) throw new Error("Conversation not found");
 
-      const newFavoriteState = !conversation.is_favorite
+      const newFavoriteState = !conversation.is_favorite;
 
       const { error: updateError } = await supabase
-        .from('coach_conversations')
+        .from("coach_conversations")
         .update({ is_favorite: newFavoriteState })
-        .eq('id', conversationId)
-        .eq('user_id', userId)
+        .eq("id", conversationId)
+        .eq("user_id", userId);
 
-      if (updateError) throw updateError
+      if (updateError) throw updateError;
 
-      return { conversationId, newFavoriteState }
+      return { conversationId, newFavoriteState };
     },
     onMutate: async (conversationId) => {
-      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] })
+      await queryClient.cancelQueries({ queryKey: [QUERY_KEY, userId] });
 
-      const previousConversations = queryClient.getQueryData<ConversationMetadata[]>([
-        QUERY_KEY,
-        userId,
-      ])
+      const previousConversations = queryClient.getQueryData<
+        ConversationMetadata[]
+      >([QUERY_KEY, userId]);
 
-      const conversation = conversations.find((c) => c.id === conversationId)
+      const conversation = conversations.find((c) => c.id === conversationId);
 
-      queryClient.setQueryData<ConversationMetadata[]>([QUERY_KEY, userId], (old = []) =>
-        old.map((c) =>
-          c.id === conversationId ? { ...c, is_favorite: !c.is_favorite } : c
-        )
-      )
+      queryClient.setQueryData<ConversationMetadata[]>(
+        [QUERY_KEY, userId],
+        (old = []) =>
+          old.map((c) =>
+            c.id === conversationId ? { ...c, is_favorite: !c.is_favorite } : c,
+          ),
+      );
 
-      return { previousConversations, conversation }
+      return { previousConversations, conversation };
     },
     onError: (err, conversationId, context) => {
       if (context?.previousConversations) {
-        queryClient.setQueryData([QUERY_KEY, userId], context.previousConversations)
+        queryClient.setQueryData(
+          [QUERY_KEY, userId],
+          context.previousConversations,
+        );
       }
-      console.error('Toggle favorite failed:', err)
-      setError(err as Error)
+      console.error("Toggle favorite failed:", err);
+      setError(err as Error);
     },
     onSuccess: () => {
-      const current = queryClient.getQueryData<ConversationMetadata[]>([QUERY_KEY, userId])
-      if (current) saveToLocalStorage(current)
+      const current = queryClient.getQueryData<ConversationMetadata[]>([
+        QUERY_KEY,
+        userId,
+      ]);
+      if (current) saveToLocalStorage(current);
     },
-  })
+  });
 
   // ============================================================================
   // LOAD CONVERSATION
@@ -383,28 +421,28 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 
   const loadConversation = useCallback(
     async (conversationId: string): Promise<CoachConversation | null> => {
-      if (!userId) return null
+      if (!userId) return null;
 
       try {
         const { data, error: loadError } = await supabase
-          .from('coach_conversations')
-          .select('*')
-          .eq('id', conversationId)
-          .eq('user_id', userId)
-          .single()
+          .from("coach_conversations")
+          .select("*")
+          .eq("id", conversationId)
+          .eq("user_id", userId)
+          .single();
 
-        if (loadError) throw loadError
+        if (loadError) throw loadError;
 
-        return CoachConversationSchema.parse(data)
+        return CoachConversationSchema.parse(data);
       } catch (err) {
-        console.error('Failed to load conversation:', err)
-        setError(err as Error)
-        toast.error('Échec du chargement de la conversation')
-        return null
+        console.error("Failed to load conversation:", err);
+        setError(err as Error);
+        toast.error("Échec du chargement de la conversation");
+        return null;
       }
     },
-    [userId]
-  )
+    [userId],
+  );
 
   // ============================================================================
   // SEARCH CONVERSATIONS (Client-side)
@@ -412,18 +450,18 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 
   const searchConversations = useCallback(
     (query: string): ConversationMetadata[] => {
-      if (!query.trim()) return conversations
+      if (!query.trim()) return conversations;
 
-      const lowerQuery = query.toLowerCase()
+      const lowerQuery = query.toLowerCase();
 
       return conversations.filter(
         (c) =>
           c.title.toLowerCase().includes(lowerQuery) ||
-          c.preview?.toLowerCase().includes(lowerQuery)
-      )
+          c.preview?.toLowerCase().includes(lowerQuery),
+      );
     },
-    [conversations]
-  )
+    [conversations],
+  );
 
   // ============================================================================
   // FILTER CONVERSATIONS
@@ -431,54 +469,58 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 
   const filterConversations = useCallback(
     (filters: ConversationListFilters): ConversationMetadata[] => {
-      let filtered = [...conversations]
+      let filtered = [...conversations];
 
       // Search query
       if (filters.searchQuery) {
-        filtered = searchConversations(filters.searchQuery)
+        filtered = searchConversations(filters.searchQuery);
       }
 
       // Favorites only
       if (filters.showFavoritesOnly) {
-        filtered = filtered.filter((c) => c.is_favorite)
+        filtered = filtered.filter((c) => c.is_favorite);
       }
 
       // Date range
-      if (filters.dateRange && filters.dateRange !== 'all') {
-        const now = new Date()
-        const daysAgo = filters.dateRange === 'week' ? 7 : 30
-        const cutoffDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000)
+      if (filters.dateRange && filters.dateRange !== "all") {
+        const now = new Date();
+        const daysAgo = filters.dateRange === "week" ? 7 : 30;
+        const cutoffDate = new Date(
+          now.getTime() - daysAgo * 24 * 60 * 60 * 1000,
+        );
 
-        filtered = filtered.filter((c) => new Date(c.last_message_at) >= cutoffDate)
+        filtered = filtered.filter(
+          (c) => new Date(c.last_message_at) >= cutoffDate,
+        );
       }
 
       // Sort
       if (filters.sortBy) {
         filtered.sort((a, b) => {
-          let comparison = 0
+          let comparison = 0;
 
           switch (filters.sortBy) {
-            case 'date':
+            case "date":
               comparison =
                 new Date(b.last_message_at).getTime() -
-                new Date(a.last_message_at).getTime()
-              break
-            case 'message_count':
-              comparison = b.message_count - a.message_count
-              break
-            case 'title':
-              comparison = a.title.localeCompare(b.title)
-              break
+                new Date(a.last_message_at).getTime();
+              break;
+            case "message_count":
+              comparison = b.message_count - a.message_count;
+              break;
+            case "title":
+              comparison = a.title.localeCompare(b.title);
+              break;
           }
 
-          return filters.sortOrder === 'asc' ? -comparison : comparison
-        })
+          return filters.sortOrder === "asc" ? -comparison : comparison;
+        });
       }
 
-      return filtered
+      return filtered;
     },
-    [conversations, searchConversations]
-  )
+    [conversations, searchConversations],
+  );
 
   // ============================================================================
   // GENERATE TITLE (Client-side fallback)
@@ -488,10 +530,10 @@ export function useCoachHistory(): UseCoachHistoryReturn {
     async (messages: CoachMessage[]): Promise<string> => {
       // TODO: Call backend API for LLM-generated titles
       // For now, use client-side generation
-      return generateSimpleTitle(messages, 60)
+      return generateSimpleTitle(messages, 60);
     },
-    []
-  )
+    [],
+  );
 
   // ============================================================================
   // PUBLIC API
@@ -501,47 +543,56 @@ export function useCoachHistory(): UseCoachHistoryReturn {
     async (
       messages: CoachMessage[],
       sessionId: string,
-      conversationId?: string
+      conversationId?: string,
     ): Promise<string | null> => {
       if (!canUseHistory) {
-        console.warn('User does not have access to coach history feature')
-        return null
+        console.warn("User does not have access to coach history feature");
+        return null;
       }
 
-      if (messages.length === 0) return null
+      if (!userId) {
+        // Not authenticated yet - skip silently to avoid infinite error loop
+        return null;
+      }
+
+      if (messages.length === 0) return null;
 
       try {
-        const result = await saveMutation.mutateAsync({ messages, sessionId, conversationId })
-        return result
+        const result = await saveMutation.mutateAsync({
+          messages,
+          sessionId,
+          conversationId,
+        });
+        return result;
       } catch (err) {
-        console.error('Save conversation error:', err)
-        return null
+        console.error("Save conversation error:", err);
+        return null;
       }
     },
-    [canUseHistory, saveMutation]
-  )
+    [canUseHistory, userId, saveMutation],
+  );
 
   const deleteConversation = useCallback(
     async (conversationId: string): Promise<void> => {
-      await deleteMutation.mutateAsync(conversationId)
+      await deleteMutation.mutateAsync(conversationId);
     },
-    [deleteMutation]
-  )
+    [deleteMutation],
+  );
 
   const toggleFavorite = useCallback(
     async (conversationId: string): Promise<void> => {
-      await toggleFavoriteMutation.mutateAsync(conversationId)
+      await toggleFavoriteMutation.mutateAsync(conversationId);
     },
-    [toggleFavoriteMutation]
-  )
+    [toggleFavoriteMutation],
+  );
 
   const refreshConversations = useCallback(async () => {
-    await refetch()
-  }, [refetch])
+    await refetch();
+  }, [refetch]);
 
   const clearError = useCallback(() => {
-    setError(null)
-  }, [])
+    setError(null);
+  }, []);
 
   return {
     conversations,
@@ -560,7 +611,7 @@ export function useCoachHistory(): UseCoachHistoryReturn {
     setCurrentConversationId,
     refreshConversations,
     clearError,
-  }
+  };
 }
 
 // ============================================================================
@@ -568,17 +619,17 @@ export function useCoachHistory(): UseCoachHistoryReturn {
 // ============================================================================
 
 export function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
   useEffect(() => {
     const handler = setTimeout(() => {
-      setDebouncedValue(value)
-    }, delay)
+      setDebouncedValue(value);
+    }, delay);
 
     return () => {
-      clearTimeout(handler)
-    }
-  }, [value, delay])
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
 
-  return debouncedValue
+  return debouncedValue;
 }

--- a/frontend-next/src/hooks/use-coach-history.ts
+++ b/frontend-next/src/hooks/use-coach-history.ts
@@ -9,7 +9,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase/client";
-import { useAuth } from "@/lib/auth/jwt-provider";
+import { useAuth } from "@/contexts/auth-context";
 import { useSubscription } from "@/contexts/subscription-context";
 import { toast } from "sonner";
 import type {
@@ -113,7 +113,8 @@ function loadFromLocalStorage(): ConversationMetadata[] {
 // ============================================================================
 
 export function useCoachHistory(): UseCoachHistoryReturn {
-  const { userId } = useAuth();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
   const { hasFeature } = useSubscription();
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
Fixes #31

## Root cause

`use-coach-history.ts` imported `useAuth` from `@/lib/auth/jwt-provider` — a provider that is **never mounted** in the app's provider tree. The mounted provider is `AuthProvider` from `@/contexts/auth-context`.

This caused `useAuth()` to always return the default context `{ userId: null }`, so every save attempt threw `Error: User not authenticated`, regardless of whether the user was logged in.

## Fix (3 layers)

**Layer 1 — Root cause** (`use-coach-history.ts`):
Switch from `@/lib/auth/jwt-provider` to `@/contexts/auth-context` and derive `userId` from `user?.id`.

**Layer 2 — Defensive guard** (`use-coach-history.ts`):
`saveConversation` bails silently when `userId` is null, preventing the mutation from firing and `onError` from triggering `setError()` re-renders.

**Layer 3 — Ref pattern** (`assistant/page.tsx`):
Hold `saveConversation` in a ref and remove it from the auto-save `useEffect` deps. This prevents the effect from re-firing every time `saveMutation` changes its object reference (pending ↔ idle transitions).

## Test plan

- [ ] Open assistant page as authenticated user
- [ ] Send a message and receive a response
- [ ] Verify no "Save failed" / "User not authenticated" loop in console
- [ ] Verify input field remains usable after first AI response
- [ ] Verify conversation is saved when user has `has_coach_history` feature