### PR TITLE
fix(jobs): Fill search input when clicking popular job suggestions

### DIFF
--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -66,6 +66,9 @@ import {
 
 export default function JobsPage() {
   const [jobTitle, setJobTitle] = useState("");
+  const [popularQuery, setPopularQuery] = useState<string | undefined>(
+    undefined,
+  );
   const [selectedCountry, setSelectedCountry] = useState("");
   const [selectedCity, setSelectedCity] = useState("");
   const [contractType, setContractType] = useState("");
@@ -716,6 +719,7 @@ export default function JobsPage() {
             onSearch={handleSearch}
             isLoading={searchQuery.isFetching}
             disabled={false}
+            initialQuery={popularQuery}
           />
         ) : (
           <Card className="shadow-sm border-2 border-slate-200 bg-white">
@@ -1540,10 +1544,11 @@ export default function JobsPage() {
         jobs.length === 0 && (
           <JobsPlaceholder
             onSearchClick={(popularJobTitle) => {
-              // Fill the input and scroll to it so user can see & confirm
-              setJobTitle(popularJobTitle);
+              setPopularQuery(popularJobTitle);
               setTimeout(() => {
-                const input = document.getElementById("jobTitle");
+                const input =
+                  document.getElementById("query-inline") ??
+                  document.getElementById("query-mobile");
                 input?.scrollIntoView({ behavior: "smooth", block: "center" });
                 input?.focus();
               }, 50);

--- a/frontend-next/src/components/jobs/search-form-inline.tsx
+++ b/frontend-next/src/components/jobs/search-form-inline.tsx
@@ -1,12 +1,15 @@
-'use client'
+"use client";
 
-import { useState, useEffect } from 'react'
-import { Search, MapPin, Globe } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { AutocompleteInput, type AutocompleteOption } from '@/components/ui/autocomplete-input'
-import { useSubscription } from '@/contexts/subscription-context'
-import { toast } from 'sonner'
-import { huntzenApi } from '@/lib/api/huntzen-client'
+import { useState, useEffect } from "react";
+import { Search, MapPin, Globe } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AutocompleteInput,
+  type AutocompleteOption,
+} from "@/components/ui/autocomplete-input";
+import { useSubscription } from "@/contexts/subscription-context";
+import { toast } from "sonner";
+import { huntzenApi } from "@/lib/api/huntzen-client";
 
 /**
  * SearchFormInline - Horizontal search form for Jobs page
@@ -23,129 +26,143 @@ import { huntzenApi } from '@/lib/api/huntzen-client'
  */
 
 interface SearchFormInlineProps {
-  onSearch: (params: SearchParams) => void
-  isLoading?: boolean
-  disabled?: boolean
+  onSearch: (params: SearchParams) => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+  initialQuery?: string;
 }
 
 export interface SearchParams {
-  query: string
-  location: string
-  country: string
-  radiusKm?: number
-  includeRemote?: boolean
+  query: string;
+  location: string;
+  country: string;
+  radiusKm?: number;
+  includeRemote?: boolean;
 }
 
-export function SearchFormInline({ onSearch, isLoading = false, disabled = false }: SearchFormInlineProps) {
-  const [query, setQuery] = useState('')
-  const [location, setLocation] = useState('')
-  const [country, setCountry] = useState('')
-  const [selectedCountryName, setSelectedCountryName] = useState('')
-  const [isCountryValid, setIsCountryValid] = useState(false) // Track if valid country selected
-  const [radiusKm, setRadiusKm] = useState(50) // Default 50km radius
-  const [includeRemote, setIncludeRemote] = useState(true) // Include remote jobs by default
-  const [errors, setErrors] = useState<Record<string, string>>({})
+export function SearchFormInline({
+  onSearch,
+  isLoading = false,
+  disabled = false,
+  initialQuery,
+}: SearchFormInlineProps) {
+  const [query, setQuery] = useState(initialQuery ?? "");
+  const [location, setLocation] = useState("");
+  const [country, setCountry] = useState("");
+  const [selectedCountryName, setSelectedCountryName] = useState("");
+  const [isCountryValid, setIsCountryValid] = useState(false); // Track if valid country selected
+  const [radiusKm, setRadiusKm] = useState(50); // Default 50km radius
+  const [includeRemote, setIncludeRemote] = useState(true); // Include remote jobs by default
+  const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const { canUse, getRemaining, isFreePlan } = useSubscription()
+  const { canUse, getRemaining, isFreePlan } = useSubscription();
 
   // Fetch countries for autocomplete
-  const fetchCountries = async (query: string): Promise<AutocompleteOption[]> => {
-    if (!query) return []
+  const fetchCountries = async (
+    query: string,
+  ): Promise<AutocompleteOption[]> => {
+    if (!query) return [];
     try {
-      const countries = await huntzenApi.getCountries()
+      const countries = await huntzenApi.getCountries();
       return countries
-        .filter(c => c.name.toLowerCase().includes(query.toLowerCase()))
+        .filter((c) => c.name.toLowerCase().includes(query.toLowerCase()))
         .slice(0, 8)
-        .map(c => ({ label: c.name, value: c.code }))
+        .map((c) => ({ label: c.name, value: c.code }));
     } catch (error) {
-      return []
+      return [];
     }
-  }
+  };
 
   // Fetch cities for autocomplete - DYNAMIC SEARCH with OpenStreetMap
   const fetchCities = async (query: string): Promise<AutocompleteOption[]> => {
-    console.log('🏙️ fetchCities called:', { query, country, isCountryValid })
+    console.log("🏙️ fetchCities called:", { query, country, isCountryValid });
     if (!query || query.length < 1 || !country) {
-      console.log('❌ Missing query or country code')
-      return []
+      console.log("❌ Missing query or country code");
+      return [];
     }
     try {
-      console.log('🌐 Searching cities dynamically via Nominatim:', query)
+      console.log("🌐 Searching cities dynamically via Nominatim:", query);
       // Use dynamic search with OpenStreetMap Nominatim
-      const cities = await huntzenApi.searchCities(query, country)
-      console.log('✅ Cities found:', cities.length)
-      return cities.map(c => ({ label: c, value: c }))
+      const cities = await huntzenApi.searchCities(query, country);
+      console.log("✅ Cities found:", cities.length);
+      return cities.map((c) => ({ label: c, value: c }));
     } catch (error) {
-      console.error('❌ Error searching cities:', error)
-      return []
+      console.error("❌ Error searching cities:", error);
+      return [];
     }
-  }
+  };
 
   // Handle country selection
   const handleCountryChange = (value: string) => {
-    console.log('🔍 handleCountryChange received:', { value, length: value.length, isUppercase: value === value.toUpperCase() })
-    setCountry(value)
+    console.log("🔍 handleCountryChange received:", {
+      value,
+      length: value.length,
+      isUppercase: value === value.toUpperCase(),
+    });
+    setCountry(value);
 
     // Clear country name when empty
     if (!value) {
-      setSelectedCountryName('')
-      setIsCountryValid(false)
-      console.log('❌ Country cleared')
-      return
+      setSelectedCountryName("");
+      setIsCountryValid(false);
+      console.log("❌ Country cleared");
+      return;
     }
 
     // If it's a valid country code (2-3 chars), find the country name
     if (value.length >= 2 && value.length <= 3) {
-      console.log('✅ Valid code format, fetching country name...')
-      huntzenApi.getCountries().then(countries => {
-        const found = countries.find(c => c.code.toLowerCase() === value.toLowerCase())
+      console.log("✅ Valid code format, fetching country name...");
+      huntzenApi.getCountries().then((countries) => {
+        const found = countries.find(
+          (c) => c.code.toLowerCase() === value.toLowerCase(),
+        );
         if (found) {
-          console.log('✅ Country found:', found.name)
-          setSelectedCountryName(found.name)
-          setIsCountryValid(true)
+          console.log("✅ Country found:", found.name);
+          setSelectedCountryName(found.name);
+          setIsCountryValid(true);
         } else {
-          console.log('❌ Country code not found in list')
-          setIsCountryValid(false)
+          console.log("❌ Country code not found in list");
+          setIsCountryValid(false);
         }
-      })
+      });
     } else {
       // User is typing text, not a valid code yet
-      console.log('⏳ User typing, not a valid code yet')
-      setIsCountryValid(false)
+      console.log("⏳ User typing, not a valid code yet");
+      setIsCountryValid(false);
     }
-  }
+  };
 
   // Validation
   const validate = (): boolean => {
-    const newErrors: Record<string, string> = {}
+    const newErrors: Record<string, string> = {};
 
     if (!query.trim()) {
-      newErrors.query = 'Le métier est requis'
+      newErrors.query = "Le métier est requis";
     }
 
     if (!country.trim()) {
-      newErrors.country = 'Le pays est requis'
+      newErrors.country = "Le pays est requis";
     } else if (!isCountryValid) {
-      newErrors.country = 'Veuillez sélectionner un pays dans la liste'
+      newErrors.country = "Veuillez sélectionner un pays dans la liste";
     }
 
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
 
   // Handle search
   const handleSearch = () => {
     // Validate form
     if (!validate()) {
-      toast.error('Veuillez remplir tous les champs requis')
-      return
+      toast.error("Veuillez remplir tous les champs requis");
+      return;
     }
 
     // Check freemium limits
-    if (!canUse('job_search')) {
-      const remaining = getRemaining('job_search')
-      toast.error(`Limite de recherches atteinte. Rechargez à ${remaining}`)
-      return
+    if (!canUse("job_search")) {
+      const remaining = getRemaining("job_search");
+      toast.error(`Limite de recherches atteinte. Rechargez à ${remaining}`);
+      return;
     }
 
     // Execute search
@@ -155,24 +172,31 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
       country: country.trim(),
       radiusKm: location.trim() ? radiusKm : undefined, // Only send radius if city is specified
       includeRemote, // Include remote jobs setting
-    })
+    });
 
     // Clear errors on successful search
-    setErrors({})
-  }
+    setErrors({});
+  };
+
+  // Sync initialQuery prop into internal state when it changes
+  useEffect(() => {
+    if (initialQuery !== undefined && initialQuery !== "") {
+      setQuery(initialQuery);
+    }
+  }, [initialQuery]);
 
   // Clear errors when user types
   useEffect(() => {
     if (query.trim()) {
-      setErrors(prev => ({ ...prev, query: '' }))
+      setErrors((prev) => ({ ...prev, query: "" }));
     }
-  }, [query])
+  }, [query]);
 
   useEffect(() => {
     if (country.trim()) {
-      setErrors(prev => ({ ...prev, country: '' }))
+      setErrors((prev) => ({ ...prev, country: "" }));
     }
-  }, [country])
+  }, [country]);
 
   return (
     <div className="w-full">
@@ -195,9 +219,9 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
                 onChange={(e) => setQuery(e.target.value)}
                 disabled={disabled || isLoading}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault()
-                    handleSearch()
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSearch();
                   }
                 }}
                 className={`
@@ -209,13 +233,14 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
                   focus:outline-none focus:ring-2 focus:ring-offset-0
                   transition-all duration-200
                   disabled:opacity-50 disabled:cursor-not-allowed
-                  ${errors.query
-                    ? 'border-red-300 focus:ring-red-500 focus:border-red-500'
-                    : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+                  ${
+                    errors.query
+                      ? "border-red-300 focus:ring-red-500 focus:border-red-500"
+                      : "border-gray-300 focus:ring-blue-500 focus:border-blue-500"
                   }
                 `}
                 aria-invalid={!!errors.query}
-                aria-describedby={errors.query ? 'query-error' : undefined}
+                aria-describedby={errors.query ? "query-error" : undefined}
               />
             </div>
             {errors.query && (
@@ -249,7 +274,11 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
               onSearch={fetchCities}
               disabled={disabled || isLoading || !isCountryValid}
               icon={<MapPin className="h-5 w-5" />}
-              emptyMessage={!isCountryValid ? "Sélectionnez d'abord un pays" : "Aucune ville trouvée"}
+              emptyMessage={
+                !isCountryValid
+                  ? "Sélectionnez d'abord un pays"
+                  : "Aucune ville trouvée"
+              }
             />
           </div>
 
@@ -261,7 +290,7 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
               size="lg"
               className="px-6 whitespace-nowrap bg-gradient-to-r from-huntzen-blue to-huntzen-turquoise hover:from-huntzen-blue/90 hover:to-huntzen-turquoise/90"
             >
-              {isLoading ? 'Recherche...' : 'Rechercher'}
+              {isLoading ? "Recherche..." : "Rechercher"}
             </Button>
           </div>
         </div>
@@ -294,8 +323,12 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
                 <MapPin className="h-4 w-4 text-gray-400 flex-shrink-0" />
                 <div className="flex-1 min-w-0 max-w-md">
                   <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs font-medium text-gray-700">Rayon de recherche</span>
-                    <span className="text-xs font-bold text-huntzen-blue">{radiusKm} km</span>
+                    <span className="text-xs font-medium text-gray-700">
+                      Rayon de recherche
+                    </span>
+                    <span className="text-xs font-bold text-huntzen-blue">
+                      {radiusKm} km
+                    </span>
                   </div>
                   <input
                     type="range"
@@ -330,9 +363,9 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
               onChange={(e) => setQuery(e.target.value)}
               disabled={disabled || isLoading}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault()
-                  handleSearch()
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSearch();
                 }
               }}
               className={`
@@ -344,13 +377,14 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
                 focus:outline-none focus:ring-2 focus:ring-offset-0
                 transition-all duration-200
                 disabled:opacity-50 disabled:cursor-not-allowed
-                ${errors.query
-                  ? 'border-red-300 focus:ring-red-500 focus:border-red-500'
-                  : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+                ${
+                  errors.query
+                    ? "border-red-300 focus:ring-red-500 focus:border-red-500"
+                    : "border-gray-300 focus:ring-blue-500 focus:border-blue-500"
                 }
               `}
               aria-invalid={!!errors.query}
-              aria-describedby={errors.query ? 'query-error-mobile' : undefined}
+              aria-describedby={errors.query ? "query-error-mobile" : undefined}
             />
           </div>
           {errors.query && (
@@ -381,7 +415,11 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
           onSearch={fetchCities}
           disabled={disabled || isLoading || !isCountryValid}
           icon={<MapPin className="h-5 w-5" />}
-          emptyMessage={!isCountryValid ? "Sélectionnez d'abord un pays" : "Aucune ville trouvée"}
+          emptyMessage={
+            !isCountryValid
+              ? "Sélectionnez d'abord un pays"
+              : "Aucune ville trouvée"
+          }
         />
 
         {/* Radius Slider - Only show if city is specified */}
@@ -390,8 +428,12 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
             <MapPin className="h-5 w-5 text-gray-400 flex-shrink-0" />
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between mb-2">
-                <span className="text-sm font-medium text-gray-700">Rayon de recherche</span>
-                <span className="text-sm font-bold text-huntzen-blue">{radiusKm} km</span>
+                <span className="text-sm font-medium text-gray-700">
+                  Rayon de recherche
+                </span>
+                <span className="text-sm font-bold text-huntzen-blue">
+                  {radiusKm} km
+                </span>
               </div>
               <input
                 type="range"
@@ -432,7 +474,7 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
             size="lg"
             className="w-full bg-gradient-to-r from-huntzen-blue to-huntzen-turquoise hover:from-huntzen-blue/90 hover:to-huntzen-turquoise/90"
           >
-            {isLoading ? 'Recherche...' : 'Rechercher'}
+            {isLoading ? "Recherche..." : "Rechercher"}
           </Button>
         </div>
       </div>
@@ -441,10 +483,11 @@ export function SearchFormInline({ onSearch, isLoading = false, disabled = false
       {isFreePlan && (
         <div className="mt-3 text-center">
           <p className="text-xs text-gray-500">
-            {getRemaining('job_search')} recherche(s) restante(s) aujourd&apos;hui
+            {getRemaining("job_search")} recherche(s) restante(s)
+            aujourd&apos;hui
           </p>
         </div>
       )}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- Added `initialQuery?: string` prop to `SearchFormInline`
- `useEffect` syncs the prop into the internal `query` state when it changes
- Popular job clicks now set `popularQuery` state and pass it via `initialQuery` to the form
- Scrolls and focuses the correct input (`query-inline` on desktop, `query-mobile` on mobile)

## Root Cause
`SearchFormInline` manages its own internal `query` state (`useState('')`). The parent's `setJobTitle()` had no effect on it. The V1 form input had `id="jobTitle"` but the V2 form uses `id="query-inline"`.

Closes #43