### PR TITLE
fix: Remove dark/grey colors from tool pages — enforce white 60/30/10 system

### DIFF
--- a/frontend-next/src/app/(dashboard)/admin/recruiter-requests/page.tsx
+++ b/frontend-next/src/app/(dashboard)/admin/recruiter-requests/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import {
   Search,
-  Filter,
   Download,
   Calendar,
   CheckCircle2,
@@ -14,7 +13,6 @@ import {
   Mail,
   Phone,
   Briefcase,
-  MessageSquare,
   Euro
 } from 'lucide-react'
 
@@ -44,18 +42,18 @@ interface RecruiterRequest {
 }
 
 const STATUS_COLORS = {
-  new: 'bg-blue-500/20 text-blue-400',
-  assigned: 'bg-purple-500/20 text-purple-400',
-  scheduled: 'bg-amber-500/20 text-amber-400',
-  completed: 'bg-green-500/20 text-green-400',
-  cancelled: 'bg-red-500/20 text-red-400',
+  new: 'bg-blue-100 text-blue-700',
+  assigned: 'bg-purple-100 text-purple-700',
+  scheduled: 'bg-amber-100 text-amber-700',
+  completed: 'bg-green-100 text-green-700',
+  cancelled: 'bg-red-100 text-red-700',
 }
 
 const PAYMENT_STATUS_COLORS = {
-  pending: 'bg-yellow-500/20 text-yellow-400',
-  paid: 'bg-green-500/20 text-green-400',
-  refunded: 'bg-gray-500/20 text-gray-400',
-  failed: 'bg-red-500/20 text-red-400',
+  pending: 'bg-yellow-100 text-yellow-700',
+  paid: 'bg-green-100 text-green-700',
+  refunded: 'bg-gray-100 text-gray-600',
+  failed: 'bg-red-100 text-red-700',
 }
 
 export default function RecruiterRequestsAdminPage() {
@@ -97,7 +95,6 @@ export default function RecruiterRequestsAdminPage() {
   const filterRequests = () => {
     let filtered = [...requests]
 
-    // Search filter
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
       filtered = filtered.filter(req =>
@@ -108,12 +105,10 @@ export default function RecruiterRequestsAdminPage() {
       )
     }
 
-    // Status filter
     if (statusFilter !== 'all') {
       filtered = filtered.filter(req => req.status === statusFilter)
     }
 
-    // Payment filter
     if (paymentFilter !== 'all') {
       filtered = filtered.filter(req => req.payment_status === paymentFilter)
     }
@@ -176,90 +171,90 @@ export default function RecruiterRequestsAdminPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-huntzen-blue mx-auto mb-4"></div>
-          <p className="text-white/60">Chargement des demandes...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#00D9FF] mx-auto mb-4"></div>
+          <p className="text-gray-500">Chargement des demandes...</p>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 p-6">
+    <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-white mb-2">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
             Demandes de Consultation Recruteur
           </h1>
-          <p className="text-white/60">
+          <p className="text-gray-500">
             Gérer et suivre toutes les demandes de consultation
           </p>
         </div>
 
         {/* Stats Cards */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-          <div className="bg-slate-900 border border-white/10 rounded-lg p-4">
+          <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-white/60 text-sm">Total</p>
-                <p className="text-2xl font-bold text-white">{requests.length}</p>
+                <p className="text-gray-500 text-sm">Total</p>
+                <p className="text-2xl font-bold text-gray-900">{requests.length}</p>
               </div>
-              <User className="w-8 h-8 text-huntzen-blue" />
+              <User className="w-8 h-8 text-[#00D9FF]" />
             </div>
           </div>
 
-          <div className="bg-slate-900 border border-white/10 rounded-lg p-4">
+          <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-white/60 text-sm">Payées</p>
-                <p className="text-2xl font-bold text-green-400">
+                <p className="text-gray-500 text-sm">Payées</p>
+                <p className="text-2xl font-bold text-green-600">
                   {requests.filter(r => r.payment_status === 'paid').length}
                 </p>
               </div>
-              <Euro className="w-8 h-8 text-green-400" />
+              <Euro className="w-8 h-8 text-green-500" />
             </div>
           </div>
 
-          <div className="bg-slate-900 border border-white/10 rounded-lg p-4">
+          <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-white/60 text-sm">En attente</p>
-                <p className="text-2xl font-bold text-amber-400">
+                <p className="text-gray-500 text-sm">En attente</p>
+                <p className="text-2xl font-bold text-amber-600">
                   {requests.filter(r => r.status === 'new' || r.status === 'assigned').length}
                 </p>
               </div>
-              <Clock className="w-8 h-8 text-amber-400" />
+              <Clock className="w-8 h-8 text-amber-500" />
             </div>
           </div>
 
-          <div className="bg-slate-900 border border-white/10 rounded-lg p-4">
+          <div className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-white/60 text-sm">Complétées</p>
-                <p className="text-2xl font-bold text-purple-400">
+                <p className="text-gray-500 text-sm">Complétées</p>
+                <p className="text-2xl font-bold text-purple-600">
                   {requests.filter(r => r.status === 'completed').length}
                 </p>
               </div>
-              <CheckCircle2 className="w-8 h-8 text-purple-400" />
+              <CheckCircle2 className="w-8 h-8 text-purple-500" />
             </div>
           </div>
         </div>
 
         {/* Filters and Search */}
-        <div className="bg-slate-900 border border-white/10 rounded-lg p-4 mb-6">
+        <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6 shadow-sm">
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             {/* Search */}
             <div className="md:col-span-2">
               <div className="relative">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-white/40" />
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
                   type="text"
                   placeholder="Rechercher par nom, email, secteur..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-10 pr-4 py-2 bg-slate-800 border border-white/10 rounded-lg text-white placeholder-white/40 focus:outline-none focus:border-huntzen-blue"
+                  className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-lg text-gray-900 placeholder-gray-400 focus:outline-none focus:border-[#00D9FF] focus:ring-1 focus:ring-[#00D9FF]"
                 />
               </div>
             </div>
@@ -269,7 +264,7 @@ export default function RecruiterRequestsAdminPage() {
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value as RequestStatus | 'all')}
-                className="w-full px-4 py-2 bg-slate-800 border border-white/10 rounded-lg text-white focus:outline-none focus:border-huntzen-blue"
+                className="w-full px-4 py-2 bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-[#00D9FF]"
               >
                 <option value="all">Tous les statuts</option>
                 <option value="new">Nouveau</option>
@@ -285,7 +280,7 @@ export default function RecruiterRequestsAdminPage() {
               <select
                 value={paymentFilter}
                 onChange={(e) => setPaymentFilter(e.target.value as PaymentStatus | 'all')}
-                className="w-full px-4 py-2 bg-slate-800 border border-white/10 rounded-lg text-white focus:outline-none focus:border-huntzen-blue"
+                className="w-full px-4 py-2 bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-[#00D9FF]"
               >
                 <option value="all">Tous les paiements</option>
                 <option value="paid">Payé</option>
@@ -300,7 +295,7 @@ export default function RecruiterRequestsAdminPage() {
           <div className="mt-4 flex justify-end">
             <button
               onClick={exportToCSV}
-              className="flex items-center gap-2 px-4 py-2 bg-huntzen-blue text-white rounded-lg hover:bg-huntzen-blue/80 transition-colors"
+              className="flex items-center gap-2 px-4 py-2 bg-[#00D9FF] text-white rounded-lg hover:bg-[#00C4EA] transition-colors"
             >
               <Download className="w-4 h-4" />
               Exporter CSV
@@ -309,24 +304,24 @@ export default function RecruiterRequestsAdminPage() {
         </div>
 
         {/* Requests Table */}
-        <div className="bg-slate-900 border border-white/10 rounded-lg overflow-hidden">
+        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden shadow-sm">
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="bg-slate-800 border-b border-white/10">
+              <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Date</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Candidat</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Contact</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Secteur</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Paiement</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Statut</th>
-                  <th className="px-4 py-3 text-left text-sm font-semibold text-white/80">Actions</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Date</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Candidat</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Contact</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Secteur</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Paiement</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Statut</th>
+                  <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">Actions</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-white/10">
+              <tbody className="divide-y divide-gray-100">
                 {filteredRequests.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-4 py-8 text-center text-white/40">
+                    <td colSpan={7} className="px-4 py-8 text-center text-gray-400">
                       Aucune demande trouvée
                     </td>
                   </tr>
@@ -334,33 +329,33 @@ export default function RecruiterRequestsAdminPage() {
                   filteredRequests.map((request) => (
                     <tr
                       key={request.id}
-                      className="hover:bg-slate-800/50 cursor-pointer transition-colors"
+                      className="hover:bg-gray-50 cursor-pointer transition-colors"
                       onClick={() => setSelectedRequest(request)}
                     >
-                      <td className="px-4 py-3 text-sm text-white/60">
+                      <td className="px-4 py-3 text-sm text-gray-500">
                         {formatDate(request.created_at)}
                       </td>
                       <td className="px-4 py-3">
                         <div>
-                          <p className="text-white font-medium">{request.full_name}</p>
-                          <p className="text-white/40 text-xs">{request.experience_level}</p>
+                          <p className="text-gray-900 font-medium">{request.full_name}</p>
+                          <p className="text-gray-400 text-xs">{request.experience_level}</p>
                         </div>
                       </td>
                       <td className="px-4 py-3">
                         <div className="space-y-1">
-                          <div className="flex items-center gap-2 text-xs text-white/60">
+                          <div className="flex items-center gap-2 text-xs text-gray-500">
                             <Mail className="w-3 h-3" />
                             {request.email}
                           </div>
                           {request.phone && (
-                            <div className="flex items-center gap-2 text-xs text-white/60">
+                            <div className="flex items-center gap-2 text-xs text-gray-500">
                               <Phone className="w-3 h-3" />
                               {request.phone}
                             </div>
                           )}
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-sm text-white/80">{request.sector}</td>
+                      <td className="px-4 py-3 text-sm text-gray-700">{request.sector}</td>
                       <td className="px-4 py-3">
                         <span className={`px-2 py-1 text-xs font-medium rounded-full ${PAYMENT_STATUS_COLORS[request.payment_status]}`}>
                           {request.payment_status}
@@ -378,7 +373,7 @@ export default function RecruiterRequestsAdminPage() {
                             e.stopPropagation()
                             updateRequestStatus(request.id, e.target.value as RequestStatus)
                           }}
-                          className="px-2 py-1 text-xs bg-slate-800 border border-white/10 rounded text-white focus:outline-none focus:border-huntzen-blue"
+                          className="px-2 py-1 text-xs bg-white border border-gray-200 rounded text-gray-900 focus:outline-none focus:border-[#00D9FF]"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <option value="new">Nouveau</option>
@@ -398,14 +393,14 @@ export default function RecruiterRequestsAdminPage() {
 
         {/* Request Details Modal */}
         {selectedRequest && (
-          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-            <div className="bg-slate-900 border border-white/10 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+          <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+            <div className="bg-white border border-gray-200 rounded-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto shadow-xl">
               <div className="p-6">
                 <div className="flex items-center justify-between mb-6">
-                  <h2 className="text-2xl font-bold text-white">Détails de la demande</h2>
+                  <h2 className="text-2xl font-bold text-gray-900">Détails de la demande</h2>
                   <button
                     onClick={() => setSelectedRequest(null)}
-                    className="text-white/60 hover:text-white transition-colors"
+                    className="text-gray-400 hover:text-gray-600 transition-colors"
                   >
                     <XCircle className="w-6 h-6" />
                   </button>
@@ -414,44 +409,44 @@ export default function RecruiterRequestsAdminPage() {
                 <div className="space-y-6">
                   {/* Candidate Info */}
                   <div>
-                    <h3 className="text-lg font-semibold text-white mb-3">Informations candidat</h3>
-                    <div className="bg-slate-800 rounded-lg p-4 space-y-3">
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">Informations candidat</h3>
+                    <div className="bg-gray-50 rounded-lg p-4 space-y-3">
                       <div className="flex items-center gap-3">
-                        <User className="w-5 h-5 text-huntzen-blue" />
+                        <User className="w-5 h-5 text-[#00D9FF]" />
                         <div>
-                          <p className="text-white/60 text-sm">Nom complet</p>
-                          <p className="text-white font-medium">{selectedRequest.full_name}</p>
+                          <p className="text-gray-500 text-sm">Nom complet</p>
+                          <p className="text-gray-900 font-medium">{selectedRequest.full_name}</p>
                         </div>
                       </div>
                       <div className="flex items-center gap-3">
-                        <Mail className="w-5 h-5 text-huntzen-blue" />
+                        <Mail className="w-5 h-5 text-[#00D9FF]" />
                         <div>
-                          <p className="text-white/60 text-sm">Email</p>
-                          <p className="text-white font-medium">{selectedRequest.email}</p>
+                          <p className="text-gray-500 text-sm">Email</p>
+                          <p className="text-gray-900 font-medium">{selectedRequest.email}</p>
                         </div>
                       </div>
                       {selectedRequest.phone && (
                         <div className="flex items-center gap-3">
-                          <Phone className="w-5 h-5 text-huntzen-blue" />
+                          <Phone className="w-5 h-5 text-[#00D9FF]" />
                           <div>
-                            <p className="text-white/60 text-sm">Téléphone</p>
-                            <p className="text-white font-medium">{selectedRequest.phone}</p>
+                            <p className="text-gray-500 text-sm">Téléphone</p>
+                            <p className="text-gray-900 font-medium">{selectedRequest.phone}</p>
                           </div>
                         </div>
                       )}
                       <div className="flex items-center gap-3">
-                        <Briefcase className="w-5 h-5 text-huntzen-blue" />
+                        <Briefcase className="w-5 h-5 text-[#00D9FF]" />
                         <div>
-                          <p className="text-white/60 text-sm">Secteur / Expérience</p>
-                          <p className="text-white font-medium">{selectedRequest.sector} - {selectedRequest.experience_level}</p>
+                          <p className="text-gray-500 text-sm">Secteur / Expérience</p>
+                          <p className="text-gray-900 font-medium">{selectedRequest.sector} - {selectedRequest.experience_level}</p>
                         </div>
                       </div>
                       {selectedRequest.preferred_date && (
                         <div className="flex items-center gap-3">
-                          <Calendar className="w-5 h-5 text-huntzen-blue" />
+                          <Calendar className="w-5 h-5 text-[#00D9FF]" />
                           <div>
-                            <p className="text-white/60 text-sm">Date préférée</p>
-                            <p className="text-white font-medium">{formatDate(selectedRequest.preferred_date)}</p>
+                            <p className="text-gray-500 text-sm">Date préférée</p>
+                            <p className="text-gray-900 font-medium">{formatDate(selectedRequest.preferred_date)}</p>
                           </div>
                         </div>
                       )}
@@ -460,30 +455,30 @@ export default function RecruiterRequestsAdminPage() {
 
                   {/* Message */}
                   <div>
-                    <h3 className="text-lg font-semibold text-white mb-3">Message du candidat</h3>
-                    <div className="bg-slate-800 rounded-lg p-4">
-                      <p className="text-white/80 leading-relaxed">{selectedRequest.message}</p>
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">Message du candidat</h3>
+                    <div className="bg-gray-50 rounded-lg p-4">
+                      <p className="text-gray-700 leading-relaxed">{selectedRequest.message}</p>
                     </div>
                   </div>
 
                   {/* Payment Info */}
                   <div>
-                    <h3 className="text-lg font-semibold text-white mb-3">Informations paiement</h3>
-                    <div className="bg-slate-800 rounded-lg p-4 space-y-2">
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">Informations paiement</h3>
+                    <div className="bg-gray-50 rounded-lg p-4 space-y-2">
                       <div className="flex justify-between">
-                        <span className="text-white/60">Montant</span>
-                        <span className="text-white font-bold">{formatAmount(selectedRequest.amount_cents)}</span>
+                        <span className="text-gray-500">Montant</span>
+                        <span className="text-gray-900 font-bold">{formatAmount(selectedRequest.amount_cents)}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-white/60">Statut paiement</span>
+                        <span className="text-gray-500">Statut paiement</span>
                         <span className={`px-2 py-1 text-xs font-medium rounded-full ${PAYMENT_STATUS_COLORS[selectedRequest.payment_status]}`}>
                           {selectedRequest.payment_status}
                         </span>
                       </div>
                       {selectedRequest.payment_intent_id && (
                         <div className="flex justify-between text-sm">
-                          <span className="text-white/60">Payment Intent ID</span>
-                          <span className="text-white/40 font-mono text-xs">{selectedRequest.payment_intent_id}</span>
+                          <span className="text-gray-500">Payment Intent ID</span>
+                          <span className="text-gray-400 font-mono text-xs">{selectedRequest.payment_intent_id}</span>
                         </div>
                       )}
                     </div>
@@ -491,12 +486,12 @@ export default function RecruiterRequestsAdminPage() {
 
                   {/* Status */}
                   <div>
-                    <h3 className="text-lg font-semibold text-white mb-3">Statut de la demande</h3>
-                    <div className="bg-slate-800 rounded-lg p-4">
+                    <h3 className="text-lg font-semibold text-gray-900 mb-3">Statut de la demande</h3>
+                    <div className="bg-gray-50 rounded-lg p-4">
                       <select
                         value={selectedRequest.status}
                         onChange={(e) => updateRequestStatus(selectedRequest.id, e.target.value as RequestStatus)}
-                        className="w-full px-4 py-2 bg-slate-700 border border-white/10 rounded-lg text-white focus:outline-none focus:border-huntzen-blue"
+                        className="w-full px-4 py-2 bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-[#00D9FF]"
                       >
                         <option value="new">🆕 Nouveau</option>
                         <option value="assigned">👤 Assigné</option>

--- a/frontend-next/src/components/jobs/blurred-job-card.tsx
+++ b/frontend-next/src/components/jobs/blurred-job-card.tsx
@@ -66,15 +66,15 @@ export function BlurredJobCard({ index, className = '' }: BlurredJobCardProps) {
       </div>
 
       {/* Lock overlay */}
-      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-t from-white/90 via-white/70 to-white/50 dark:from-gray-900/90 dark:via-gray-900/70 dark:to-gray-900/50 pointer-events-none">
+      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-t from-white/90 via-white/70 to-white/50 pointer-events-none">
         <div className="text-center p-4 transform transition-transform group-hover:scale-105 pointer-events-auto">
-          <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 mb-3 shadow-lg shadow-violet-200 dark:shadow-violet-900/30 animate-pulse">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 mb-3 shadow-lg shadow-violet-200 animate-pulse">
             <Lock className="w-6 h-6 text-white" />
           </div>
-          <p className="font-semibold text-gray-800 dark:text-gray-200 mb-1">
+          <p className="font-semibold text-gray-800 mb-1">
             Offre verrouillee
           </p>
-          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+          <p className="text-sm text-gray-600 mb-3">
             Passez Premium pour voir cette offre
           </p>
           <Button
@@ -111,7 +111,7 @@ export function JobsLimitReached({
 
   return (
     <div
-      className={`col-span-full p-8 rounded-xl bg-gradient-to-br from-violet-50 to-purple-50 dark:from-violet-950/30 dark:to-purple-950/30 border-2 border-dashed border-violet-200 dark:border-violet-800 text-center ${className}`}
+      className={`col-span-full p-8 rounded-xl bg-gradient-to-br from-violet-50 to-purple-50 border-2 border-dashed border-violet-200 text-center ${className}`}
     >
       <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 mb-4 shadow-lg">
         <Lock className="w-8 h-8 text-white" />

--- a/frontend-next/src/components/jobs/gradient-job-card.tsx
+++ b/frontend-next/src/components/jobs/gradient-job-card.tsx
@@ -113,7 +113,7 @@ export const GradientJobCard = React.forwardRef<
       className={cn(
         "relative overflow-hidden cursor-pointer group",
         "border-2 border-dashed border-violet-200",
-        "bg-white dark:bg-gray-800",
+        "bg-white",
         "transition-all duration-300",
         "hover:border-violet-300 hover:shadow-lg",
         className,
@@ -127,7 +127,7 @@ export const GradientJobCard = React.forwardRef<
     >
       {/* Preview content - reduced opacity */}
       <div className="relative z-10 select-none pointer-events-none">
-        <CardHeader className="pb-3 bg-gray-50 dark:bg-gray-800/80">
+        <CardHeader className="pb-3 bg-gray-50">
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0 opacity-30">
               <div className="flex items-center gap-2 mb-2">
@@ -148,7 +148,7 @@ export const GradientJobCard = React.forwardRef<
 
             {/* Source badge */}
             <div className="opacity-25">
-              <div className="px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-xs">
+              <div className="px-2 py-1 rounded bg-gray-100 text-xs">
                 {formatJobSource(job.source)}
               </div>
             </div>
@@ -184,7 +184,7 @@ export const GradientJobCard = React.forwardRef<
       <div
         className={cn(
           "absolute inset-0 z-20",
-          "bg-gradient-to-t from-white via-white/95 to-white/80 dark:from-gray-800 dark:via-gray-800/95 dark:to-gray-800/80",
+          "bg-gradient-to-t from-white via-white/95 to-white/80",
           "pointer-events-none",
         )}
         aria-hidden="true"
@@ -199,10 +199,10 @@ export const GradientJobCard = React.forwardRef<
 
         {/* Text content */}
         <div className="text-center space-y-1 mb-4">
-          <h4 className="font-semibold text-gray-800 dark:text-gray-100">
+          <h4 className="font-semibold text-gray-800">
             Offre verrouillée
           </h4>
-          <p className="text-sm text-gray-600 dark:text-gray-300">
+          <p className="text-sm text-gray-600">
             Passez Premium pour voir cette offre
           </p>
         </div>
@@ -249,7 +249,7 @@ export const JobsLimitReached = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "col-span-full p-8 rounded-xl bg-gradient-to-br from-violet-50 to-purple-50 dark:from-violet-900/20 dark:to-purple-900/20 border-2 border-dashed border-violet-200 dark:border-violet-800 text-center",
+        "col-span-full p-8 rounded-xl bg-gradient-to-br from-violet-50 to-purple-50 border-2 border-dashed border-violet-200 text-center",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- **gradient-job-card.tsx** — 8 `dark:` variants supprimés (fond carte, header, badge source, overlay gradient, textes)
- **blurred-job-card.tsx** — 5 `dark:` variants supprimés (overlay gradient, shadow violet, textes)
- **admin/recruiter-requests/page.tsx** — refonte complète du thème dark slate → light white
  - `bg-slate-950` / `bg-slate-900` → `bg-gray-50` / `bg-white`
  - Badges statuts : dark pastel → light pastel (blue-100, green-100, amber-100, red-100)
  - Textes : `text-white` → `text-gray-900`, `text-white/60` → `text-gray-500`
  - Bordures : `border-white/10` → `border-gray-200`
  - Modal détail : fond sombre → `bg-white` avec `shadow-xl`

## Design System respecté
- 60% Blanc `#FFFFFF` — tous les fonds
- 30% Navy `#0D1F3C` — sidebar uniquement (non touché)
- 10% Cyan `#00D9FF` — accents, icônes, focus rings

Closes #45