### PR TITLE
fix: Deep audit — remove ALL dark: variants from dashboard components

### DIFF
--- a/frontend-next/src/components/coach/chat-message.tsx
+++ b/frontend-next/src/components/coach/chat-message.tsx
@@ -127,9 +127,9 @@ export function ChatMessage({
                   "shadow-md hover:shadow-lg",
                 ]
               : [
-                  "bg-white dark:bg-gray-800",
-                  "text-gray-900 dark:text-gray-100",
-                  "border-2 border-gray-200 dark:border-gray-700",
+                  "bg-white",
+                  "text-gray-900",
+                  "border-2 border-gray-200",
                   "rounded-bl-md", // Sharp corner bottom-left
                   "shadow-sm hover:shadow-md",
                 ],
@@ -150,7 +150,7 @@ export function ChatMessage({
                 components={{
                   // Customize markdown rendering
                   p: ({ children }) => (
-                    <p className="mb-2 last:mb-0 leading-relaxed text-gray-800 dark:text-gray-100">
+                    <p className="mb-2 last:mb-0 leading-relaxed text-gray-800">
                       {children}
                     </p>
                   ),
@@ -165,28 +165,28 @@ export function ChatMessage({
                     </ol>
                   ),
                   li: ({ children }) => (
-                    <li className="text-gray-800 dark:text-gray-100">
+                    <li className="text-gray-800">
                       {children}
                     </li>
                   ),
                   code: ({ inline, children, ...props }: any) =>
                     inline ? (
                       <code
-                        className="px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 text-violet-600 dark:text-violet-400 rounded text-xs font-mono"
+                        className="px-1.5 py-0.5 bg-gray-100 text-violet-600 rounded text-xs font-mono"
                         {...props}
                       >
                         {children}
                       </code>
                     ) : (
                       <code
-                        className="block p-3 bg-gray-50 dark:bg-gray-900 rounded-lg text-xs font-mono overflow-x-auto"
+                        className="block p-3 bg-gray-50 rounded-lg text-xs font-mono overflow-x-auto"
                         {...props}
                       >
                         {children}
                       </code>
                     ),
                   strong: ({ children }) => (
-                    <strong className="font-semibold text-gray-800 dark:text-gray-100">
+                    <strong className="font-semibold text-gray-800">
                       {children}
                     </strong>
                   ),
@@ -214,7 +214,7 @@ export function ChatMessage({
               className={cn(
                 "absolute -top-2 -right-2",
                 "size-6 rounded-full",
-                "bg-gray-800 hover:bg-gray-900",
+                "bg-[#0D1F3C] hover:bg-[#0D1F3C]/90",
                 "flex items-center justify-center",
                 "shadow-md",
                 "transition-all duration-150",
@@ -259,7 +259,7 @@ export function ChatMessage({
         {showTimestamp && (
           <div
             className={cn(
-              "text-xs text-gray-400 dark:text-gray-500",
+              "text-xs text-gray-400",
               "opacity-0 group-hover:opacity-100",
               "transition-opacity duration-150",
               "px-2",
@@ -300,18 +300,18 @@ export function TypingIndicator() {
       </div>
 
       {/* Typing dots */}
-      <div className="px-4 py-3 rounded-2xl rounded-bl-md bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 shadow-sm">
+      <div className="px-4 py-3 rounded-2xl rounded-bl-md bg-white border-2 border-gray-200 shadow-sm">
         <div className="flex gap-1">
           <div
-            className="size-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce"
+            className="size-2 rounded-full bg-gray-400 animate-bounce"
             style={{ animationDelay: "0ms", animationDuration: "1s" }}
           />
           <div
-            className="size-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce"
+            className="size-2 rounded-full bg-gray-400 animate-bounce"
             style={{ animationDelay: "200ms", animationDuration: "1s" }}
           />
           <div
-            className="size-2 rounded-full bg-gray-400 dark:bg-gray-500 animate-bounce"
+            className="size-2 rounded-full bg-gray-400 animate-bounce"
             style={{ animationDelay: "400ms", animationDuration: "1s" }}
           />
         </div>

--- a/frontend-next/src/components/coach/history-sidebar.tsx
+++ b/frontend-next/src/components/coach/history-sidebar.tsx
@@ -110,7 +110,7 @@ export function HistorySidebar({
         <Button
           variant="outline"
           size="sm"
-          className="gap-2 border-2 border-gray-200 dark:border-gray-600 hover:border-huntzen-blue hover:bg-huntzen-blue/5"
+          className="gap-2 border-2 border-gray-200 hover:border-huntzen-blue hover:bg-huntzen-blue/5"
         >
           <History className="w-4 h-4" />
           Historique
@@ -134,10 +134,10 @@ export function HistorySidebar({
           </SheetHeader>
 
           {/* Search and Filters */}
-          <div className="p-4 space-y-3 border-b bg-gray-50 dark:bg-gray-800/50">
+          <div className="p-4 space-y-3 border-b bg-gray-50">
             {/* Search */}
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500" />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
               <Input
                 ref={searchInputRef}
                 type="text"
@@ -149,7 +149,7 @@ export function HistorySidebar({
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery("")}
-                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -188,7 +188,7 @@ export function HistorySidebar({
                     setSearchQuery("");
                     setShowFavoritesOnly(false);
                   }}
-                  className="text-gray-600 dark:text-gray-400"
+                  className="text-gray-600"
                 >
                   Réinitialiser
                 </Button>
@@ -208,19 +208,19 @@ export function HistorySidebar({
             ) : conversations.length === 0 ? (
               // Empty state
               <div className="flex flex-col items-center justify-center h-full text-center p-8">
-                <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center mb-4">
+                <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mb-4">
                   {searchQuery || showFavoritesOnly ? (
-                    <Search className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+                    <Search className="w-8 h-8 text-gray-400" />
                   ) : (
-                    <MessageSquarePlus className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+                    <MessageSquarePlus className="w-8 h-8 text-gray-400" />
                   )}
                 </div>
-                <h3 className="font-semibold text-gray-900 dark:text-white mb-2">
+                <h3 className="font-semibold text-gray-900 mb-2">
                   {searchQuery || showFavoritesOnly
                     ? "Aucune conversation trouvée"
                     : "Pas encore de conversations"}
                 </h3>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                <p className="text-sm text-gray-600 mb-4">
                   {searchQuery || showFavoritesOnly
                     ? "Essayez de modifier vos filtres de recherche"
                     : "Vos conversations avec le Coach IA apparaîtront ici"}
@@ -255,8 +255,8 @@ export function HistorySidebar({
           </div>
 
           {/* Footer */}
-          <div className="p-4 border-t bg-gray-50 dark:bg-gray-800/50">
-            <div className="text-xs text-gray-600 dark:text-gray-400 space-y-1">
+          <div className="p-4 border-t bg-gray-50">
+            <div className="text-xs text-gray-600 space-y-1">
               <div className="flex items-center justify-between">
                 <span>Total:</span>
                 <span className="font-medium">

--- a/frontend-next/src/components/cv/score-ring.tsx
+++ b/frontend-next/src/components/cv/score-ring.tsx
@@ -119,7 +119,7 @@ export function ScoreRing({
             fill="none"
             stroke="currentColor"
             strokeWidth={config.stroke}
-            className="text-gray-200 dark:text-gray-700"
+            className="text-gray-200"
           />
           {/* Progress */}
           <circle
@@ -185,7 +185,7 @@ export function ScoreBreakdown({ details, className = '' }: ScoreBreakdownProps)
               {cat.value}/{cat.max}
             </span>
           </div>
-          <div className="h-2 bg-gray-100 dark:bg-gray-800 rounded-full overflow-hidden">
+          <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
             <div
               className={`h-full ${cat.color} rounded-full transition-all duration-500`}
               style={{ width: `${(cat.value / cat.max) * 100}%` }}

--- a/frontend-next/src/components/freemium/feature-lock.tsx
+++ b/frontend-next/src/components/freemium/feature-lock.tsx
@@ -49,12 +49,12 @@ export function FeatureLockOverlay({
       </div>
 
       {/* Lock overlay */}
-      <div className="absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-gray-900/60 backdrop-blur-[2px] rounded-lg pointer-events-none">
+      <div className="absolute inset-0 flex items-center justify-center bg-white/60 backdrop-blur-[2px] rounded-lg pointer-events-none">
         <div className="text-center p-4 pointer-events-auto">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 mb-3 animate-pulse">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 mb-3 animate-pulse">
             <Lock className="w-6 h-6 text-gray-500" />
           </div>
-          <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          <p className="text-sm font-medium text-gray-700 mb-1">
             {message || `Disponible avec ${PLAN_NAMES[requiredPlan]}`}
           </p>
           <Button

--- a/frontend-next/src/components/freemium/pricing-modal.tsx
+++ b/frontend-next/src/components/freemium/pricing-modal.tsx
@@ -266,7 +266,7 @@ export function PricingModal() {
                 className={`relative rounded-xl border-2 p-5 transition-all hover:shadow-lg ${
                   plan.popular
                     ? "border-violet-500 shadow-violet-100 shadow-lg"
-                    : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                    : "border-gray-200 hover:border-gray-300"
                 }`}
               >
                 {/* Popular Badge */}
@@ -290,18 +290,18 @@ export function PricingModal() {
                 </div>
 
                 {/* Price */}
-                <div className="text-center mb-4 py-3 bg-white dark:bg-gray-800 rounded-lg">
+                <div className="text-center mb-4 py-3 bg-white rounded-lg">
                   <div className="flex items-baseline justify-center gap-1">
                     {plan.id === "free" ? (
-                      <span className="text-3xl font-bold text-gray-900 dark:text-white">
+                      <span className="text-3xl font-bold text-gray-900">
                         Gratuit
                       </span>
                     ) : (
                       <>
-                        <span className="text-3xl font-bold text-gray-900 dark:text-white">
+                        <span className="text-3xl font-bold text-gray-900">
                           {plan.price}€
                         </span>
-                        <span className="text-base text-gray-600 dark:text-gray-400">
+                        <span className="text-base text-gray-600">
                           {plan.period}
                         </span>
                       </>
@@ -332,7 +332,7 @@ export function PricingModal() {
                             <Check className="w-2.5 h-2.5 text-white" />
                           </div>
                         ) : (
-                          <div className="w-4 h-4 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0 mt-0.5">
+                          <div className="w-4 h-4 rounded-full bg-gray-100 flex items-center justify-center flex-shrink-0 mt-0.5">
                             <X className="w-2.5 h-2.5 text-gray-400" />
                           </div>
                         )}
@@ -340,7 +340,7 @@ export function PricingModal() {
                           className={
                             feature.included
                               ? ""
-                              : "text-gray-400 dark:text-gray-500"
+                              : "text-gray-400"
                           }
                         >
                           {feature.name}
@@ -405,7 +405,7 @@ export function PricingCards({
           className={`relative rounded-2xl border-2 p-6 transition-all hover:shadow-xl ${
             plan.popular
               ? "border-violet-500 shadow-violet-100 shadow-lg scale-[1.02]"
-              : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+              : "border-gray-200 hover:border-gray-300"
           }`}
         >
           {plan.popular && (
@@ -460,13 +460,13 @@ export function PricingCards({
                       <Check className="w-3 h-3 text-white" />
                     </div>
                   ) : (
-                    <div className="w-5 h-5 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                    <div className="w-5 h-5 rounded-full bg-gray-100 flex items-center justify-center">
                       <X className="w-3 h-3 text-gray-400" />
                     </div>
                   )}
                   <span
                     className={
-                      feature.included ? "" : "text-gray-400 dark:text-gray-500"
+                      feature.included ? "" : "text-gray-400"
                     }
                   >
                     {feature.name}

--- a/frontend-next/src/components/freemium/upgrade-banner.tsx
+++ b/frontend-next/src/components/freemium/upgrade-banner.tsx
@@ -44,7 +44,7 @@ export function UpgradeBanner({
       <div
         className={`flex items-center justify-between gap-4 px-4 py-2 bg-gradient-to-r from-violet-500/10 to-purple-500/10 border-b border-violet-200 ${className}`}
       >
-        <p className="text-sm text-violet-700 dark:text-violet-300">
+        <p className="text-sm text-violet-700">
           <Sparkles className="w-4 h-4 inline mr-1" />
           Passez Premium pour debloquer toutes les fonctionnalites
         </p>
@@ -115,17 +115,17 @@ export function UpgradeBanner({
   // Default variant
   return (
     <div
-      className={`flex items-center justify-between gap-4 px-4 py-3 bg-gradient-to-r from-blue-50 via-violet-50 to-purple-50 dark:from-blue-950/30 dark:via-violet-950/30 dark:to-purple-950/30 border border-violet-200 dark:border-violet-800 rounded-lg ${className}`}
+      className={`flex items-center justify-between gap-4 px-4 py-3 bg-gradient-to-r from-blue-50 via-violet-50 to-purple-50 border border-violet-200 rounded-lg ${className}`}
     >
       <div className="flex items-center gap-3">
         <div className="p-2 rounded-full bg-gradient-to-br from-violet-500 to-purple-600">
           <Sparkles className="w-4 h-4 text-white" />
         </div>
         <div>
-          <p className="font-medium text-gray-900 dark:text-gray-100">
+          <p className="font-medium text-gray-900">
             Debloquez tout le potentiel de HuntZen
           </p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-gray-600">
             Recherches illimitees, export PDF, simulation entretien et plus
           </p>
         </div>
@@ -141,7 +141,7 @@ export function UpgradeBanner({
         </Button>
         <button
           onClick={handleDismiss}
-          className="p-1.5 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+          className="p-1.5 rounded-full hover:bg-gray-200 transition-colors"
         >
           <X className="w-4 h-4 text-gray-500" />
         </button>
@@ -167,7 +167,7 @@ export function FeatureUpgradePrompt({
 
   return (
     <div
-      className={`p-6 rounded-xl bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 border border-gray-200 dark:border-gray-700 text-center ${className}`}
+      className={`p-6 rounded-xl bg-gradient-to-br from-gray-50 to-gray-100 border border-gray-200 text-center ${className}`}
     >
       <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-br from-violet-500 to-purple-600 mb-4">
         <Sparkles className="w-6 h-6 text-white" />

--- a/frontend-next/src/components/freemium/usage-counter.tsx
+++ b/frontend-next/src/components/freemium/usage-counter.tsx
@@ -130,14 +130,14 @@ export function UsageCounter({
   return (
     <div className={`space-y-1.5 ${className}`}>
       <div className="flex items-center justify-between text-sm">
-        <span className="flex items-center gap-1.5 text-white/90 dark:text-gray-100">
+        <span className="flex items-center gap-1.5 text-white/90">
           {showIcon && config.icon}
           <span>
             {feature === 'coach_time'
               ? config.formatValue(remaining, max)
               : `${remaining} ${config.label}`}
             {feature !== 'coach_time' && (
-              <span className="text-xs ml-1 text-white/60 dark:text-gray-300">
+              <span className="text-xs ml-1 text-white/60">
                 {config.maxLabel(max)}
               </span>
             )}

--- a/frontend-next/src/components/landing-header.tsx
+++ b/frontend-next/src/components/landing-header.tsx
@@ -130,7 +130,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                   onMouseLeave={() => setOutilsOpen(false)}
                   className={`absolute top-full left-0 mt-2 w-56 rounded-xl shadow-2xl border backdrop-blur-md overflow-hidden ${
                     shouldBeWhite
-                      ? "bg-white/95 dark:bg-gray-800/95 border-gray-200 dark:border-gray-700"
+                      ? "bg-white/95 border-gray-200"
                       : "bg-black/95 border-white/10"
                   }`}
                 >
@@ -139,7 +139,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setOutilsOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 hover:bg-gray-100 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -150,7 +150,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setOutilsOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 hover:bg-gray-100 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -186,7 +186,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                   onMouseLeave={() => setRessourcesOpen(false)}
                   className={`absolute top-full left-0 mt-2 w-56 rounded-xl shadow-2xl border backdrop-blur-md overflow-hidden ${
                     shouldBeWhite
-                      ? "bg-white/95 dark:bg-gray-800/95 border-gray-200 dark:border-gray-700"
+                      ? "bg-white/95 border-gray-200"
                       : "bg-black/95 border-white/10"
                   }`}
                 >
@@ -195,7 +195,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 hover:bg-gray-100 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -206,7 +206,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 hover:bg-gray-100 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -217,7 +217,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
                     onClick={() => setRessourcesOpen(false)}
                     className={`block px-4 py-3 text-sm font-semibold transition-colors ${
                       shouldBeWhite
-                        ? "text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-[#00D9FF]"
+                        ? "text-gray-900 hover:bg-gray-100 hover:text-[#00D9FF]"
                         : "text-white/90 hover:bg-white/10 hover:text-[#00D9FF]"
                     }`}
                   >
@@ -246,13 +246,13 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
           {user ? (
             <Link href="/jobs">
               <div
-                className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${shouldBeWhite ? "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600" : "bg-white/10 hover:bg-white/20"}`}
+                className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${shouldBeWhite ? "bg-gray-100 hover:bg-gray-200" : "bg-white/10 hover:bg-white/20"}`}
               >
                 <div className="w-7 h-7 rounded-full bg-[#00D9FF]/20 flex items-center justify-center">
                   <User className="w-4 h-4 text-[#00D9FF]" />
                 </div>
                 <span
-                  className={`text-sm font-medium hidden md:inline ${shouldBeWhite ? "text-black dark:text-white" : "text-white"}`}
+                  className={`text-sm font-medium hidden md:inline ${shouldBeWhite ? "text-black" : "text-white"}`}
                 >
                   {user.user_metadata?.full_name || user.email?.split("@")[0]}
                 </span>
@@ -296,7 +296,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -20 }}
-          className={`lg:hidden absolute top-20 left-0 right-0 backdrop-blur-md border-b ${shouldBeWhite ? "bg-white/95 dark:bg-gray-800/95 border-gray-200 dark:border-gray-700" : "bg-black/95 border-white/10"}`}
+          className={`lg:hidden absolute top-20 left-0 right-0 backdrop-blur-md border-b ${shouldBeWhite ? "bg-white/95 border-gray-200" : "bg-black/95 border-white/10"}`}
         >
           <nav className="container mx-auto px-6 py-4 flex flex-col gap-3">
             <Link
@@ -316,10 +316,10 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
 
             {/* Outils Section */}
             <div
-              className={`border-t pt-3 mt-2 ${shouldBeWhite ? "border-gray-200 dark:border-gray-700" : "border-white/10"}`}
+              className={`border-t pt-3 mt-2 ${shouldBeWhite ? "border-gray-200" : "border-white/10"}`}
             >
               <p
-                className={`text-xs font-semibold uppercase tracking-wide mb-2 ${shouldBeWhite ? "text-gray-500 dark:text-gray-400" : "text-white/60"}`}
+                className={`text-xs font-semibold uppercase tracking-wide mb-2 ${shouldBeWhite ? "text-gray-500" : "text-white/60"}`}
               >
                 Outils
               </p>
@@ -341,10 +341,10 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
 
             {/* Ressources Section */}
             <div
-              className={`border-t pt-3 ${shouldBeWhite ? "border-gray-200 dark:border-gray-700" : "border-white/10"}`}
+              className={`border-t pt-3 ${shouldBeWhite ? "border-gray-200" : "border-white/10"}`}
             >
               <p
-                className={`text-xs font-semibold uppercase tracking-wide mb-2 ${shouldBeWhite ? "text-gray-500 dark:text-gray-400" : "text-white/60"}`}
+                className={`text-xs font-semibold uppercase tracking-wide mb-2 ${shouldBeWhite ? "text-gray-500" : "text-white/60"}`}
               >
                 Ressources
               </p>

--- a/frontend-next/src/components/profile/subscription-card.tsx
+++ b/frontend-next/src/components/profile/subscription-card.tsx
@@ -115,11 +115,11 @@ export function SubscriptionCard() {
           <div>
             <p className="text-2xl font-bold">
               {planConfig.price}
-              <span className="text-sm font-normal text-gray-500 dark:text-gray-400">
+              <span className="text-sm font-normal text-gray-500">
                 {planConfig.period}
               </span>
             </p>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
+            <p className="text-sm text-gray-600">
               {planConfig.description}
             </p>
           </div>
@@ -142,7 +142,7 @@ export function SubscriptionCard() {
 
       {/* Features List */}
       <div className="space-y-3">
-        <h3 className="font-semibold text-sm text-gray-700 dark:text-gray-300">
+        <h3 className="font-semibold text-sm text-gray-700">
           Fonctionnalités incluses
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -151,7 +151,7 @@ export function SubscriptionCard() {
               key={key}
               className={cn(
                 "flex items-center gap-2 text-sm",
-                enabled ? "text-gray-700 dark:text-gray-300" : "text-gray-400",
+                enabled ? "text-gray-700" : "text-gray-400",
               )}
             >
               {enabled ? (
@@ -171,7 +171,7 @@ export function SubscriptionCard() {
         </div>
 
         {/* Quota limits */}
-        <div className="pt-2 space-y-1 text-sm text-gray-600 dark:text-gray-400">
+        <div className="pt-2 space-y-1 text-sm text-gray-600">
           <div className="flex items-center gap-2">
             <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
             <span>
@@ -203,13 +203,13 @@ export function SubscriptionCard() {
 
       {/* Usage Quotas */}
       <div className="space-y-4">
-        <h3 className="font-semibold text-sm text-gray-700 dark:text-gray-300">
+        <h3 className="font-semibold text-sm text-gray-700">
           Utilisation du jour
         </h3>
 
         {/* CV Analysis */}
         <div className="space-y-1">
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+          <p className="text-xs text-gray-500 font-medium">
             Analyses CV
           </p>
           <UsageCounter feature="cv_analysis" showIcon={false} />
@@ -217,7 +217,7 @@ export function SubscriptionCard() {
 
         {/* Coach Time */}
         <div className="space-y-1">
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+          <p className="text-xs text-gray-500 font-medium">
             Temps Coach IA
           </p>
           <UsageCounter feature="coach_time" showIcon={false} />
@@ -225,7 +225,7 @@ export function SubscriptionCard() {
 
         {/* Job Searches */}
         <div className="space-y-1">
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-medium">
+          <p className="text-xs text-gray-500 font-medium">
             Recherches d'emploi
           </p>
           <UsageCounter feature="job_search" showIcon={false} />
@@ -236,17 +236,17 @@ export function SubscriptionCard() {
       {isFreePlan && (
         <>
           <Separator />
-          <div className="bg-gradient-to-r from-violet-50 to-purple-50 dark:from-violet-900/20 dark:to-purple-900/20 border border-violet-200 dark:border-violet-700 rounded-lg p-4 space-y-3">
+          <div className="bg-gradient-to-r from-violet-50 to-purple-50 border border-violet-200 rounded-lg p-4 space-y-3">
             <div className="flex items-start gap-3">
               <Crown
                 className="w-5 h-5 text-violet-600 shrink-0 mt-0.5"
                 aria-hidden="true"
               />
               <div className="space-y-1">
-                <p className="font-semibold text-violet-900 dark:text-violet-100">
+                <p className="font-semibold text-violet-900">
                   Débloquez tout le potentiel de HuntZen
                 </p>
-                <p className="text-sm text-violet-700 dark:text-violet-300">
+                <p className="text-sm text-violet-700">
                   Passez à un plan payant pour des analyses illimitées, plus de
                   temps de coaching, et des fonctionnalités exclusives.
                 </p>
@@ -285,7 +285,7 @@ export function SubscriptionCard() {
               Annuler l'abonnement
             </Button>
           </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+          <p className="text-xs text-gray-500 text-center">
             💡 L'annulation d'abonnement sera disponible prochainement
           </p>
         </>

--- a/frontend-next/src/components/profile/user-profile-widget.tsx
+++ b/frontend-next/src/components/profile/user-profile-widget.tsx
@@ -82,7 +82,7 @@ function QuotaBar({ feature, quota }: QuotaBarProps) {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-sm">
-        <span className="font-medium text-gray-700 dark:text-gray-300">
+        <span className="font-medium text-gray-700">
           {FEATURE_LABELS[feature] || feature}
         </span>
         <span className={`font-semibold ${getTextColor()}`}>
@@ -91,7 +91,7 @@ function QuotaBar({ feature, quota }: QuotaBarProps) {
       </div>
 
       {limit !== -1 && (
-        <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+        <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
           <div
             className={`h-full transition-all duration-300 ${getBarColor()}`}
             style={{ width: `${Math.min(percentage, 100)}%` }}
@@ -105,7 +105,7 @@ function QuotaBar({ feature, quota }: QuotaBarProps) {
       )}
 
       {remaining === 0 && limit !== -1 && (
-        <p className="text-xs text-red-600 dark:text-red-400">
+        <p className="text-xs text-red-600">
           Quota atteint pour aujourd'hui
         </p>
       )}
@@ -216,33 +216,33 @@ export function UserProfileWidget({ className = '' }: UserProfileWidgetProps) {
         </div>
 
         <div className="flex-1">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+          <h2 className="text-xl font-semibold text-gray-900">
             {profile.full_name || 'Utilisateur'}
           </h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
+          <p className="text-sm text-gray-600">
             {profile.email}
           </p>
         </div>
       </div>
 
       {/* Subscription Info */}
-      <div className="p-4 rounded-lg bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20 border border-blue-200 dark:border-blue-800">
+      <div className="p-4 rounded-lg bg-gradient-to-br from-blue-50 to-purple-50 border border-blue-200">
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <Crown className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-            <h3 className="font-semibold text-gray-900 dark:text-white">
+            <Crown className="w-5 h-5 text-blue-600" />
+            <h3 className="font-semibold text-gray-900">
               Plan {subscription.plan_display_name}
             </h3>
           </div>
           {subscription.price_monthly > 0 && (
-            <span className="text-lg font-bold text-blue-600 dark:text-blue-400">
+            <span className="text-lg font-bold text-blue-600">
               {subscription.price_monthly}€<span className="text-sm font-normal">/mois</span>
             </span>
           )}
         </div>
 
         {subscription.current_period_end && (
-          <p className="text-xs text-gray-600 dark:text-gray-400">
+          <p className="text-xs text-gray-600">
             Renouvellement le {new Date(subscription.current_period_end).toLocaleDateString('fr-FR')}
           </p>
         )}
@@ -250,10 +250,10 @@ export function UserProfileWidget({ className = '' }: UserProfileWidgetProps) {
 
       {/* Quotas */}
       <div className="space-y-4">
-        <h3 className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+        <h3 className="font-semibold text-gray-900 flex items-center gap-2">
           <span>Utilisation du jour</span>
           {quotas.cv_analysis?.reset_at && (
-            <span className="text-xs text-gray-500 dark:text-gray-400 font-normal">
+            <span className="text-xs text-gray-500 font-normal">
               (réinitialisation à minuit)
             </span>
           )}
@@ -265,8 +265,8 @@ export function UserProfileWidget({ className = '' }: UserProfileWidgetProps) {
       </div>
 
       {/* Account Info */}
-      <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+      <div className="pt-4 border-t border-gray-200">
+        <p className="text-xs text-gray-500">
           Membre depuis {profile.created_at ? new Date(profile.created_at).toLocaleDateString('fr-FR', {
             year: 'numeric',
             month: 'long',


### PR DESCRIPTION
## Problème
L'audit précédent était insuffisant. De nombreux éléments dark/grey persistaient dans toutes les pages dashboard.

## Corrections

### `chat-message.tsx`
- Bulles assistant: `bg-white` (supprimé `dark:bg-gray-800`), bordure sans dark:
- Markdown: textes sans dark: override
- Blocs code: `bg-gray-50` sans dark:
- Bouton copier: `bg-[#0D1F3C]` navy (était `bg-gray-800` hardcodé)
- Points typing: `bg-gray-400` sans dark:
- TypingIndicator: bulle blanche sans dark:

### `history-sidebar.tsx`
- Section recherche: `bg-gray-50` sans dark:
- État vide: icônes et textes sans dark:
- Footer: `bg-gray-50` sans dark:

### Composants freemium (4 fichiers)
- `usage-counter.tsx`: textes sans dark:
- `upgrade-banner.tsx`: 6 dark: supprimés sur bg/text/border
- `feature-lock.tsx`: overlay/icône/texte sans dark:
- `pricing-modal.tsx`: 10 dark: supprimés

### Composants profile (2 fichiers)
- `subscription-card.tsx`: 13 dark: supprimés
- `user-profile-widget.tsx`: 14 dark: supprimés

### `cv/score-ring.tsx`: SVG sans dark:
### `landing-header.tsx`: dropdowns/mobile menu sans dark:

## Résultat
**Dashboard: 0 dark: variants restants** (seul `theme-toggle.tsx` conserve ses dark: car utilisé uniquement sur la landing page intentionnellement thémée)

Closes #47