### PR TITLE
feat(i18n): Complete multilingual support — auth pages, all dashboard pages, sidebar switcher

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -367,5 +367,280 @@
     "featurePrompt": {
       "unlock": "Unlock this feature"
     }
+  },
+  "auth": {
+    "login": {
+      "title": "Welcome back!",
+      "subtitle": "Log in to access your workspace",
+      "googleCta": "Continue with Google",
+      "divider": "Or with email",
+      "emailLabel": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "passwordLabel": "Password",
+      "forgotPassword": "Forgot password?",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password",
+      "loading": "Logging in...",
+      "cta": "Log in",
+      "noAccount": "Don't have an account?",
+      "signupLink": "Create a free account",
+      "termsPrefix": "By continuing, you accept our",
+      "terms": "Terms of Service",
+      "and": "and our",
+      "privacy": "Privacy Policy"
+    },
+    "signup": {
+      "title": "Create your account",
+      "subtitle": "Join HuntZen and boost your career",
+      "subtitleCV": "Start your free CV analysis",
+      "passwordMismatch": "Passwords don't match",
+      "passwordTooShort": "Password must be at least 6 characters",
+      "googleCta": "Sign up with Google",
+      "divider": "Or with email",
+      "fullNameLabel": "Full name",
+      "fullNamePlaceholder": "John Doe",
+      "emailLabel": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "passwordLabel": "Password",
+      "passwordPlaceholder": "Minimum 6 characters",
+      "confirmPasswordLabel": "Confirm password",
+      "confirmPasswordPlaceholder": "Re-enter your password",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password",
+      "loading": "Creating...",
+      "cta": "Create my free account",
+      "hasAccount": "Already have an account?",
+      "loginLink": "Log in",
+      "termsPrefix": "By creating an account, you accept our",
+      "terms": "Terms of Service",
+      "and": "and our",
+      "privacy": "Privacy Policy",
+      "cvBanner": {
+        "title": "Welcome offer:",
+        "feature1": "1 free CV analysis per day",
+        "feature2": "Detailed ATS score",
+        "feature3": "Job matching",
+        "feature4": "Full history"
+      },
+      "success": {
+        "title": "Registration successful! 🎉",
+        "sentEmail": "We have sent a confirmation email to:",
+        "checkEmail": "Check your inbox",
+        "checkEmailDesc": "(and spam) to confirm your email address before logging in.",
+        "goToLogin": "Go to login",
+        "close": "Close",
+        "noEmail": "Didn't receive the email? Wait a few minutes or check your spam."
+      },
+      "timeout": {
+        "title": "Slow connection detected",
+        "description": "The request took too long. Check your internet connection and try again in a moment."
+      }
+    }
+  },
+  "dashboard": {
+    "jobs": {
+      "title": "Job Search",
+      "subtitle": "Access thousands of job listings from the best recruitment platforms, aggregated and updated daily.",
+      "form": {
+        "title": "Define your search criteria",
+        "subtitle": "Fill in the fields below to find offers that match your profile",
+        "contractType": "Contract type",
+        "optional": "(optional)",
+        "allContracts": "All contract types",
+        "allTypes": "✓ All types",
+        "jobTitle": "Job title",
+        "country": "Country",
+        "city": "City",
+        "cityHint": "Whole country if empty",
+        "selectCountryFirst": "Select a country first",
+        "loadingPlaceholder": "Loading...",
+        "jobTitlePlaceholder": "E.g: Full Stack Developer, Project Manager...",
+        "cityPlaceholder": "London, Paris, Brussels...",
+        "countryPlaceholder": "France, Belgium, Switzerland...",
+        "searching": "Searching...",
+        "search": "Start search",
+        "unlock": "Unlock unlimited searches",
+        "advancedFilters": "Advanced filters",
+        "remaining_one": "{count} remaining",
+        "remaining_other": "{count} remaining",
+        "noCountryFound": "No country found",
+        "noCityFound": "No city found"
+      },
+      "error": {
+        "title": "Search error",
+        "generic": "An error occurred during the search. Please try again.",
+        "formLoad": "Error loading the form. Please refresh the page.",
+        "fillRequired": "Please fill in the job title and country"
+      },
+      "corrected": {
+        "title": "Improved search",
+        "subtitle": "We optimized your search:"
+      },
+      "results": {
+        "count_one": "{count} offer found",
+        "count_other": "{count} offers found",
+        "refresh": "Refresh",
+        "updating": "Updating...",
+        "justNow": "just now",
+        "oneMinuteAgo": "1 minute ago",
+        "minutesAgo": "{n} minutes ago",
+        "staleWarning": "- Refresh recommended",
+        "updatedAt": "Updated {time}",
+        "recent": "Recent and relevant results",
+        "visibleOf": "{visible} visible out of {total}",
+        "unlockAll": "Unlock all offers →",
+        "cache": "💾 Cache"
+      },
+      "card": {
+        "details": "View details",
+        "save": "Save this offer",
+        "alreadySaved": "Already in favorites",
+        "premiumFeature": "Premium feature",
+        "locationUnknown": "Location not specified",
+        "alreadySavedShort": "Already saved",
+        "saveShort": "Save"
+      },
+      "empty": {
+        "title": "No offers found",
+        "subtitle": "We didn't find any offers matching your criteria at the moment.",
+        "tips": "💡 Tips:",
+        "tip1": "Try more general keywords",
+        "tip2": "Check the spelling of the job title",
+        "tip3": "Widen your geographic area (city → whole country)",
+        "tip4": "Select \"All types\" for the contract"
+      },
+      "toast": {
+        "saved": "Offer added to favorites ✨",
+        "saveError": "Error while saving",
+        "mustLogin": "Log in to save offers",
+        "mustLoginSave": "You must be logged in to save offers",
+        "alreadySaved": "This offer is already in your favorites",
+        "filtersApplied": "{count} advanced filter(s) applied",
+        "filtersAppliedDesc": "Search updated with new filters",
+        "filtersAppliedNext": "Filters will be applied to the next search",
+        "filtersReset": "Advanced filters reset"
+      }
+    },
+    "cvAnalysis": {
+      "title": "CV Analysis",
+      "loading": "Loading your workspace...",
+      "errorTitle": "Error loading CV analysis",
+      "errorDesc": "An error occurred. Please refresh the page.",
+      "subtitle": "Optimize your CV to maximize your chances of getting an interview. Get a detailed analysis and personalized recommendations."
+    },
+    "assistant": {
+      "title": "Career Assistant",
+      "history": "History",
+      "newConversation": "New",
+      "simulation": "Simulation",
+      "timeWarning": "Less than 3 minutes left! Go Premium for unlimited time.",
+      "upgradePremium": "Go Premium",
+      "placeholder": "Ask your question... (Enter to send, Shift+Enter for new line)",
+      "timeExpiredTitle": "Time's up",
+      "timeExpiredDesc": "You've used your {minutes} free minutes",
+      "unlockUnlimited": "Unlock unlimited time",
+      "errorMessage": "Sorry, an error occurred. Could you rephrase your question?",
+      "unlimited": "Unlimited"
+    },
+    "salons": {
+      "title": "Job Fairs & Forums"
+    },
+    "savedJobs": {
+      "title": "Saved Jobs",
+      "searchPlaceholder": "Search in your offers...",
+      "noJobs": "You haven't saved any offers yet",
+      "noJobsDesc": "Explore available offers and save the ones that interest you",
+      "loginRequired": "Log in to see your saved offers",
+      "deleteError": "Error while deleting",
+      "deleted": "Offer deleted",
+      "viewOffer": "View offer",
+      "delete": "Delete",
+      "savedAt": "Saved on",
+      "searchJobs": "Search for jobs"
+    },
+    "recruiterContact": {
+      "title": "Contact a Recruiter",
+      "stats": {
+        "consultations": "Successful consultations",
+        "satisfaction": "Average satisfaction",
+        "delay": "Average delay"
+      },
+      "benefits": {
+        "personalizedTitle": "Personalized advice",
+        "personalizedDesc": "An expert recruiter analyzes your profile and gives you tailored recommendations",
+        "expertiseTitle": "Professional expertise",
+        "expertiseDesc": "Our recruiters have 10+ years of experience in executive and talent recruitment",
+        "fastResponseTitle": "Fast response",
+        "fastResponseDesc": "You'll be contacted within 48h to schedule your 30-minute consultation"
+      },
+      "pricing": {
+        "title": "Recruiter Consultation",
+        "sessionDesc": "Individual 30-minute session",
+        "perConsultation": "/ consultation",
+        "noSubscription": "One-time payment, no subscription",
+        "item1Title": "30-minute video session",
+        "item1Desc": "Live exchange with an expert",
+        "item2Title": "Personalized analysis",
+        "item2Desc": "CV, LinkedIn profile, job search strategy",
+        "item3Title": "Concrete action plan",
+        "item3Desc": "Immediately actionable recommendations",
+        "item4Title": "Written summary",
+        "item4Desc": "Detailed recap after the consultation",
+        "securePay": "Secure payment by Stripe"
+      },
+      "form": {
+        "title": "Book my consultation",
+        "desc": "Fill in the form to be contacted by an expert recruiter",
+        "fullName": "Full name *",
+        "email": "Email *",
+        "phone": "Phone",
+        "sector": "Industry *",
+        "sectorPlaceholder": "Select your industry",
+        "experienceLevel": "Experience level *",
+        "experiencePlaceholder": "Select your level",
+        "preferredDate": "Preferred date (optional)",
+        "message": "Message / Questions *",
+        "messagePlaceholder": "Briefly describe your situation and professional goals...",
+        "submitting": "Processing...",
+        "submit": "Book my consultation (€50)",
+        "submitNote": "After validation, you'll be redirected to secure Stripe payment",
+        "error": "An error occurred. Please try again.",
+        "sectors": {
+          "tech": "Tech / IT",
+          "finance": "Finance / Banking",
+          "marketing": "Marketing / Communications",
+          "sales": "Sales / Business Development",
+          "hr": "HR / Recruitment",
+          "engineering": "Engineering",
+          "healthcare": "Healthcare",
+          "education": "Education",
+          "other": "Other"
+        },
+        "levels": {
+          "junior": "Junior (0-3 years)",
+          "confirmed": "Mid-level (3-7 years)",
+          "senior": "Senior (7-12 years)",
+          "expert": "Expert (12+ years)",
+          "manager": "Manager / Lead",
+          "executive": "Executive / C-level"
+        }
+      },
+      "validation": {
+        "fullNameRequired": "Full name is required",
+        "fullNameTooShort": "Name must contain at least 2 characters",
+        "emailRequired": "Email is required",
+        "emailInvalid": "Invalid email format",
+        "phoneInvalid": "Invalid phone format",
+        "sectorRequired": "Industry is required",
+        "experienceRequired": "Experience level is required",
+        "messageRequired": "Message is required",
+        "messageTooShort": "Message must contain at least 10 characters"
+      },
+      "cta": {
+        "title": "Ready to boost your career?",
+        "spots": "👥 5 consultations booked this week",
+        "button": "Book now (€50)"
+      }
+    }
   }
 }

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -367,5 +367,280 @@
     "featurePrompt": {
       "unlock": "Desbloquear esta funcionalidad"
     }
+  },
+  "auth": {
+    "login": {
+      "title": "¡Bienvenido de vuelta!",
+      "subtitle": "Inicia sesión para acceder a tu espacio",
+      "googleCta": "Continuar con Google",
+      "divider": "O con correo",
+      "emailLabel": "Correo electrónico",
+      "emailPlaceholder": "tu@ejemplo.com",
+      "passwordLabel": "Contraseña",
+      "forgotPassword": "¿Olvidaste tu contraseña?",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña",
+      "loading": "Iniciando sesión...",
+      "cta": "Iniciar sesión",
+      "noAccount": "¿No tienes cuenta?",
+      "signupLink": "Crear una cuenta gratis",
+      "termsPrefix": "Al continuar, aceptas nuestros",
+      "terms": "Términos de servicio",
+      "and": "y nuestra",
+      "privacy": "Política de privacidad"
+    },
+    "signup": {
+      "title": "Crear tu cuenta",
+      "subtitle": "Únete a HuntZen y potencia tu carrera",
+      "subtitleCV": "Comienza tu análisis de CV gratis",
+      "passwordMismatch": "Las contraseñas no coinciden",
+      "passwordTooShort": "La contraseña debe tener al menos 6 caracteres",
+      "googleCta": "Registrarse con Google",
+      "divider": "O con correo",
+      "fullNameLabel": "Nombre completo",
+      "fullNamePlaceholder": "Juan García",
+      "emailLabel": "Correo electrónico",
+      "emailPlaceholder": "tu@ejemplo.com",
+      "passwordLabel": "Contraseña",
+      "passwordPlaceholder": "Mínimo 6 caracteres",
+      "confirmPasswordLabel": "Confirmar contraseña",
+      "confirmPasswordPlaceholder": "Reescribe tu contraseña",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña",
+      "loading": "Creando...",
+      "cta": "Crear mi cuenta gratis",
+      "hasAccount": "¿Ya tienes cuenta?",
+      "loginLink": "Iniciar sesión",
+      "termsPrefix": "Al crear una cuenta, aceptas nuestros",
+      "terms": "Términos de servicio",
+      "and": "y nuestra",
+      "privacy": "Política de privacidad",
+      "cvBanner": {
+        "title": "Oferta de bienvenida:",
+        "feature1": "1 análisis de CV gratuito al día",
+        "feature2": "Puntuación ATS detallada",
+        "feature3": "Coincidencia de empleos",
+        "feature4": "Historial completo"
+      },
+      "success": {
+        "title": "¡Registro exitoso! 🎉",
+        "sentEmail": "Hemos enviado un correo de confirmación a:",
+        "checkEmail": "Revisa tu bandeja de entrada",
+        "checkEmailDesc": "(y spam) para confirmar tu correo antes de iniciar sesión.",
+        "goToLogin": "Ir al inicio de sesión",
+        "close": "Cerrar",
+        "noEmail": "¿No recibiste el correo? Espera unos minutos o revisa tu spam."
+      },
+      "timeout": {
+        "title": "Conexión lenta detectada",
+        "description": "La solicitud tardó demasiado. Verifica tu conexión a internet e inténtalo de nuevo."
+      }
+    }
+  },
+  "dashboard": {
+    "jobs": {
+      "title": "Búsqueda de Empleo",
+      "subtitle": "Accede a miles de ofertas de trabajo de las mejores plataformas de reclutamiento, agregadas y actualizadas diariamente.",
+      "form": {
+        "title": "Define tus criterios de búsqueda",
+        "subtitle": "Rellena los campos para encontrar ofertas que coincidan con tu perfil",
+        "contractType": "Tipo de contrato",
+        "optional": "(opcional)",
+        "allContracts": "Todos los tipos de contrato",
+        "allTypes": "✓ Todos los tipos",
+        "jobTitle": "Título del puesto",
+        "country": "País",
+        "city": "Ciudad",
+        "cityHint": "Todo el país si está vacío",
+        "selectCountryFirst": "Selecciona primero un país",
+        "loadingPlaceholder": "Cargando...",
+        "jobTitlePlaceholder": "Ej: Desarrollador Full Stack, Jefe de Proyecto...",
+        "cityPlaceholder": "Madrid, Barcelona, Buenos Aires...",
+        "countryPlaceholder": "España, México, Argentina...",
+        "searching": "Buscando...",
+        "search": "Iniciar búsqueda",
+        "unlock": "Desbloquear búsquedas ilimitadas",
+        "advancedFilters": "Filtros avanzados",
+        "remaining_one": "{count} restante",
+        "remaining_other": "{count} restantes",
+        "noCountryFound": "País no encontrado",
+        "noCityFound": "Ciudad no encontrada"
+      },
+      "error": {
+        "title": "Error en la búsqueda",
+        "generic": "Ocurrió un error durante la búsqueda. Por favor inténtalo de nuevo.",
+        "formLoad": "Error al cargar el formulario. Por favor recarga la página.",
+        "fillRequired": "Por favor completa el título del puesto y el país"
+      },
+      "corrected": {
+        "title": "Búsqueda mejorada",
+        "subtitle": "Optimizamos tu búsqueda:"
+      },
+      "results": {
+        "count_one": "{count} oferta encontrada",
+        "count_other": "{count} ofertas encontradas",
+        "refresh": "Actualizar",
+        "updating": "Actualizando...",
+        "justNow": "ahora mismo",
+        "oneMinuteAgo": "hace 1 minuto",
+        "minutesAgo": "hace {n} minutos",
+        "staleWarning": "- Actualización recomendada",
+        "updatedAt": "Actualizado {time}",
+        "recent": "Resultados recientes y relevantes",
+        "visibleOf": "{visible} visible(s) de {total}",
+        "unlockAll": "Desbloquear todas las ofertas →",
+        "cache": "💾 Caché"
+      },
+      "card": {
+        "details": "Ver detalles",
+        "save": "Guardar esta oferta",
+        "alreadySaved": "Ya en favoritos",
+        "premiumFeature": "Función Premium",
+        "locationUnknown": "Ubicación no especificada",
+        "alreadySavedShort": "Ya guardado",
+        "saveShort": "Guardar"
+      },
+      "empty": {
+        "title": "No se encontraron ofertas",
+        "subtitle": "No encontramos ofertas que coincidan con tus criterios en este momento.",
+        "tips": "💡 Sugerencias:",
+        "tip1": "Intenta con palabras clave más generales",
+        "tip2": "Verifica la ortografía del título del puesto",
+        "tip3": "Amplía tu zona geográfica (ciudad → todo el país)",
+        "tip4": "Selecciona \"Todos los tipos\" para el contrato"
+      },
+      "toast": {
+        "saved": "Oferta añadida a favoritos ✨",
+        "saveError": "Error al guardar",
+        "mustLogin": "Inicia sesión para guardar ofertas",
+        "mustLoginSave": "Debes iniciar sesión para guardar ofertas",
+        "alreadySaved": "Esta oferta ya está en tus favoritos",
+        "filtersApplied": "{count} filtro(s) avanzado(s) aplicado(s)",
+        "filtersAppliedDesc": "Búsqueda actualizada con los nuevos filtros",
+        "filtersAppliedNext": "Los filtros se aplicarán a la próxima búsqueda",
+        "filtersReset": "Filtros avanzados restablecidos"
+      }
+    },
+    "cvAnalysis": {
+      "title": "Análisis de CV",
+      "loading": "Cargando tu espacio...",
+      "errorTitle": "Error al cargar el análisis de CV",
+      "errorDesc": "Ocurrió un error. Por favor recarga la página.",
+      "subtitle": "Optimiza tu CV para maximizar tus posibilidades de conseguir una entrevista. Obtén un análisis detallado y recomendaciones personalizadas."
+    },
+    "assistant": {
+      "title": "Asistente de Carrera",
+      "history": "Historial",
+      "newConversation": "Nueva",
+      "simulation": "Simulación",
+      "timeWarning": "¡Le quedan menos de 3 minutos! Pase a Premium para tiempo ilimitado.",
+      "upgradePremium": "Ir a Premium",
+      "placeholder": "Haga su pregunta... (Enter para enviar, Shift+Enter para nueva línea)",
+      "timeExpiredTitle": "Tiempo agotado",
+      "timeExpiredDesc": "Ha usado sus {minutes} minutos gratuitos",
+      "unlockUnlimited": "Desbloquear tiempo ilimitado",
+      "errorMessage": "Lo siento, ocurrió un error. ¿Puede reformular su pregunta?",
+      "unlimited": "Ilimitado"
+    },
+    "salons": {
+      "title": "Ferias y Foros de Empleo"
+    },
+    "savedJobs": {
+      "title": "Ofertas Guardadas",
+      "searchPlaceholder": "Buscar en tus ofertas...",
+      "noJobs": "Aún no has guardado ninguna oferta",
+      "noJobsDesc": "Explora las ofertas disponibles y guarda las que te interesen",
+      "loginRequired": "Inicia sesión para ver tus ofertas guardadas",
+      "deleteError": "Error al eliminar",
+      "deleted": "Oferta eliminada",
+      "viewOffer": "Ver oferta",
+      "delete": "Eliminar",
+      "savedAt": "Guardada el",
+      "searchJobs": "Buscar empleos"
+    },
+    "recruiterContact": {
+      "title": "Contactar un Reclutador",
+      "stats": {
+        "consultations": "Consultas exitosas",
+        "satisfaction": "Satisfacción promedio",
+        "delay": "Plazo promedio"
+      },
+      "benefits": {
+        "personalizedTitle": "Consejos personalizados",
+        "personalizedDesc": "Un reclutador experto analiza su perfil y le da recomendaciones a medida",
+        "expertiseTitle": "Experiencia profesional",
+        "expertiseDesc": "Nuestros reclutadores tienen 10+ años de experiencia en contratación de ejecutivos",
+        "fastResponseTitle": "Respuesta rápida",
+        "fastResponseDesc": "Será contactado en 48h para programar su consulta de 30 minutos"
+      },
+      "pricing": {
+        "title": "Consulta con Reclutador",
+        "sessionDesc": "Sesión individual de 30 minutos",
+        "perConsultation": "/ consulta",
+        "noSubscription": "Pago único, sin suscripción",
+        "item1Title": "Sesión de vídeo de 30 minutos",
+        "item1Desc": "Intercambio en vivo con un experto",
+        "item2Title": "Análisis personalizado",
+        "item2Desc": "CV, perfil de LinkedIn, estrategia de búsqueda",
+        "item3Title": "Plan de acción concreto",
+        "item3Desc": "Recomendaciones accionables de inmediato",
+        "item4Title": "Resumen escrito",
+        "item4Desc": "Resumen detallado después de la consulta",
+        "securePay": "Pago seguro por Stripe"
+      },
+      "form": {
+        "title": "Reservar mi consulta",
+        "desc": "Complete el formulario para ser contactado por un reclutador experto",
+        "fullName": "Nombre completo *",
+        "email": "Email *",
+        "phone": "Teléfono",
+        "sector": "Sector *",
+        "sectorPlaceholder": "Seleccione su sector",
+        "experienceLevel": "Nivel de experiencia *",
+        "experiencePlaceholder": "Seleccione su nivel",
+        "preferredDate": "Fecha preferida (opcional)",
+        "message": "Mensaje / Preguntas *",
+        "messagePlaceholder": "Describa brevemente su situación y objetivos profesionales...",
+        "submitting": "Procesando...",
+        "submit": "Reservar mi consulta (50€)",
+        "submitNote": "Tras la validación, será redirigido al pago seguro de Stripe",
+        "error": "Ocurrió un error. Por favor inténtelo de nuevo.",
+        "sectors": {
+          "tech": "Tecnología / IT",
+          "finance": "Finanzas / Banca",
+          "marketing": "Marketing / Comunicación",
+          "sales": "Ventas / Comercial",
+          "hr": "RRHH / Selección",
+          "engineering": "Ingeniería",
+          "healthcare": "Salud",
+          "education": "Educación",
+          "other": "Otro"
+        },
+        "levels": {
+          "junior": "Junior (0-3 años)",
+          "confirmed": "Intermedio (3-7 años)",
+          "senior": "Senior (7-12 años)",
+          "expert": "Experto (12+ años)",
+          "manager": "Manager / Lead",
+          "executive": "Ejecutivo / C-level"
+        }
+      },
+      "validation": {
+        "fullNameRequired": "El nombre completo es obligatorio",
+        "fullNameTooShort": "El nombre debe tener al menos 2 caracteres",
+        "emailRequired": "El email es obligatorio",
+        "emailInvalid": "Formato de email no válido",
+        "phoneInvalid": "Formato de teléfono no válido",
+        "sectorRequired": "El sector es obligatorio",
+        "experienceRequired": "El nivel de experiencia es obligatorio",
+        "messageRequired": "El mensaje es obligatorio",
+        "messageTooShort": "El mensaje debe tener al menos 10 caracteres"
+      },
+      "cta": {
+        "title": "¿Listo para impulsar su carrera?",
+        "spots": "👥 5 consultas reservadas esta semana",
+        "button": "Reservar ahora (50€)"
+      }
+    }
   }
 }

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -367,5 +367,280 @@
     "featurePrompt": {
       "unlock": "Débloquer cette fonctionnalité"
     }
+  },
+  "auth": {
+    "login": {
+      "title": "Bon retour !",
+      "subtitle": "Connectez-vous pour accéder à votre espace",
+      "googleCta": "Continuer avec Google",
+      "divider": "Ou avec email",
+      "emailLabel": "Adresse email",
+      "emailPlaceholder": "vous@example.com",
+      "passwordLabel": "Mot de passe",
+      "forgotPassword": "Mot de passe oublié ?",
+      "showPassword": "Afficher le mot de passe",
+      "hidePassword": "Masquer le mot de passe",
+      "loading": "Connexion en cours...",
+      "cta": "Se connecter",
+      "noAccount": "Pas encore de compte ?",
+      "signupLink": "Créer un compte gratuitement",
+      "termsPrefix": "En continuant, vous acceptez nos",
+      "terms": "Conditions d'utilisation",
+      "and": "et notre",
+      "privacy": "Politique de confidentialité"
+    },
+    "signup": {
+      "title": "Créer votre compte",
+      "subtitle": "Rejoignez HuntZen et boostez votre carrière",
+      "subtitleCV": "Commencez votre analyse CV gratuitement",
+      "passwordMismatch": "Les mots de passe ne correspondent pas",
+      "passwordTooShort": "Le mot de passe doit contenir au moins 6 caractères",
+      "googleCta": "S'inscrire avec Google",
+      "divider": "Ou avec email",
+      "fullNameLabel": "Nom complet",
+      "fullNamePlaceholder": "Jean Dupont",
+      "emailLabel": "Adresse email",
+      "emailPlaceholder": "vous@example.com",
+      "passwordLabel": "Mot de passe",
+      "passwordPlaceholder": "Minimum 6 caractères",
+      "confirmPasswordLabel": "Confirmer le mot de passe",
+      "confirmPasswordPlaceholder": "Retapez votre mot de passe",
+      "showPassword": "Afficher le mot de passe",
+      "hidePassword": "Masquer le mot de passe",
+      "loading": "Création en cours...",
+      "cta": "Créer mon compte gratuitement",
+      "hasAccount": "Vous avez déjà un compte ?",
+      "loginLink": "Se connecter",
+      "termsPrefix": "En créant un compte, vous acceptez nos",
+      "terms": "Conditions d'utilisation",
+      "and": "et notre",
+      "privacy": "Politique de confidentialité",
+      "cvBanner": {
+        "title": "Offre de bienvenue :",
+        "feature1": "1 analyse CV gratuite par jour",
+        "feature2": "Score ATS détaillé",
+        "feature3": "Matching emploi",
+        "feature4": "Historique complet"
+      },
+      "success": {
+        "title": "Inscription réussie ! 🎉",
+        "sentEmail": "Nous venons d'envoyer un email de confirmation à :",
+        "checkEmail": "Vérifiez votre boîte mail",
+        "checkEmailDesc": "(et vos spams) pour confirmer votre adresse email avant de vous connecter.",
+        "goToLogin": "Aller à la connexion",
+        "close": "Fermer",
+        "noEmail": "Vous n'avez pas reçu l'email ? Attendez quelques minutes ou vérifiez vos spams."
+      },
+      "timeout": {
+        "title": "Connexion lente détectée",
+        "description": "La requête a pris trop de temps. Vérifiez votre connexion internet et réessayez dans quelques instants."
+      }
+    }
+  },
+  "dashboard": {
+    "jobs": {
+      "title": "Recherche d'Emplois",
+      "subtitle": "Accédez à des milliers d'offres d'emploi provenant des meilleures plateformes de recrutement, agrégées et mises à jour quotidiennement.",
+      "form": {
+        "title": "Définissez vos critères de recherche",
+        "subtitle": "Remplissez les champs ci-dessous pour trouver les offres qui correspondent à votre profil",
+        "contractType": "Type de contrat",
+        "optional": "(optionnel)",
+        "allContracts": "Tous les types de contrat",
+        "allTypes": "✓ Tous les types",
+        "jobTitle": "Titre du poste",
+        "country": "Pays",
+        "city": "Ville",
+        "cityHint": "Tout le pays si vide",
+        "selectCountryFirst": "Selectionnez d'abord un pays",
+        "loadingPlaceholder": "Chargement...",
+        "jobTitlePlaceholder": "Ex: Developpeur Full Stack, Chef de Projet...",
+        "cityPlaceholder": "Paris, Lyon, Bruxelles...",
+        "countryPlaceholder": "France, Belgique, Suisse...",
+        "searching": "Recherche en cours...",
+        "search": "Lancer la recherche",
+        "unlock": "Débloquer les recherches illimitées",
+        "advancedFilters": "Filtres avancés",
+        "remaining_one": "{count} restante",
+        "remaining_other": "{count} restantes",
+        "noCountryFound": "Aucun pays trouvé",
+        "noCityFound": "Aucune ville trouvée"
+      },
+      "error": {
+        "title": "Erreur lors de la recherche",
+        "generic": "Une erreur est survenue lors de la recherche. Veuillez reessayer.",
+        "formLoad": "Erreur lors du chargement du formulaire. Veuillez rafraîchir la page.",
+        "fillRequired": "Veuillez remplir le titre du poste et le pays"
+      },
+      "corrected": {
+        "title": "Recherche améliorée",
+        "subtitle": "Nous avons optimisé votre recherche :"
+      },
+      "results": {
+        "count_one": "{count} offre trouvée",
+        "count_other": "{count} offres trouvées",
+        "refresh": "Actualiser",
+        "updating": "Actualisation en cours...",
+        "justNow": "à l'instant",
+        "oneMinuteAgo": "il y a 1 minute",
+        "minutesAgo": "il y a {n} minutes",
+        "staleWarning": "- Actualisation recommandée",
+        "updatedAt": "Actualisé {time}",
+        "recent": "Résultats récents et pertinents",
+        "visibleOf": "{visible} visible{s} sur {total}",
+        "unlockAll": "Débloquer toutes les offres →",
+        "cache": "💾 Cache"
+      },
+      "card": {
+        "details": "Voir détails",
+        "save": "Sauvegarder cette offre",
+        "alreadySaved": "Déjà dans vos favoris",
+        "premiumFeature": "Fonctionnalite Premium",
+        "locationUnknown": "Localisation non specifiee",
+        "alreadySavedShort": "Déjà sauvegardé",
+        "saveShort": "Sauvegarder"
+      },
+      "empty": {
+        "title": "Aucune offre trouvee",
+        "subtitle": "Nous n'avons pas trouve d'offres correspondant a vos criteres pour le moment.",
+        "tips": "💡 Suggestions :",
+        "tip1": "Essayez avec des mots-cles plus generaux",
+        "tip2": "Verifiez l'orthographe du titre de poste",
+        "tip3": "Elargissez votre zone geographique (ville → pays entier)",
+        "tip4": "Selectionnez \"Tous les types\" pour le contrat"
+      },
+      "toast": {
+        "saved": "Offre ajoutée aux favoris ✨",
+        "saveError": "Erreur lors de la sauvegarde",
+        "mustLogin": "Connectez-vous pour sauvegarder des offres",
+        "mustLoginSave": "Vous devez être connecté pour sauvegarder des offres",
+        "alreadySaved": "Cette offre est déjà dans vos favoris",
+        "filtersApplied": "{count} filtre(s) avancé(s) appliqué(s)",
+        "filtersAppliedDesc": "Recherche mise à jour avec les nouveaux filtres",
+        "filtersAppliedNext": "Les filtres seront appliqués à la prochaine recherche",
+        "filtersReset": "Filtres avancés réinitialisés"
+      }
+    },
+    "cvAnalysis": {
+      "title": "Analyse de CV",
+      "loading": "Chargement de votre espace...",
+      "errorTitle": "Erreur lors du chargement de l'analyse CV",
+      "errorDesc": "Une erreur s'est produite. Veuillez rafraîchir la page.",
+      "subtitle": "Optimisez votre CV pour maximiser vos chances de décrocher un entretien. Obtenez une analyse détaillée et des recommandations personnalisées."
+    },
+    "assistant": {
+      "title": "Assistant Carrière",
+      "history": "Historique",
+      "newConversation": "Nouvelle",
+      "simulation": "Simulation",
+      "timeWarning": "Il vous reste moins de 3 minutes ! Passez Premium pour un temps illimité.",
+      "upgradePremium": "Passer Premium",
+      "placeholder": "Posez votre question... (Entrée pour envoyer, Shift+Entrée pour nouvelle ligne)",
+      "timeExpiredTitle": "Temps écoulé",
+      "timeExpiredDesc": "Vous avez utilisé vos {minutes} minutes gratuites",
+      "unlockUnlimited": "Débloquer le temps illimité",
+      "errorMessage": "Désolé, une erreur est survenue. Pouvez-vous reformuler votre question ?",
+      "unlimited": "Illimité"
+    },
+    "salons": {
+      "title": "Salons & Forums"
+    },
+    "savedJobs": {
+      "title": "Offres Sauvegardées",
+      "searchPlaceholder": "Rechercher dans vos offres...",
+      "noJobs": "Vous n'avez pas encore sauvegardé d'offres",
+      "noJobsDesc": "Explorez les offres disponibles et sauvegardez celles qui vous intéressent",
+      "loginRequired": "Connectez-vous pour voir vos offres sauvegardées",
+      "deleteError": "Erreur lors de la suppression",
+      "deleted": "Offre supprimée",
+      "viewOffer": "Voir l'offre",
+      "delete": "Supprimer",
+      "savedAt": "Sauvegardée le",
+      "searchJobs": "Rechercher des emplois"
+    },
+    "recruiterContact": {
+      "title": "Contacter un Recruteur",
+      "stats": {
+        "consultations": "Consultations réussies",
+        "satisfaction": "Satisfaction moyenne",
+        "delay": "Délai moyen"
+      },
+      "benefits": {
+        "personalizedTitle": "Conseils personnalisés",
+        "personalizedDesc": "Un recruteur expert analyse votre profil et vous donne des recommandations sur-mesure",
+        "expertiseTitle": "Expertise professionnelle",
+        "expertiseDesc": "Nos recruteurs ont 10+ ans d'expérience dans le recrutement de cadres et talents",
+        "fastResponseTitle": "Réponse rapide",
+        "fastResponseDesc": "Vous serez contacté sous 48h pour planifier votre consultation de 30 minutes"
+      },
+      "pricing": {
+        "title": "Consultation Recruteur",
+        "sessionDesc": "Session individuelle de 30 minutes",
+        "perConsultation": "/ consultation",
+        "noSubscription": "Paiement unique, aucun abonnement",
+        "item1Title": "Session vidéo de 30 minutes",
+        "item1Desc": "Échange en direct avec un expert",
+        "item2Title": "Analyse personnalisée",
+        "item2Desc": "CV, profil LinkedIn, stratégie de recherche",
+        "item3Title": "Plan d'action concret",
+        "item3Desc": "Recommandations actionnables immédiatement",
+        "item4Title": "Compte-rendu écrit",
+        "item4Desc": "Résumé détaillé après la consultation",
+        "securePay": "Paiement sécurisé par Stripe"
+      },
+      "form": {
+        "title": "Réserver ma consultation",
+        "desc": "Remplissez le formulaire pour être contacté par un recruteur expert",
+        "fullName": "Nom complet *",
+        "email": "Email *",
+        "phone": "Téléphone",
+        "sector": "Secteur d'activité *",
+        "sectorPlaceholder": "Sélectionnez votre secteur",
+        "experienceLevel": "Niveau d'expérience *",
+        "experiencePlaceholder": "Sélectionnez votre niveau",
+        "preferredDate": "Date préférée (optionnel)",
+        "message": "Message / Questions *",
+        "messagePlaceholder": "Décrivez brièvement votre situation et vos objectifs professionnels...",
+        "submitting": "Traitement en cours...",
+        "submit": "Réserver ma consultation (50€)",
+        "submitNote": "Après validation, vous serez redirigé vers le paiement sécurisé Stripe",
+        "error": "Une erreur est survenue. Veuillez réessayer.",
+        "sectors": {
+          "tech": "Tech / IT",
+          "finance": "Finance / Banque",
+          "marketing": "Marketing / Communication",
+          "sales": "Vente / Commercial",
+          "hr": "RH / Recrutement",
+          "engineering": "Ingénierie",
+          "healthcare": "Santé",
+          "education": "Éducation",
+          "other": "Autre"
+        },
+        "levels": {
+          "junior": "Junior (0-3 ans)",
+          "confirmed": "Confirmé (3-7 ans)",
+          "senior": "Senior (7-12 ans)",
+          "expert": "Expert (12+ ans)",
+          "manager": "Manager / Lead",
+          "executive": "Executive / C-level"
+        }
+      },
+      "validation": {
+        "fullNameRequired": "Le nom complet est requis",
+        "fullNameTooShort": "Le nom doit contenir au moins 2 caractères",
+        "emailRequired": "L'email est requis",
+        "emailInvalid": "Format d'email invalide",
+        "phoneInvalid": "Format de téléphone invalide",
+        "sectorRequired": "Le secteur d'activité est requis",
+        "experienceRequired": "Le niveau d'expérience est requis",
+        "messageRequired": "Le message est requis",
+        "messageTooShort": "Le message doit contenir au moins 10 caractères"
+      },
+      "cta": {
+        "title": "Prêt à booster votre carrière ?",
+        "spots": "👥 5 consultations réservées cette semaine",
+        "button": "Réserver maintenant (50€)"
+      }
+    }
   }
 }

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -367,5 +367,280 @@
     "featurePrompt": {
       "unlock": "Desbloquear esta funcionalidade"
     }
+  },
+  "auth": {
+    "login": {
+      "title": "Bem-vindo de volta!",
+      "subtitle": "Faça login para acessar seu espaço",
+      "googleCta": "Continuar com Google",
+      "divider": "Ou com email",
+      "emailLabel": "Endereço de email",
+      "emailPlaceholder": "voce@exemplo.com",
+      "passwordLabel": "Senha",
+      "forgotPassword": "Esqueceu a senha?",
+      "showPassword": "Mostrar senha",
+      "hidePassword": "Ocultar senha",
+      "loading": "Entrando...",
+      "cta": "Entrar",
+      "noAccount": "Não tem conta?",
+      "signupLink": "Criar uma conta grátis",
+      "termsPrefix": "Ao continuar, você aceita nossos",
+      "terms": "Termos de Serviço",
+      "and": "e nossa",
+      "privacy": "Política de Privacidade"
+    },
+    "signup": {
+      "title": "Criar sua conta",
+      "subtitle": "Junte-se ao HuntZen e impulsione sua carreira",
+      "subtitleCV": "Comece sua análise de CV grátis",
+      "passwordMismatch": "As senhas não coincidem",
+      "passwordTooShort": "A senha deve ter pelo menos 6 caracteres",
+      "googleCta": "Cadastrar com Google",
+      "divider": "Ou com email",
+      "fullNameLabel": "Nome completo",
+      "fullNamePlaceholder": "João Silva",
+      "emailLabel": "Endereço de email",
+      "emailPlaceholder": "voce@exemplo.com",
+      "passwordLabel": "Senha",
+      "passwordPlaceholder": "Mínimo 6 caracteres",
+      "confirmPasswordLabel": "Confirmar senha",
+      "confirmPasswordPlaceholder": "Digite novamente sua senha",
+      "showPassword": "Mostrar senha",
+      "hidePassword": "Ocultar senha",
+      "loading": "Criando...",
+      "cta": "Criar minha conta grátis",
+      "hasAccount": "Já tem uma conta?",
+      "loginLink": "Entrar",
+      "termsPrefix": "Ao criar uma conta, você aceita nossos",
+      "terms": "Termos de Serviço",
+      "and": "e nossa",
+      "privacy": "Política de Privacidade",
+      "cvBanner": {
+        "title": "Oferta de boas-vindas:",
+        "feature1": "1 análise de CV grátis por dia",
+        "feature2": "Pontuação ATS detalhada",
+        "feature3": "Correspondência de empregos",
+        "feature4": "Histórico completo"
+      },
+      "success": {
+        "title": "Cadastro realizado! 🎉",
+        "sentEmail": "Enviamos um email de confirmação para:",
+        "checkEmail": "Verifique sua caixa de entrada",
+        "checkEmailDesc": "(e spam) para confirmar seu email antes de fazer login.",
+        "goToLogin": "Ir para o login",
+        "close": "Fechar",
+        "noEmail": "Não recebeu o email? Aguarde alguns minutos ou verifique o spam."
+      },
+      "timeout": {
+        "title": "Conexão lenta detectada",
+        "description": "A solicitação demorou muito. Verifique sua conexão e tente novamente em breve."
+      }
+    }
+  },
+  "dashboard": {
+    "jobs": {
+      "title": "Busca de Empregos",
+      "subtitle": "Acesse milhares de vagas das melhores plataformas de recrutamento, agregadas e atualizadas diariamente.",
+      "form": {
+        "title": "Defina seus critérios de busca",
+        "subtitle": "Preencha os campos abaixo para encontrar vagas que correspondam ao seu perfil",
+        "contractType": "Tipo de contrato",
+        "optional": "(opcional)",
+        "allContracts": "Todos os tipos de contrato",
+        "allTypes": "✓ Todos os tipos",
+        "jobTitle": "Título do cargo",
+        "country": "País",
+        "city": "Cidade",
+        "cityHint": "Todo o país se vazio",
+        "selectCountryFirst": "Selecione um país primeiro",
+        "loadingPlaceholder": "Carregando...",
+        "jobTitlePlaceholder": "Ex: Desenvolvedor Full Stack, Gerente de Projeto...",
+        "cityPlaceholder": "São Paulo, Rio de Janeiro, Lisboa...",
+        "countryPlaceholder": "Brasil, Portugal, Angola...",
+        "searching": "Buscando...",
+        "search": "Iniciar busca",
+        "unlock": "Desbloquear buscas ilimitadas",
+        "advancedFilters": "Filtros avançados",
+        "remaining_one": "{count} restante",
+        "remaining_other": "{count} restantes",
+        "noCountryFound": "País não encontrado",
+        "noCityFound": "Cidade não encontrada"
+      },
+      "error": {
+        "title": "Erro na busca",
+        "generic": "Ocorreu um erro durante a busca. Por favor tente novamente.",
+        "formLoad": "Erro ao carregar o formulário. Por favor recarregue a página.",
+        "fillRequired": "Por favor preencha o título do cargo e o país"
+      },
+      "corrected": {
+        "title": "Busca melhorada",
+        "subtitle": "Otimizamos sua busca:"
+      },
+      "results": {
+        "count_one": "{count} vaga encontrada",
+        "count_other": "{count} vagas encontradas",
+        "refresh": "Atualizar",
+        "updating": "Atualizando...",
+        "justNow": "agora mesmo",
+        "oneMinuteAgo": "há 1 minuto",
+        "minutesAgo": "há {n} minutos",
+        "staleWarning": "- Atualização recomendada",
+        "updatedAt": "Atualizado {time}",
+        "recent": "Resultados recentes e relevantes",
+        "visibleOf": "{visible} visível(is) de {total}",
+        "unlockAll": "Desbloquear todas as vagas →",
+        "cache": "💾 Cache"
+      },
+      "card": {
+        "details": "Ver detalhes",
+        "save": "Salvar esta vaga",
+        "alreadySaved": "Já nos favoritos",
+        "premiumFeature": "Recurso Premium",
+        "locationUnknown": "Localização não especificada",
+        "alreadySavedShort": "Já salvo",
+        "saveShort": "Salvar"
+      },
+      "empty": {
+        "title": "Nenhuma vaga encontrada",
+        "subtitle": "Não encontramos vagas que correspondam aos seus critérios no momento.",
+        "tips": "💡 Sugestões:",
+        "tip1": "Tente palavras-chave mais gerais",
+        "tip2": "Verifique a ortografia do título do cargo",
+        "tip3": "Amplie sua área geográfica (cidade → todo o país)",
+        "tip4": "Selecione \"Todos os tipos\" para o contrato"
+      },
+      "toast": {
+        "saved": "Vaga adicionada aos favoritos ✨",
+        "saveError": "Erro ao salvar",
+        "mustLogin": "Faça login para salvar vagas",
+        "mustLoginSave": "Você deve estar logado para salvar vagas",
+        "alreadySaved": "Esta vaga já está nos seus favoritos",
+        "filtersApplied": "{count} filtro(s) avançado(s) aplicado(s)",
+        "filtersAppliedDesc": "Busca atualizada com os novos filtros",
+        "filtersAppliedNext": "Os filtros serão aplicados à próxima busca",
+        "filtersReset": "Filtros avançados redefinidos"
+      }
+    },
+    "cvAnalysis": {
+      "title": "Análise de CV",
+      "loading": "Carregando seu espaço...",
+      "errorTitle": "Erro ao carregar a análise de CV",
+      "errorDesc": "Ocorreu um erro. Por favor recarregue a página.",
+      "subtitle": "Otimize seu CV para maximizar suas chances de conseguir uma entrevista. Obtenha uma análise detalhada e recomendações personalizadas."
+    },
+    "assistant": {
+      "title": "Assistente de Carreira",
+      "history": "Histórico",
+      "newConversation": "Nova",
+      "simulation": "Simulação",
+      "timeWarning": "Restam menos de 3 minutos! Vá ao Premium para tempo ilimitado.",
+      "upgradePremium": "Ir ao Premium",
+      "placeholder": "Faça sua pergunta... (Enter para enviar, Shift+Enter para nova linha)",
+      "timeExpiredTitle": "Tempo esgotado",
+      "timeExpiredDesc": "Você usou seus {minutes} minutos gratuitos",
+      "unlockUnlimited": "Desbloquear tempo ilimitado",
+      "errorMessage": "Desculpe, ocorreu um erro. Pode reformular sua pergunta?",
+      "unlimited": "Ilimitado"
+    },
+    "salons": {
+      "title": "Feiras e Fóruns de Emprego"
+    },
+    "savedJobs": {
+      "title": "Vagas Salvas",
+      "searchPlaceholder": "Buscar nas suas vagas...",
+      "noJobs": "Você ainda não salvou nenhuma vaga",
+      "noJobsDesc": "Explore as vagas disponíveis e salve as que te interessam",
+      "loginRequired": "Faça login para ver suas vagas salvas",
+      "deleteError": "Erro ao excluir",
+      "deleted": "Vaga excluída",
+      "viewOffer": "Ver vaga",
+      "delete": "Excluir",
+      "savedAt": "Salvo em",
+      "searchJobs": "Buscar empregos"
+    },
+    "recruiterContact": {
+      "title": "Contatar um Recrutador",
+      "stats": {
+        "consultations": "Consultas bem-sucedidas",
+        "satisfaction": "Satisfação média",
+        "delay": "Prazo médio"
+      },
+      "benefits": {
+        "personalizedTitle": "Conselhos personalizados",
+        "personalizedDesc": "Um recrutador especialista analisa seu perfil e dá recomendações sob medida",
+        "expertiseTitle": "Expertise profissional",
+        "expertiseDesc": "Nossos recrutadores têm 10+ anos de experiência em recrutamento executivo",
+        "fastResponseTitle": "Resposta rápida",
+        "fastResponseDesc": "Você será contatado em 48h para agendar sua consulta de 30 minutos"
+      },
+      "pricing": {
+        "title": "Consulta com Recrutador",
+        "sessionDesc": "Sessão individual de 30 minutos",
+        "perConsultation": "/ consulta",
+        "noSubscription": "Pagamento único, sem assinatura",
+        "item1Title": "Sessão de vídeo de 30 minutos",
+        "item1Desc": "Troca ao vivo com um especialista",
+        "item2Title": "Análise personalizada",
+        "item2Desc": "CV, perfil LinkedIn, estratégia de busca",
+        "item3Title": "Plano de ação concreto",
+        "item3Desc": "Recomendações acionáveis imediatamente",
+        "item4Title": "Resumo escrito",
+        "item4Desc": "Resumo detalhado após a consulta",
+        "securePay": "Pagamento seguro pelo Stripe"
+      },
+      "form": {
+        "title": "Reservar minha consulta",
+        "desc": "Preencha o formulário para ser contatado por um recrutador especialista",
+        "fullName": "Nome completo *",
+        "email": "Email *",
+        "phone": "Telefone",
+        "sector": "Setor *",
+        "sectorPlaceholder": "Selecione seu setor",
+        "experienceLevel": "Nível de experiência *",
+        "experiencePlaceholder": "Selecione seu nível",
+        "preferredDate": "Data preferida (opcional)",
+        "message": "Mensagem / Perguntas *",
+        "messagePlaceholder": "Descreva brevemente sua situação e objetivos profissionais...",
+        "submitting": "Processando...",
+        "submit": "Reservar minha consulta (50€)",
+        "submitNote": "Após validação, você será redirecionado para o pagamento seguro Stripe",
+        "error": "Ocorreu um erro. Por favor, tente novamente.",
+        "sectors": {
+          "tech": "Tecnologia / TI",
+          "finance": "Finanças / Banco",
+          "marketing": "Marketing / Comunicação",
+          "sales": "Vendas / Comercial",
+          "hr": "RH / Recrutamento",
+          "engineering": "Engenharia",
+          "healthcare": "Saúde",
+          "education": "Educação",
+          "other": "Outro"
+        },
+        "levels": {
+          "junior": "Júnior (0-3 anos)",
+          "confirmed": "Intermediário (3-7 anos)",
+          "senior": "Sênior (7-12 anos)",
+          "expert": "Especialista (12+ anos)",
+          "manager": "Gerente / Lead",
+          "executive": "Executivo / C-level"
+        }
+      },
+      "validation": {
+        "fullNameRequired": "O nome completo é obrigatório",
+        "fullNameTooShort": "O nome deve conter pelo menos 2 caracteres",
+        "emailRequired": "O email é obrigatório",
+        "emailInvalid": "Formato de email inválido",
+        "phoneInvalid": "Formato de telefone inválido",
+        "sectorRequired": "O setor é obrigatório",
+        "experienceRequired": "O nível de experiência é obrigatório",
+        "messageRequired": "A mensagem é obrigatória",
+        "messageTooShort": "A mensagem deve conter pelo menos 10 caracteres"
+      },
+      "cta": {
+        "title": "Pronto para impulsionar sua carreira?",
+        "spots": "👥 5 consultas reservadas esta semana",
+        "button": "Reservar agora (50€)"
+      }
+    }
   }
 }

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -36,8 +36,10 @@ import { HistorySidebar } from "@/components/coach/history-sidebar";
 import { ExportDialog } from "@/components/coach/export-dialog";
 import { useCoachHistory, useDebounce } from "@/hooks/use-coach-history";
 import { toCoachMessage, toChatMessage } from "@/types/coach-history";
+import { useTranslations } from "next-intl";
 
 export default function AssistantPage() {
+  const t = useTranslations("dashboard.assistant");
   const [messages, setMessages] = useState<ChatMessageType[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
@@ -89,7 +91,7 @@ export default function AssistantPage() {
 
   // Format time as mm:ss
   const formatTime = (seconds: number) => {
-    if (seconds === Infinity || seconds > 3600 * 24) return "Illimite";
+    if (seconds === Infinity || seconds > 3600 * 24) return t("unlimited");
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${mins}:${secs.toString().padStart(2, "0")}`;
@@ -188,8 +190,7 @@ export default function AssistantPage() {
       const errorMessage: ChatMessageType = {
         id: uuidv4(),
         role: "assistant",
-        content:
-          "Desole, une erreur est survenue. Pouvez-vous reformuler votre question ?",
+        content: t("errorMessage"),
         timestamp: new Date(),
       };
       setMessages((prev) => [...prev, errorMessage]);
@@ -339,7 +340,7 @@ export default function AssistantPage() {
               className="gap-2 bg-slate-100 border-slate-300 text-slate-700 hover:bg-slate-200 hover:border-[#00D9FF] hover:text-slate-900"
             >
               <History className="w-4 h-4" />
-              Historique
+              {t("history")}
               <Lock className="w-3 h-3" />
             </Button>
           )}
@@ -353,7 +354,7 @@ export default function AssistantPage() {
               className="gap-2 bg-slate-100 border-slate-300 text-slate-700 hover:bg-slate-200 hover:border-[#00D9FF] hover:text-slate-900"
             >
               <Plus className="w-4 h-4" />
-              Nouvelle
+              {t("newConversation")}
             </Button>
           )}
 
@@ -365,7 +366,7 @@ export default function AssistantPage() {
             className="hidden gap-2"
           >
             <Mic className="w-4 h-4" />
-            Simulation
+            {t("simulation")}
             {!hasFeature("has_interview_sim") && <Lock className="w-3 h-3" />}
           </Button>
         </motion.div>
@@ -384,17 +385,14 @@ export default function AssistantPage() {
                 className="px-4 py-2 bg-amber-50 border-b border-amber-200 flex items-center gap-2 text-amber-700"
               >
                 <AlertTriangle className="w-4 h-4" />
-                <span className="text-sm font-medium">
-                  Il vous reste moins de 3 minutes ! Passez Premium pour un
-                  temps illimité.
-                </span>
+                <span className="text-sm font-medium">{t("timeWarning")}</span>
                 <Button
                   size="sm"
                   variant="ghost"
                   className="ml-auto text-amber-700 hover:text-amber-800 hover:bg-amber-100"
                   onClick={() => openPricingModal("coach_minutes_per_day")}
                 >
-                  Passer Premium
+                  {t("upgradePremium")}
                 </Button>
               </motion.div>
             )}
@@ -514,7 +512,7 @@ export default function AssistantPage() {
                   <ExpandableTextarea
                     value={input}
                     onChange={setInput}
-                    placeholder="Posez votre question... (Entrée pour envoyer, Shift+Entrée pour nouvelle ligne)"
+                    placeholder={t("placeholder")}
                     disabled={loading}
                     minHeight={44}
                     maxHeight={120}
@@ -563,17 +561,20 @@ export default function AssistantPage() {
                 >
                   <Clock className="w-6 h-6 text-gray-400" />
                 </motion.div>
-                <p className="font-bold text-slate-900 mb-1">Temps écoulé</p>
+                <p className="font-bold text-slate-900 mb-1">
+                  {t("timeExpiredTitle")}
+                </p>
                 <p className="text-sm text-slate-700 mb-3">
-                  Vous avez utilisé vos {limits.coach_minutes_per_day} minutes
-                  gratuites
+                  {t("timeExpiredDesc", {
+                    minutes: limits.coach_minutes_per_day,
+                  })}
                 </p>
                 <Button
                   onClick={() => openPricingModal("coach_minutes_per_day")}
                   className="h-12 text-base font-bold bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:shadow-lg hover:shadow-[#00D9FF]/40 text-white transition-all duration-300"
                 >
                   <Sparkles className="w-5 h-5 mr-2" />
-                  Débloquer le temps illimité
+                  {t("unlockUnlimited")}
                 </Button>
               </motion.div>
             )}

--- a/frontend-next/src/app/(dashboard)/cv-analysis/page.tsx
+++ b/frontend-next/src/app/(dashboard)/cv-analysis/page.tsx
@@ -8,9 +8,11 @@ import { UsageCounter } from "@/components/freemium/usage-counter";
 import { CVUploadAsyncWizard } from "@/components/cv/cv-upload-async-wizard";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { Card } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
 
 export default function CVAnalysisPage() {
   const { session, loading } = useAuth();
+  const t = useTranslations("dashboard.cvAnalysis");
 
   // Freemium state
   const { canUse, incrementUsage, hasFeature, openPricingModal } =
@@ -22,7 +24,7 @@ export default function CVAnalysisPage() {
       <div className="max-w-7xl mx-auto p-6">
         <div className="flex flex-col items-center justify-center min-h-[400px]">
           <Loader2 className="w-12 h-12 animate-spin text-[#00D9FF] mb-4" />
-          <p className="text-slate-600">Chargement de votre espace...</p>
+          <p className="text-slate-600">{t("loading")}</p>
         </div>
       </div>
     );
@@ -48,13 +50,8 @@ export default function CVAnalysisPage() {
             >
               <FileText className="w-7 h-7 text-white" />
             </motion.div>
-            <h1 className="text-4xl font-black text-slate-900">Analyse CV</h1>
+            <h1 className="text-4xl font-black text-slate-900">{t("title")}</h1>
           </div>
-          <p className="text-base text-slate-700 leading-relaxed max-w-3xl">
-            Optimisez votre CV pour maximiser vos chances de décrocher un
-            entretien. Obtenez une analyse détaillée et des recommandations
-            personnalisées.
-          </p>
         </div>
 
         {/* Usage Counter - only shown when authenticated */}
@@ -75,10 +72,10 @@ export default function CVAnalysisPage() {
           <Card className="p-8 bg-red-50 border-red-200">
             <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
             <h3 className="text-lg font-bold text-slate-900 mb-2 text-center">
-              Erreur lors du chargement de l'analyse CV
+              {t("errorTitle")}
             </h3>
             <p className="text-slate-600 text-center">
-              Une erreur s'est produite. Veuillez rafraîchir la page.
+              {t("errorDesc")}
             </p>
           </Card>
         }

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
@@ -65,6 +66,7 @@ import {
 } from "@/components/jobs/advanced-filters-modal";
 
 export default function JobsPage() {
+  const t = useTranslations("dashboard.jobs");
   const [jobTitle, setJobTitle] = useState("");
   const [popularQuery, setPopularQuery] = useState<string | undefined>(
     undefined,
@@ -532,12 +534,12 @@ export default function JobsPage() {
     },
     onSuccess: (_, job) => {
       setSavedJobIds((prev) => new Set(prev).add(job.id));
-      toast.success("Offre ajoutée aux favoris ✨");
+      toast.success(t("toast.saved"));
       // Invalidate saved jobs query
       queryClient.invalidateQueries({ queryKey: ["saved-jobs"] });
     },
     onError: (error: Error) => {
-      toast.error(error.message || "Erreur lors de la sauvegarde");
+      toast.error(error.message || t("toast.saveError"));
     },
   });
 
@@ -547,13 +549,13 @@ export default function JobsPage() {
       return;
     }
     if (!auth?.user) {
-      toast.error("Connectez-vous pour sauvegarder des offres");
+      toast.error(t("toast.mustLogin"));
       return;
     }
 
     // Check if already saved
     if (savedJobIds.has(job.id)) {
-      toast.info("Cette offre est déjà dans vos favoris");
+      toast.info(t("toast.alreadySaved"));
       return;
     }
 
@@ -622,14 +624,14 @@ export default function JobsPage() {
     // Show confirmation toast
     const filtersCount = Object.keys(filters).length;
     if (filtersCount > 0) {
-      toast.success(`${filtersCount} filtre(s) avancé(s) appliqué(s)`, {
+      toast.success(t("toast.filtersApplied", { count: filtersCount }), {
         description:
           filtersCount > 0 && jobs.length > 0
-            ? "Recherche mise à jour avec les nouveaux filtres"
-            : "Les filtres seront appliqués à la prochaine recherche",
+            ? t("toast.filtersAppliedDesc")
+            : t("toast.filtersAppliedNext"),
       });
     } else {
-      toast.info("Filtres avancés réinitialisés");
+      toast.info(t("toast.filtersReset"));
       // Re-run search to remove filters
       if (jobs.length > 0) {
         handleSearch({
@@ -678,14 +680,10 @@ export default function JobsPage() {
             >
               <Search className="w-7 h-7 text-white" />
             </motion.div>
-            <h1 className="text-4xl font-black text-slate-900">
-              Recherche d&apos;Emplois
-            </h1>
+            <h1 className="text-4xl font-black text-slate-900">{t("title")}</h1>
           </motion.div>
           <p className="text-slate-700 text-base max-w-3xl leading-relaxed">
-            Accédez à des milliers d&apos;offres d&apos;emploi provenant des
-            meilleures plateformes de recrutement, agrégées et mises à jour
-            quotidiennement.
+            {t("subtitle")}
           </p>
         </div>
 
@@ -707,10 +705,7 @@ export default function JobsPage() {
         fallback={
           <Card className="p-6 bg-red-50 border-red-200">
             <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-3" />
-            <p className="text-red-700 text-center">
-              Erreur lors du chargement du formulaire. Veuillez rafraîchir la
-              page.
-            </p>
+            <p className="text-red-700 text-center">{t("error.formLoad")}</p>
           </Card>
         }
       >
@@ -728,11 +723,10 @@ export default function JobsPage() {
                 <div>
                   <CardTitle className="text-2xl font-bold flex items-center gap-2.5 text-slate-900">
                     <Filter className="w-6 h-6 text-huntzen-blue" />
-                    Définissez vos critères de recherche
+                    {t("form.title")}
                   </CardTitle>
                   <p className="text-sm text-slate-600 mt-2">
-                    Remplissez les champs ci-dessous pour trouver les offres qui
-                    correspondent à votre profil
+                    {t("form.subtitle")}
                   </p>
                 </div>
 
@@ -741,9 +735,9 @@ export default function JobsPage() {
                     htmlFor="contractType"
                     className="text-sm font-semibold"
                   >
-                    Type de contrat{" "}
+                    {t("form.contractType")}{" "}
                     <span className="text-muted-foreground text-xs font-normal">
-                      (optionnel)
+                      {t("form.optional")}
                     </span>
                   </Label>
                   <Select
@@ -757,10 +751,10 @@ export default function JobsPage() {
                       id="contractType"
                       className="h-11 border-2 focus:border-primary"
                     >
-                      <SelectValue placeholder="Tous les types de contrat" />
+                      <SelectValue placeholder={t("form.allContracts")} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">✓ Tous les types</SelectItem>
+                      <SelectItem value="all">{t("form.allTypes")}</SelectItem>
                       {contractTypes.map((type) => (
                         <SelectItem key={type.id} value={type.id}>
                           {type.label}
@@ -786,18 +780,22 @@ export default function JobsPage() {
                   {searchQuery.isFetching ? (
                     <>
                       <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                      Recherche en cours...
+                      {t("form.searching")}
                     </>
                   ) : (
                     <>
                       <Search className="mr-2 h-5 w-5" />
-                      Lancer la recherche
+                      {t("form.search")}
                       {isFreePlan &&
                         searchesRemaining <= 3 &&
                         searchesRemaining > 0 && (
                           <span className="ml-2 px-2 py-0.5 bg-white/20 rounded-full text-xs font-semibold">
-                            {searchesRemaining} restante
-                            {searchesRemaining !== 1 ? "s" : ""}
+                            {t(
+                              searchesRemaining !== 1
+                                ? "form.remaining_other"
+                                : "form.remaining_one",
+                              { count: searchesRemaining },
+                            )}
                           </span>
                         )}
                     </>
@@ -812,7 +810,7 @@ export default function JobsPage() {
                   className="gap-2"
                 >
                   <Sparkles className="w-4 h-4" />
-                  Filtres avancés
+                  {t("form.advancedFilters")}
                   {!hasFeature("has_advanced_filters") && (
                     <Lock className="w-3.5 h-3.5" />
                   )}
@@ -827,12 +825,13 @@ export default function JobsPage() {
                       htmlFor="jobTitle"
                       className="text-sm font-semibold flex items-center gap-1"
                     >
-                      Titre du poste <span className="text-red-500">*</span>
+                      {t("form.jobTitle")}{" "}
+                      <span className="text-red-500">*</span>
                     </Label>
                     <Input
                       id="jobTitle"
                       name="jobTitle"
-                      placeholder="Ex: Developpeur Full Stack, Chef de Projet..."
+                      placeholder={t("form.jobTitlePlaceholder")}
                       value={jobTitle}
                       onChange={(e) => setJobTitle(e.target.value)}
                       required
@@ -845,7 +844,8 @@ export default function JobsPage() {
                       htmlFor="country"
                       className="text-sm font-semibold flex items-center gap-1"
                     >
-                      Pays <span className="text-red-500">*</span>
+                      {t("form.country")}{" "}
+                      <span className="text-red-500">*</span>
                     </Label>
                     <Input
                       ref={countryInputRef}
@@ -853,8 +853,8 @@ export default function JobsPage() {
                       name="country"
                       placeholder={
                         loadingCountries
-                          ? "Chargement..."
-                          : "France, Belgique, Suisse..."
+                          ? t("form.loadingPlaceholder")
+                          : t("form.countryPlaceholder")
                       }
                       value={countrySearch}
                       className="h-11 border-2 focus:border-primary"
@@ -926,7 +926,7 @@ export default function JobsPage() {
                           ref={countrySuggestionsRef}
                           className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-xl p-3 text-sm text-slate-600 pointer-events-auto"
                         >
-                          Aucun pays trouvé
+                          {t("form.noCountryFound")}
                         </div>
                       )}
                   </div>
@@ -934,14 +934,14 @@ export default function JobsPage() {
                   <div className="space-y-2 relative">
                     <div className="flex items-center justify-between">
                       <Label htmlFor="city" className="text-sm font-semibold">
-                        Ville{" "}
+                        {t("form.city")}{" "}
                         <span className="text-muted-foreground text-xs font-normal">
-                          (optionnel)
+                          {t("form.optional")}
                         </span>
                       </Label>
                       {selectedCountry && !citySearch && (
                         <span className="text-xs text-huntzen-blue font-medium">
-                          Tout le pays si vide
+                          {t("form.cityHint")}
                         </span>
                       )}
                     </div>
@@ -951,10 +951,10 @@ export default function JobsPage() {
                       name="city"
                       placeholder={
                         !selectedCountry
-                          ? "Selectionnez d'abord un pays"
+                          ? t("form.selectCountryFirst")
                           : loadingCities
-                            ? "Chargement..."
-                            : "Paris, Lyon, Bruxelles..."
+                            ? t("form.loadingPlaceholder")
+                            : t("form.cityPlaceholder")
                       }
                       value={citySearch}
                       className="h-11 border-2 focus:border-primary"
@@ -1028,7 +1028,7 @@ export default function JobsPage() {
                           ref={citySuggestionsRef}
                           className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-xl p-3 text-sm text-slate-600 pointer-events-auto"
                         >
-                          Aucune ville trouvée
+                          {t("form.noCityFound")}
                         </div>
                       )}
                   </div>
@@ -1038,9 +1038,9 @@ export default function JobsPage() {
                       htmlFor="contractType"
                       className="text-sm font-semibold"
                     >
-                      Type de contrat{" "}
+                      {t("form.contractType")}{" "}
                       <span className="text-muted-foreground text-xs font-normal">
-                        (optionnel)
+                        {t("form.optional")}
                       </span>
                     </Label>
                     <Select
@@ -1054,10 +1054,12 @@ export default function JobsPage() {
                         id="contractType"
                         className="h-11 border-2 focus:border-primary"
                       >
-                        <SelectValue placeholder="Tous les types de contrat" />
+                        <SelectValue placeholder={t("form.allContracts")} />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="all">✓ Tous les types</SelectItem>
+                        <SelectItem value="all">
+                          {t("form.allTypes")}
+                        </SelectItem>
                         {contractTypes.map((type) => (
                           <SelectItem key={type.id} value={type.id}>
                             {type.label}
@@ -1083,18 +1085,22 @@ export default function JobsPage() {
                     {searchQuery.isFetching ? (
                       <>
                         <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                        Recherche en cours...
+                        {t("form.searching")}
                       </>
                     ) : (
                       <>
                         <Search className="mr-2 h-5 w-5" />
-                        Lancer la recherche
+                        {t("form.search")}
                         {isFreePlan &&
                           searchesRemaining <= 3 &&
                           searchesRemaining > 0 && (
                             <span className="ml-2 px-2 py-0.5 bg-white/20 rounded-full text-xs font-semibold">
-                              {searchesRemaining} restante
-                              {searchesRemaining !== 1 ? "s" : ""}
+                              {t(
+                                searchesRemaining !== 1
+                                  ? "form.remaining_other"
+                                  : "form.remaining_one",
+                                { count: searchesRemaining },
+                              )}
                             </span>
                           )}
                       </>
@@ -1110,7 +1116,7 @@ export default function JobsPage() {
                       className="gap-2 border-2 border-[#00D9FF] text-[#00D9FF] hover:bg-[#00D9FF]/10 h-12 font-semibold"
                     >
                       <Sparkles className="w-4 h-4" />
-                      Débloquer les recherches illimitées
+                      {t("form.unlock")}
                     </Button>
                   )}
                 </div>
@@ -1128,12 +1134,12 @@ export default function JobsPage() {
               <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
               <div>
                 <h3 className="font-semibold text-red-700 mb-1">
-                  Erreur lors de la recherche
+                  {t("error.title")}
                 </h3>
                 <p className="text-sm text-red-600">
                   {searchQuery.error instanceof Error
                     ? searchQuery.error.message
-                    : "Une erreur est survenue lors de la recherche. Veuillez reessayer."}
+                    : t("error.generic")}
                 </p>
               </div>
             </div>
@@ -1153,10 +1159,10 @@ export default function JobsPage() {
               <Sparkles className="w-5 h-5 text-[#00D9FF] flex-shrink-0 mt-0.5" />
               <div>
                 <h3 className="font-bold text-slate-900 mb-1">
-                  Recherche améliorée
+                  {t("corrected.title")}
                 </h3>
                 <p className="text-sm text-slate-700">
-                  Nous avons optimisé votre recherche :{" "}
+                  {t("corrected.subtitle")}{" "}
                   <strong className="font-bold text-[#00D9FF]">
                     {correctedQuery}
                   </strong>
@@ -1244,8 +1250,9 @@ export default function JobsPage() {
                 <div>
                   <div className="flex items-center gap-2">
                     <h2 className="text-2xl font-black text-emerald-700">
-                      {jobs.length} offre{jobs.length > 1 ? "s" : ""} trouvée
-                      {jobs.length > 1 ? "s" : ""}
+                      {jobs.length === 1
+                        ? t("results.count_one", { count: jobs.length })
+                        : t("results.count_other", { count: jobs.length })}
                     </h2>
                     {/* Cache badge - Shows when data is from cache */}
                     {searchQuery.isFetched &&
@@ -1321,7 +1328,9 @@ export default function JobsPage() {
                       searchQuery.isFetching && "animate-spin",
                     )}
                   />
-                  <span className="hidden sm:inline">Actualiser</span>
+                  <span className="hidden sm:inline">
+                    {t("results.refresh")}
+                  </span>
                 </Button>
               </div>
               {isFreePlan && (
@@ -1343,7 +1352,7 @@ export default function JobsPage() {
                     onClick={() => openPricingModal("jobs_visible")}
                     className="text-xs text-[#00D9FF] hover:text-[#00C4EA] p-0 h-auto font-semibold"
                   >
-                    Débloquer toutes les offres →
+                    {t("results.unlockAll")}
                   </Button>
                 </motion.div>
               )}
@@ -1400,15 +1409,15 @@ export default function JobsPage() {
                             )}
                             title={
                               !hasFeature("has_favorites")
-                                ? "Fonctionnalite Premium"
+                                ? t("card.premiumFeature")
                                 : savedJobIds.has(job.id)
-                                  ? "Deja dans vos favoris"
-                                  : "Sauvegarder cette offre"
+                                  ? t("card.alreadySaved")
+                                  : t("card.save")
                             }
                             aria-label={
                               savedJobIds.has(job.id)
-                                ? "Déjà sauvegardé"
-                                : "Sauvegarder"
+                                ? t("card.alreadySavedShort")
+                                : t("card.saveShort")
                             }
                             disabled={
                               saveJobMutation.isPending ||
@@ -1444,7 +1453,7 @@ export default function JobsPage() {
                         <div className="flex items-center gap-2 text-sm text-muted-foreground bg-gray-50 px-3 py-2 rounded-lg">
                           <MapPin className="h-4 w-4 text-primary flex-shrink-0" />
                           <span className="font-medium">
-                            {job.location || "Localisation non specifiee"}
+                            {job.location || t("card.locationUnknown")}
                           </span>
                         </div>
 
@@ -1468,7 +1477,7 @@ export default function JobsPage() {
                           className="flex-1 bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:from-[#00C4EA] hover:to-[#00B3D9] text-white font-bold shadow-md hover:shadow-lg hover:shadow-[#00D9FF]/30 transition-all h-11"
                           onClick={() => handleViewDetails(job)}
                         >
-                          Voir détails
+                          {t("card.details")}
                           <ExternalLink className="ml-2 h-4 w-4" />
                         </Button>
                       </div>
@@ -1565,23 +1574,18 @@ export default function JobsPage() {
                 <Search className="h-10 w-10 text-muted-foreground/50" />
               </div>
               <h3 className="text-2xl font-bold text-slate-700 mb-2">
-                Aucune offre trouvee
+                {t("empty.title")}
               </h3>
               <p className="text-base text-muted-foreground mb-6 max-w-md mx-auto">
-                Nous n&apos;avons pas trouve d&apos;offres correspondant a vos
-                criteres pour le moment.
+                {t("empty.subtitle")}
               </p>
               <div className="space-y-2 text-sm text-muted-foreground max-w-lg mx-auto">
-                <p className="font-semibold">💡 Suggestions :</p>
+                <p className="font-semibold">{t("empty.tips")}</p>
                 <ul className="text-left space-y-1 inline-block">
-                  <li>• Essayez avec des mots-cles plus generaux</li>
-                  <li>• Verifiez l&apos;orthographe du titre de poste</li>
-                  <li>
-                    • Elargissez votre zone geographique (ville → pays entier)
-                  </li>
-                  <li>
-                    • Selectionnez &quot;Tous les types&quot; pour le contrat
-                  </li>
+                  <li>• {t("empty.tip1")}</li>
+                  <li>• {t("empty.tip2")}</li>
+                  <li>• {t("empty.tip3")}</li>
+                  <li>• {t("empty.tip4")}</li>
                 </ul>
               </div>
             </CardContent>

--- a/frontend-next/src/app/(dashboard)/recruiter-contact/page.tsx
+++ b/frontend-next/src/app/(dashboard)/recruiter-contact/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "lucide-react";
 import { huntzenApi } from "@/lib/api/huntzen-client";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useOptionalAuth } from "@/contexts/auth-context";
 import { HeroSection } from "@/components/recruiter/hero-section";
 import { ProcessSteps } from "@/components/recruiter/process-steps";
@@ -41,6 +42,7 @@ import { TestimonialsSection } from "@/components/recruiter/testimonials-section
 import { FAQSection } from "@/components/recruiter/faq-section";
 
 export default function RecruiterContactPage() {
+  const t = useTranslations("dashboard.recruiterContact");
   const router = useRouter();
   const auth = useOptionalAuth();
   const user = auth?.user;
@@ -62,29 +64,27 @@ export default function RecruiterContactPage() {
   const validateField = (field: string, value: string): string => {
     switch (field) {
       case "fullName":
-        if (!value.trim()) return "Le nom complet est requis";
-        if (value.trim().length < 2)
-          return "Le nom doit contenir au moins 2 caractères";
+        if (!value.trim()) return t("validation.fullNameRequired");
+        if (value.trim().length < 2) return t("validation.fullNameTooShort");
         return "";
       case "email":
-        if (!value.trim()) return "L'email est requis";
+        if (!value.trim()) return t("validation.emailRequired");
         const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (!emailRegex.test(value)) return "Format d'email invalide";
+        if (!emailRegex.test(value)) return t("validation.emailInvalid");
         return "";
       case "phone":
         if (value && !/^[\d\s+()-]+$/.test(value))
-          return "Format de téléphone invalide";
+          return t("validation.phoneInvalid");
         return "";
       case "sector":
-        if (!value) return "Le secteur d'activité est requis";
+        if (!value) return t("validation.sectorRequired");
         return "";
       case "experienceLevel":
-        if (!value) return "Le niveau d'expérience est requis";
+        if (!value) return t("validation.experienceRequired");
         return "";
       case "message":
-        if (!value.trim()) return "Le message est requis";
-        if (value.trim().length < 10)
-          return "Le message doit contenir au moins 10 caractères";
+        if (!value.trim()) return t("validation.messageRequired");
+        if (value.trim().length < 10) return t("validation.messageTooShort");
         return "";
       default:
         return "";
@@ -137,7 +137,7 @@ export default function RecruiterContactPage() {
         window.location.href = paymentResponse.checkout_url;
       }
     } catch (error: any) {
-      alert("Une erreur est survenue. Veuillez réessayer.");
+      alert(t("form.error"));
     } finally {
       setIsSubmitting(false);
     }
@@ -179,7 +179,7 @@ export default function RecruiterContactPage() {
           className="text-center p-6 bg-white rounded-xl border-2 border-[#00D9FF]/20 hover:border-[#00D9FF] hover:shadow-lg transition-all"
         >
           <div className="text-4xl font-black text-[#00D9FF] mb-2">127</div>
-          <p className="text-sm text-gray-600">Consultations réussies</p>
+          <p className="text-sm text-gray-600">{t("stats.consultations")}</p>
         </motion.div>
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
@@ -188,7 +188,7 @@ export default function RecruiterContactPage() {
           className="text-center p-6 bg-white rounded-xl border-2 border-[#00C4EA]/20 hover:border-[#00C4EA] hover:shadow-lg transition-all"
         >
           <div className="text-4xl font-black text-[#00C4EA] mb-2">4.9/5</div>
-          <p className="text-sm text-gray-600">Satisfaction moyenne</p>
+          <p className="text-sm text-gray-600">{t("stats.satisfaction")}</p>
         </motion.div>
         <motion.div
           initial={{ opacity: 0, scale: 0.95 }}
@@ -197,7 +197,7 @@ export default function RecruiterContactPage() {
           className="text-center p-6 bg-white rounded-xl border-2 border-[#00D9FF]/20 hover:border-[#00D9FF] hover:shadow-lg transition-all"
         >
           <div className="text-4xl font-black text-[#00D9FF] mb-2">48h</div>
-          <p className="text-sm text-gray-600">Délai moyen</p>
+          <p className="text-sm text-gray-600">{t("stats.delay")}</p>
         </motion.div>
       </motion.div>
 
@@ -206,23 +206,20 @@ export default function RecruiterContactPage() {
         {[
           {
             icon: CheckCircle2,
-            title: "Conseils personnalisés",
-            description:
-              "Un recruteur expert analyse votre profil et vous donne des recommandations sur-mesure",
+            title: t("benefits.personalizedTitle"),
+            description: t("benefits.personalizedDesc"),
             delay: 0.7,
           },
           {
             icon: Star,
-            title: "Expertise professionnelle",
-            description:
-              "Nos recruteurs ont 10+ ans d'expérience dans le recrutement de cadres et talents",
+            title: t("benefits.expertiseTitle"),
+            description: t("benefits.expertiseDesc"),
             delay: 0.8,
           },
           {
             icon: Clock,
-            title: "Réponse rapide",
-            description:
-              "Vous serez contacté sous 48h pour planifier votre consultation de 30 minutes",
+            title: t("benefits.fastResponseTitle"),
+            description: t("benefits.fastResponseDesc"),
             delay: 0.9,
           },
         ].map((benefit, index) => (
@@ -265,40 +262,42 @@ export default function RecruiterContactPage() {
           <CardHeader className="bg-gradient-to-br from-[#00D9FF] to-[#00C4EA] text-white">
             <CardTitle className="text-2xl flex items-center gap-2">
               <Sparkles className="w-6 h-6" />
-              Consultation Recruteur
+              {t("pricing.title")}
             </CardTitle>
             <CardDescription className="text-white/90 text-lg">
-              Session individuelle de 30 minutes
+              {t("pricing.sessionDesc")}
             </CardDescription>
           </CardHeader>
           <CardContent className="pt-6">
             <div className="mb-6">
               <div className="flex items-baseline gap-2 mb-2">
                 <span className="text-5xl font-bold text-black">50€</span>
-                <span className="text-gray-600">/ consultation</span>
+                <span className="text-gray-600">
+                  {t("pricing.perConsultation")}
+                </span>
               </div>
               <p className="text-sm text-gray-600">
-                Paiement unique, aucun abonnement
+                {t("pricing.noSubscription")}
               </p>
             </div>
 
             <div className="space-y-4">
               {[
                 {
-                  title: "Session vidéo de 30 minutes",
-                  description: "Échange en direct avec un expert",
+                  title: t("pricing.item1Title"),
+                  description: t("pricing.item1Desc"),
                 },
                 {
-                  title: "Analyse personnalisée",
-                  description: "CV, profil LinkedIn, stratégie de recherche",
+                  title: t("pricing.item2Title"),
+                  description: t("pricing.item2Desc"),
                 },
                 {
-                  title: "Plan d'action concret",
-                  description: "Recommandations actionnables immédiatement",
+                  title: t("pricing.item3Title"),
+                  description: t("pricing.item3Desc"),
                 },
                 {
-                  title: "Compte-rendu écrit",
-                  description: "Résumé détaillé après la consultation",
+                  title: t("pricing.item4Title"),
+                  description: t("pricing.item4Desc"),
                 },
               ].map((item, index) => (
                 <motion.div
@@ -320,7 +319,7 @@ export default function RecruiterContactPage() {
             <div className="mt-6 pt-6 border-t">
               <div className="flex items-center gap-2 text-sm text-gray-600">
                 <Shield className="w-4 h-4" />
-                <span>Paiement sécurisé par Stripe</span>
+                <span>{t("pricing.securePay")}</span>
               </div>
             </div>
           </CardContent>
@@ -329,19 +328,14 @@ export default function RecruiterContactPage() {
         {/* Request Form */}
         <Card className="border-2 border-gray-200 h-fit">
           <CardHeader>
-            <CardTitle className="text-black">
-              Réserver ma consultation
-            </CardTitle>
-            <CardDescription>
-              Remplissez le formulaire pour être contacté par un recruteur
-              expert
-            </CardDescription>
+            <CardTitle className="text-black">{t("form.title")}</CardTitle>
+            <CardDescription>{t("form.desc")}</CardDescription>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid gap-4">
                 <div>
-                  <Label htmlFor="fullName">Nom complet *</Label>
+                  <Label htmlFor="fullName">{t("form.fullName")}</Label>
                   <Input
                     id="fullName"
                     placeholder="Jean Dupont"
@@ -360,7 +354,7 @@ export default function RecruiterContactPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="email">Email *</Label>
+                  <Label htmlFor="email">{t("form.email")}</Label>
                   <div className="relative">
                     <Mail className="absolute left-3 top-3 w-4 h-4 text-slate-400" />
                     <Input
@@ -381,7 +375,7 @@ export default function RecruiterContactPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="phone">Téléphone</Label>
+                  <Label htmlFor="phone">{t("form.phone")}</Label>
                   <div className="relative">
                     <Phone className="absolute left-3 top-3 w-4 h-4 text-slate-400" />
                     <Input
@@ -401,7 +395,7 @@ export default function RecruiterContactPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="sector">Secteur d'activité *</Label>
+                  <Label htmlFor="sector">{t("form.sector")}</Label>
                   <Select
                     value={formData.sector}
                     onValueChange={(value) => {
@@ -415,20 +409,34 @@ export default function RecruiterContactPage() {
                       className={`${touched.sector && errors.sector ? "border-red-500 focus:border-red-500 focus:ring-red-500" : ""}`}
                       aria-invalid={touched.sector && !!errors.sector}
                     >
-                      <SelectValue placeholder="Sélectionnez votre secteur" />
+                      <SelectValue placeholder={t("form.sectorPlaceholder")} />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="tech">Tech / IT</SelectItem>
-                      <SelectItem value="finance">Finance / Banque</SelectItem>
-                      <SelectItem value="marketing">
-                        Marketing / Communication
+                      <SelectItem value="tech">
+                        {t("form.sectors.tech")}
                       </SelectItem>
-                      <SelectItem value="sales">Vente / Commercial</SelectItem>
-                      <SelectItem value="hr">RH / Recrutement</SelectItem>
-                      <SelectItem value="engineering">Ingénierie</SelectItem>
-                      <SelectItem value="healthcare">Santé</SelectItem>
-                      <SelectItem value="education">Éducation</SelectItem>
-                      <SelectItem value="other">Autre</SelectItem>
+                      <SelectItem value="finance">
+                        {t("form.sectors.finance")}
+                      </SelectItem>
+                      <SelectItem value="marketing">
+                        {t("form.sectors.marketing")}
+                      </SelectItem>
+                      <SelectItem value="sales">
+                        {t("form.sectors.sales")}
+                      </SelectItem>
+                      <SelectItem value="hr">{t("form.sectors.hr")}</SelectItem>
+                      <SelectItem value="engineering">
+                        {t("form.sectors.engineering")}
+                      </SelectItem>
+                      <SelectItem value="healthcare">
+                        {t("form.sectors.healthcare")}
+                      </SelectItem>
+                      <SelectItem value="education">
+                        {t("form.sectors.education")}
+                      </SelectItem>
+                      <SelectItem value="other">
+                        {t("form.sectors.other")}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                   {touched.sector && errors.sector && (
@@ -437,7 +445,9 @@ export default function RecruiterContactPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="experienceLevel">Niveau d'expérience *</Label>
+                  <Label htmlFor="experienceLevel">
+                    {t("form.experienceLevel")}
+                  </Label>
                   <Select
                     value={formData.experienceLevel}
                     onValueChange={(value) => {
@@ -453,18 +463,28 @@ export default function RecruiterContactPage() {
                         touched.experienceLevel && !!errors.experienceLevel
                       }
                     >
-                      <SelectValue placeholder="Sélectionnez votre niveau" />
+                      <SelectValue
+                        placeholder={t("form.experiencePlaceholder")}
+                      />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="junior">Junior (0-3 ans)</SelectItem>
-                      <SelectItem value="confirmed">
-                        Confirmé (3-7 ans)
+                      <SelectItem value="junior">
+                        {t("form.levels.junior")}
                       </SelectItem>
-                      <SelectItem value="senior">Senior (7-12 ans)</SelectItem>
-                      <SelectItem value="expert">Expert (12+ ans)</SelectItem>
-                      <SelectItem value="manager">Manager / Lead</SelectItem>
+                      <SelectItem value="confirmed">
+                        {t("form.levels.confirmed")}
+                      </SelectItem>
+                      <SelectItem value="senior">
+                        {t("form.levels.senior")}
+                      </SelectItem>
+                      <SelectItem value="expert">
+                        {t("form.levels.expert")}
+                      </SelectItem>
+                      <SelectItem value="manager">
+                        {t("form.levels.manager")}
+                      </SelectItem>
                       <SelectItem value="executive">
-                        Executive / C-level
+                        {t("form.levels.executive")}
                       </SelectItem>
                     </SelectContent>
                   </Select>
@@ -477,7 +497,7 @@ export default function RecruiterContactPage() {
 
                 <div>
                   <Label htmlFor="preferredDate">
-                    Date préférée (optionnel)
+                    {t("form.preferredDate")}
                   </Label>
                   <div className="relative">
                     <Calendar className="absolute left-3 top-3 w-4 h-4 text-gray-400" />
@@ -495,10 +515,10 @@ export default function RecruiterContactPage() {
                 </div>
 
                 <div>
-                  <Label htmlFor="message">Message / Questions *</Label>
+                  <Label htmlFor="message">{t("form.message")}</Label>
                   <Textarea
                     id="message"
-                    placeholder="Décrivez brièvement votre situation et vos objectifs professionnels..."
+                    placeholder={t("form.messagePlaceholder")}
                     rows={4}
                     value={formData.message}
                     onChange={(e) => handleChange("message", e.target.value)}
@@ -523,19 +543,18 @@ export default function RecruiterContactPage() {
                 {isSubmitting ? (
                   <div className="flex items-center gap-2">
                     <Loader2 className="w-5 h-5 animate-spin" />
-                    <span>Traitement en cours...</span>
+                    <span>{t("form.submitting")}</span>
                   </div>
                 ) : (
                   <>
-                    Réserver ma consultation (50€)
+                    {t("form.submit")}
                     <ArrowRight className="w-5 h-5 ml-2" />
                   </>
                 )}
               </Button>
 
               <p className="text-xs text-gray-500 text-center">
-                Après validation, vous serez redirigé vers le paiement sécurisé
-                Stripe
+                {t("form.submitNote")}
               </p>
             </form>
           </CardContent>
@@ -552,12 +571,8 @@ export default function RecruiterContactPage() {
         transition={{ delay: 1.2 }}
         className="bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] text-white p-12 rounded-3xl text-center mt-12 shadow-xl"
       >
-        <h3 className="text-3xl font-bold mb-4">
-          Prêt à booster votre carrière ?
-        </h3>
-        <p className="text-xl text-white/90 mb-6">
-          👥 <strong>5 consultations</strong> réservées cette semaine
-        </p>
+        <h3 className="text-3xl font-bold mb-4">{t("cta.title")}</h3>
+        <p className="text-xl text-white/90 mb-6">{t("cta.spots")}</p>
         <Button
           size="lg"
           className="h-14 px-12 bg-white text-[#00D9FF] hover:bg-gray-100 font-bold transition-all duration-300 hover:scale-105"
@@ -566,7 +581,7 @@ export default function RecruiterContactPage() {
             formSection?.scrollIntoView({ behavior: "smooth", block: "start" });
           }}
         >
-          Réserver maintenant (50€)
+          {t("cta.button")}
         </Button>
       </motion.div>
     </div>

--- a/frontend-next/src/app/(dashboard)/salons/page.tsx
+++ b/frontend-next/src/app/(dashboard)/salons/page.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 import DOMPurify from "dompurify";
 import { FeaturedEventsCarousel } from "@/components/salons/featured-events-carousel";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { useTranslations } from "next-intl";
 
 // Fonction pour nettoyer le HTML et extraire le texte brut
 function stripHtml(html: string): string {
@@ -49,6 +50,7 @@ function stripHtml(html: string): string {
 }
 
 export default function SalonsPage() {
+  const t = useTranslations("dashboard.salons");
   const [events, setEvents] = useState<JobFair[]>([]);
   const [visibleEventsCount, setVisibleEventsCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -173,9 +175,7 @@ export default function SalonsPage() {
             >
               <Calendar className="w-7 h-7 text-white" />
             </motion.div>
-            <h1 className="text-4xl font-black text-black">
-              Salons & Forums Emploi
-            </h1>
+            <h1 className="text-4xl font-black text-black">{t("title")}</h1>
           </div>
           <p className="text-base text-slate-700 leading-relaxed max-w-3xl">
             Découvrez les événements emploi près de chez vous et rencontrez des

--- a/frontend-next/src/app/(dashboard)/saved-jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/saved-jobs/page.tsx
@@ -17,6 +17,7 @@ import { useOptionalAuth } from "@/contexts/auth-context";
 import { createClient } from "@/lib/supabase/client";
 import { toast } from "sonner";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useTranslations } from "next-intl";
 
 interface SavedJob {
   id: string;
@@ -32,6 +33,7 @@ interface SavedJob {
 export default function SavedJobsPage() {
   const auth = useOptionalAuth();
   const user = auth?.user;
+  const t = useTranslations("dashboard.savedJobs");
 
   const [savedJobs, setSavedJobs] = useState<SavedJob[]>([]);
   const [loading, setLoading] = useState(true);
@@ -81,10 +83,10 @@ export default function SavedJobsPage() {
       if (error) throw error;
 
       setSavedJobs((prev) => prev.filter((job) => job.id !== jobId));
-      toast.success("Offre retirée des favoris");
+      toast.success(t("deleted"));
     } catch (error) {
       console.error("Failed to remove saved job:", error);
-      toast.error("Erreur lors de la suppression");
+      toast.error(t("deleteError"));
     }
   };
 
@@ -113,17 +115,14 @@ export default function SavedJobsPage() {
             <Bookmark className="w-10 h-10 text-[#00D9FF]" />
           </motion.div>
           <h2 className="text-2xl font-bold text-black">
-            Connectez-vous pour sauvegarder des offres
+            {t("loginRequired")}
           </h2>
-          <p className="text-slate-600 max-w-md mx-auto">
-            Créez un compte gratuit pour sauvegarder vos offres d'emploi
-            favorites et y accéder facilement.
-          </p>
+          <p className="text-slate-600 max-w-md mx-auto">{t("noJobsDesc")}</p>
           <Button
             onClick={() => (window.location.href = "/login")}
             className="bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:shadow-lg hover:shadow-[#00D9FF]/40 text-white transition-all duration-300"
           >
-            Se connecter
+            {t("searchJobs")}
           </Button>
         </motion.div>
       </div>
@@ -148,10 +147,10 @@ export default function SavedJobsPage() {
           >
             <Bookmark className="w-7 h-7 text-white" />
           </motion.div>
-          <h1 className="text-4xl font-black text-black">Jobs Sauvegardés</h1>
+          <h1 className="text-4xl font-black text-black">{t("title")}</h1>
         </div>
         <p className="text-base text-slate-700 leading-relaxed">
-          Retrouvez toutes vos offres d'emploi favorites en un seul endroit
+          {t("noJobsDesc")}
         </p>
         {!loading && (
           <motion.p
@@ -177,7 +176,7 @@ export default function SavedJobsPage() {
           <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
           <Input
             type="text"
-            placeholder="Rechercher dans mes favoris..."
+            placeholder={t("searchPlaceholder")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-12 text-base border-slate-300 focus:border-[#00D9FF] focus:ring-[#00D9FF]"
@@ -225,27 +224,22 @@ export default function SavedJobsPage() {
             {searchQuery ? (
               <>
                 <h3 className="text-xl font-bold text-black mb-2">
-                  Aucun résultat trouvé
+                  {t("noJobs")}
                 </h3>
-                <p className="text-slate-600 mb-4">
-                  Essayez de modifier votre recherche
-                </p>
+                <p className="text-slate-600 mb-4">{t("noJobsDesc")}</p>
               </>
             ) : (
               <>
                 <h3 className="text-xl font-bold text-black mb-2">
-                  Aucune offre sauvegardée
+                  {t("noJobs")}
                 </h3>
-                <p className="text-slate-600 mb-4">
-                  Commencez à sauvegarder vos offres favorites depuis la page de
-                  recherche
-                </p>
+                <p className="text-slate-600 mb-4">{t("noJobsDesc")}</p>
                 <Button
                   onClick={() => (window.location.href = "/jobs")}
                   className="bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:shadow-lg hover:shadow-[#00D9FF]/40 text-white transition-all duration-300"
                 >
                   <Briefcase className="w-4 h-4 mr-2" />
-                  Rechercher des offres
+                  {t("searchJobs")}
                 </Button>
               </>
             )}
@@ -288,8 +282,8 @@ export default function SavedJobsPage() {
                         <div className="flex items-center gap-1.5 text-slate-400">
                           <Clock className="w-4 h-4" />
                           <span>
-                            Sauvegardé le{" "}
-                            {new Date(job.saved_at).toLocaleDateString("fr-FR")}
+                            {t("savedAt")}{" "}
+                            {new Date(job.saved_at).toLocaleDateString()}
                           </span>
                         </div>
                       </div>
@@ -310,7 +304,7 @@ export default function SavedJobsPage() {
                         className="whitespace-nowrap bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:shadow-lg hover:shadow-[#00D9FF]/40 text-white transition-all duration-300"
                       >
                         <ExternalLink className="w-4 h-4 mr-2" />
-                        Voir l'offre
+                        {t("viewOffer")}
                       </Button>
                       <Button
                         onClick={() => handleRemoveSavedJob(job.id)}
@@ -319,7 +313,7 @@ export default function SavedJobsPage() {
                         className="text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
                       >
                         <Trash2 className="w-4 h-4 mr-2" />
-                        Retirer
+                        {t("delete")}
                       </Button>
                     </div>
                   </div>

--- a/frontend-next/src/app/login/page.tsx
+++ b/frontend-next/src/app/login/page.tsx
@@ -16,6 +16,7 @@ import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, Mail, Lock as LockIcon, Eye, EyeOff } from "lucide-react";
 import { AuthLayout } from "@/components/auth/auth-layout";
+import { useTranslations } from "next-intl";
 
 // Separate component that uses useSearchParams (must be wrapped in Suspense)
 function LoginForm() {
@@ -23,6 +24,7 @@ function LoginForm() {
   const searchParams = useSearchParams();
   const { user, signInWithGoogle, signInWithEmail, error, clearError } =
     useAuth();
+  const t = useTranslations("auth.login");
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -86,7 +88,7 @@ function LoginForm() {
             transition={{ duration: 0.5 }}
             className="text-3xl font-bold text-gray-900 mb-2"
           >
-            Bon retour !
+            {t("title")}
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: -10 }}
@@ -94,7 +96,7 @@ function LoginForm() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-gray-600"
           >
-            Connectez-vous pour accéder à votre espace
+            {t("subtitle")}
           </motion.p>
         </div>
 
@@ -155,7 +157,7 @@ function LoginForm() {
                     d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
                   />
                 </svg>
-                <span className="font-medium">Continuer avec Google</span>
+                <span className="font-medium">{t("googleCta")}</span>
               </>
             )}
           </Button>
@@ -168,7 +170,7 @@ function LoginForm() {
           </div>
           <div className="relative flex justify-center text-sm">
             <span className="px-4 bg-white text-gray-500 font-medium">
-              Ou avec email
+              {t("divider")}
             </span>
           </div>
         </div>
@@ -186,14 +188,14 @@ function LoginForm() {
               htmlFor="email"
               className="text-sm font-medium text-gray-700"
             >
-              Adresse email
+              {t("emailLabel")}
             </Label>
             <div className="relative">
               <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <Input
                 id="email"
                 type="email"
-                placeholder="vous@example.com"
+                placeholder={t("emailPlaceholder")}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
@@ -209,13 +211,13 @@ function LoginForm() {
                 htmlFor="password"
                 className="text-sm font-medium text-gray-700"
               >
-                Mot de passe
+                {t("passwordLabel")}
               </Label>
               <Link
                 href="/forgot-password"
                 className="text-sm text-[#00D9FF] hover:text-[#00C4EA] font-medium transition-colors"
               >
-                Mot de passe oublié ?
+                {t("forgotPassword")}
               </Link>
             </div>
             <div className="relative">
@@ -234,7 +236,7 @@ function LoginForm() {
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                aria-label={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                aria-label={showPassword ? t("hidePassword") : t("showPassword")}
               >
                 {showPassword ? (
                   <EyeOff className="w-5 h-5" />
@@ -254,10 +256,10 @@ function LoginForm() {
             {loading ? (
               <>
                 <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                Connexion en cours...
+                {t("loading")}
               </>
             ) : (
-              "Se connecter"
+              t("cta")
             )}
           </Button>
         </motion.form>
@@ -269,12 +271,12 @@ function LoginForm() {
           transition={{ duration: 0.5, delay: 0.4 }}
           className="text-center text-sm text-gray-600"
         >
-          Pas encore de compte ?{" "}
+          {t("noAccount")}{" "}
           <Link
             href="/signup"
             className="text-[#00D9FF] hover:text-[#00C4EA] font-semibold transition-colors"
           >
-            Créer un compte gratuitement
+            {t("signupLink")}
           </Link>
         </motion.p>
 
@@ -285,19 +287,19 @@ function LoginForm() {
           transition={{ duration: 0.5, delay: 0.5 }}
           className="text-center text-xs text-gray-500 pt-4"
         >
-          En continuant, vous acceptez nos{" "}
+          {t("termsPrefix")}{" "}
           <Link
             href="/terms"
             className="underline hover:text-gray-700 transition-colors"
           >
-            Conditions d'utilisation
+            {t("terms")}
           </Link>{" "}
-          et notre{" "}
+          {t("and")}{" "}
           <Link
             href="/privacy"
             className="underline hover:text-gray-700 transition-colors"
           >
-            Politique de confidentialité
+            {t("privacy")}
           </Link>
         </motion.p>
       </div>

--- a/frontend-next/src/app/signup/page.tsx
+++ b/frontend-next/src/app/signup/page.tsx
@@ -26,12 +26,14 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { AuthLayout } from "@/components/auth/auth-layout";
+import { useTranslations } from "next-intl";
 
 function SignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, signInWithGoogle, signUpWithEmail, error, clearError } =
     useAuth();
+  const t = useTranslations("auth.signup");
 
   // Detect CV analysis redirect
   const redirectTo = searchParams.get("redirectTo");
@@ -76,13 +78,13 @@ function SignupForm() {
 
     // Validate password match
     if (password !== confirmPassword) {
-      setPasswordError("Les mots de passe ne correspondent pas");
+      setPasswordError(t("passwordMismatch"));
       return;
     }
 
     // Validate password strength
     if (password.length < 6) {
-      setPasswordError("Le mot de passe doit contenir au moins 6 caractères");
+      setPasswordError(t("passwordTooShort"));
       return;
     }
 
@@ -102,12 +104,10 @@ function SignupForm() {
     } catch (err: any) {
       console.error("[SIGNUP] Error:", err);
 
-      // Détecter timeout pour afficher message spécifique
       if (err.message?.includes("prend trop de temps") || err.message?.includes("timeout")) {
         setIsTimeout(true);
       }
     } finally {
-      // ⚠️ CRITIQUE: Toujours arrêter le loading, même en cas d'erreur
       setLoading(false);
     }
   };
@@ -149,13 +149,13 @@ function SignupForm() {
 
               {/* Title */}
               <h2 className="text-2xl font-bold text-center text-gray-900 mb-4">
-                Inscription réussie ! 🎉
+                {t("success.title")}
               </h2>
 
               {/* Message */}
               <div className="space-y-4 mb-6">
                 <p className="text-center text-gray-700 leading-relaxed">
-                  Nous venons d'envoyer un email de confirmation à :
+                  {t("success.sentEmail")}
                 </p>
                 <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
                   <p className="text-center font-semibold text-blue-900 break-all">
@@ -164,8 +164,8 @@ function SignupForm() {
                 </div>
                 <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 rounded-r-lg">
                   <p className="text-sm text-gray-700">
-                    <strong>Vérifiez votre boîte mail</strong> (et vos spams)
-                    pour confirmer votre adresse email avant de vous connecter.
+                    <strong>{t("success.checkEmail")}</strong>{" "}
+                    {t("success.checkEmailDesc")}
                   </p>
                 </div>
               </div>
@@ -174,7 +174,7 @@ function SignupForm() {
               <div className="space-y-3">
                 <Link href="/login" className="block">
                   <Button className="w-full bg-[#00D9FF] hover:bg-[#00C4EA] text-white h-12 rounded-xl font-semibold">
-                    Aller à la connexion
+                    {t("success.goToLogin")}
                   </Button>
                 </Link>
                 <Button
@@ -182,14 +182,13 @@ function SignupForm() {
                   onClick={closeSuccessModal}
                   className="w-full h-12 rounded-xl border-2"
                 >
-                  Fermer
+                  {t("success.close")}
                 </Button>
               </div>
 
               {/* Help text */}
               <p className="text-xs text-center text-gray-500 mt-4">
-                Vous n'avez pas reçu l'email ? Attendez quelques minutes ou
-                vérifiez vos spams.
+                {t("success.noEmail")}
               </p>
             </motion.div>
           </motion.div>
@@ -205,7 +204,7 @@ function SignupForm() {
             transition={{ duration: 0.5 }}
             className="text-3xl font-bold text-gray-900 mb-2"
           >
-            Créer votre compte
+            {t("title")}
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: -10 }}
@@ -213,9 +212,7 @@ function SignupForm() {
             transition={{ duration: 0.5, delay: 0.1 }}
             className="text-gray-600"
           >
-            {showCVMessage
-              ? "Commencez votre analyse CV gratuitement"
-              : "Rejoignez HuntZen et boostez votre carrière"}
+            {showCVMessage ? t("subtitleCV") : t("subtitle")}
           </motion.p>
         </div>
 
@@ -229,31 +226,31 @@ function SignupForm() {
           >
             <h3 className="font-bold text-gray-900 mb-3 flex items-center gap-2">
               <span className="text-xl">🎯</span>
-              Offre de bienvenue :
+              {t("cvBanner.title")}
             </h3>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span>
-                  <strong>1 analyse CV gratuite</strong> par jour
+                  <strong>{t("cvBanner.feature1")}</strong>
                 </span>
               </div>
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span>
-                  <strong>Score ATS détaillé</strong>
+                  <strong>{t("cvBanner.feature2")}</strong>
                 </span>
               </div>
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span>
-                  <strong>Matching emploi</strong>
+                  <strong>{t("cvBanner.feature3")}</strong>
                 </span>
               </div>
               <div className="flex items-center gap-2 text-sm">
                 <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span>
-                  <strong>Historique</strong> complet
+                  <strong>{t("cvBanner.feature4")}</strong>
                 </span>
               </div>
             </div>
@@ -292,9 +289,9 @@ function SignupForm() {
             <Alert variant="destructive" className="border-orange-200 bg-orange-50">
               <AlertCircle className="h-4 w-4 text-orange-600" />
               <AlertDescription className="text-orange-800">
-                <strong>Connexion lente détectée</strong>
+                <strong>{t("timeout.title")}</strong>
                 <br />
-                La requête a pris trop de temps. Vérifiez votre connexion internet et réessayez dans quelques instants.
+                {t("timeout.description")}
               </AlertDescription>
             </Alert>
           </motion.div>
@@ -334,7 +331,7 @@ function SignupForm() {
                     d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
                   />
                 </svg>
-                <span className="font-medium">S'inscrire avec Google</span>
+                <span className="font-medium">{t("googleCta")}</span>
               </>
             )}
           </Button>
@@ -347,7 +344,7 @@ function SignupForm() {
           </div>
           <div className="relative flex justify-center text-sm">
             <span className="px-4 bg-white text-gray-500 font-medium">
-              Ou avec email
+              {t("divider")}
             </span>
           </div>
         </div>
@@ -365,14 +362,14 @@ function SignupForm() {
               htmlFor="fullName"
               className="text-sm font-medium text-gray-700"
             >
-              Nom complet
+              {t("fullNameLabel")}
             </Label>
             <div className="relative">
               <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <Input
                 id="fullName"
                 type="text"
-                placeholder="Jean Dupont"
+                placeholder={t("fullNamePlaceholder")}
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
                 required
@@ -387,14 +384,14 @@ function SignupForm() {
               htmlFor="email"
               className="text-sm font-medium text-gray-700"
             >
-              Adresse email
+              {t("emailLabel")}
             </Label>
             <div className="relative">
               <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <Input
                 id="email"
                 type="email"
-                placeholder="vous@example.com"
+                placeholder={t("emailPlaceholder")}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
@@ -409,14 +406,14 @@ function SignupForm() {
               htmlFor="password"
               className="text-sm font-medium text-gray-700"
             >
-              Mot de passe
+              {t("passwordLabel")}
             </Label>
             <div className="relative">
               <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <Input
                 id="password"
                 type={showPassword ? "text" : "password"}
-                placeholder="Minimum 6 caractères"
+                placeholder={t("passwordPlaceholder")}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
@@ -428,7 +425,7 @@ function SignupForm() {
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                aria-label={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                aria-label={showPassword ? t("hidePassword") : t("showPassword")}
               >
                 {showPassword ? (
                   <EyeOff className="w-5 h-5" />
@@ -444,14 +441,14 @@ function SignupForm() {
               htmlFor="confirmPassword"
               className="text-sm font-medium text-gray-700"
             >
-              Confirmer le mot de passe
+              {t("confirmPasswordLabel")}
             </Label>
             <div className="relative">
               <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
               <Input
                 id="confirmPassword"
                 type={showConfirmPassword ? "text" : "password"}
-                placeholder="Retapez votre mot de passe"
+                placeholder={t("confirmPasswordPlaceholder")}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
@@ -462,7 +459,7 @@ function SignupForm() {
                 type="button"
                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                aria-label={showConfirmPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+                aria-label={showConfirmPassword ? t("hidePassword") : t("showPassword")}
               >
                 {showConfirmPassword ? (
                   <EyeOff className="w-5 h-5" />
@@ -482,10 +479,10 @@ function SignupForm() {
             {loading ? (
               <>
                 <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                Création en cours...
+                {t("loading")}
               </>
             ) : (
-              "Créer mon compte gratuitement"
+              t("cta")
             )}
           </Button>
         </motion.form>
@@ -497,12 +494,12 @@ function SignupForm() {
           transition={{ duration: 0.5, delay: 0.5 }}
           className="text-center text-sm text-gray-600"
         >
-          Vous avez déjà un compte ?{" "}
+          {t("hasAccount")}{" "}
           <Link
             href="/login"
             className="text-[#00D9FF] hover:text-[#00C4EA] font-semibold transition-colors"
           >
-            Se connecter
+            {t("loginLink")}
           </Link>
         </motion.p>
 
@@ -513,19 +510,19 @@ function SignupForm() {
           transition={{ duration: 0.5, delay: 0.6 }}
           className="text-center text-xs text-gray-500 pt-4"
         >
-          En créant un compte, vous acceptez nos{" "}
+          {t("termsPrefix")}{" "}
           <Link
             href="/terms"
             className="underline hover:text-gray-700 transition-colors"
           >
-            Conditions d'utilisation
+            {t("terms")}
           </Link>{" "}
-          et notre{" "}
+          {t("and")}{" "}
           <Link
             href="/privacy"
             className="underline hover:text-gray-700 transition-colors"
           >
-            Politique de confidentialité
+            {t("privacy")}
           </Link>
         </motion.p>
       </div>

--- a/frontend-next/src/components/landing-header.tsx
+++ b/frontend-next/src/components/landing-header.tsx
@@ -247,7 +247,7 @@ export function LandingHeader({ forceWhite = false }: LandingHeaderProps) {
         {/* Auth Buttons */}
         <div className="flex items-center gap-2 sm:gap-3">
           {/* Language Switcher */}
-          <LanguageSwitcher />
+          <LanguageSwitcher className={shouldBeWhite ? "text-gray-900 hover:text-black" : "text-white hover:text-white"} />
 
           {/* Theme Toggle */}
           <ThemeToggle />

--- a/frontend-next/src/components/language-switcher.tsx
+++ b/frontend-next/src/components/language-switcher.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Globe } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 /**
  * Language Switcher Component
@@ -24,7 +25,7 @@ import { Globe } from "lucide-react";
  * @example
  * <LanguageSwitcher />
  */
-export function LanguageSwitcher() {
+export function LanguageSwitcher({ className }: { className?: string }) {
   const { locale, setLocale, supportedLocales } = useLocale();
 
   return (
@@ -33,7 +34,7 @@ export function LanguageSwitcher() {
         <Button
           variant="ghost"
           size="sm"
-          className="gap-2"
+          className={cn("gap-2", className)}
           aria-label="Change language"
         >
           <Globe className="h-4 w-4" />

--- a/frontend-next/src/components/layout/sidebar.tsx
+++ b/frontend-next/src/components/layout/sidebar.tsx
@@ -33,6 +33,7 @@ import { useOptionalAuth } from "@/contexts/auth-context";
 import { UsageSummary } from "@/components/freemium/usage-counter";
 import { UsageModal } from "@/components/freemium/usage-modal";
 import { useTranslations } from "next-intl";
+import { LanguageSwitcherCompact } from "@/components/language-switcher";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -351,6 +352,11 @@ export function Sidebar({ className }: SidebarProps) {
 
       {/* Footer Navigation */}
       <div className="sidebar-footer px-4 py-3 border-t border-white/10">
+        {/* Language switcher */}
+        <div className="px-2 py-2 mb-1">
+          <LanguageSwitcherCompact />
+        </div>
+
         <Link
           href="/pricing"
           className="nav-item nav-item-secondary flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium text-white/60 hover:bg-white/8 hover:text-white transition-all group focus-visible:ring-2 focus-visible:ring-[#00D9FF] focus-visible:ring-offset-2 focus-visible:outline-none"


### PR DESCRIPTION
## Summary

- **Language switcher in sidebar**: Added `LanguageSwitcherCompact` to the sidebar footer so users can change language from within the dashboard
- **Landing header scroll fix**: Language switcher text now turns dark when scrolling (matches all other nav items) — fixed by adding `className` prop to `LanguageSwitcher` with conditional color based on `shouldBeWhite`
- **Login & Signup pages**: Fully translated with `useTranslations("auth.login")` and `useTranslations("auth.signup")` — all form fields, error messages, Google CTA, success modal, timeout notice
- **Dashboard pages translated**:
  - `jobs/page.tsx` — form labels, placeholders, contract type, results count, toast messages, job cards, empty state
  - `cv-analysis/page.tsx` — title, loading state, error boundary fallback
  - `assistant/page.tsx` — history/new/simulation buttons, time warning banner, expired state, textarea placeholder
  - `salons/page.tsx` — page title
  - `saved-jobs/page.tsx` — all UI strings, search, delete actions, toast messages
  - `recruiter-contact/page.tsx` — validation errors, stats, benefits, pricing card, form labels/placeholders/selects, CTA

## Translation keys added

280+ new keys across all 4 locales (FR/EN/ES/PT):
- `auth.login.*` — 17 keys
- `auth.signup.*` — 25+ keys (including nested cvBanner, success, timeout)
- `dashboard.jobs.*` — 50+ keys (form, error, corrected, results, card, empty, toast)
- `dashboard.cvAnalysis.*` — 5 keys
- `dashboard.assistant.*` — 11 keys
- `dashboard.salons.*` — 1 key
- `dashboard.savedJobs.*` — 10 keys
- `dashboard.recruiterContact.*` — 40+ keys (stats, benefits, pricing, form with sectors/levels, validation, cta)

## Test plan

- [ ] Switch language to EN/ES/PT — verify login and signup pages translate correctly
- [ ] Verify sidebar shows language switcher and it works from within dashboard
- [ ] Scroll landing page — verify language switcher text turns dark like other nav items
- [ ] Test jobs search page in each language — form labels, placeholders, results
- [ ] Test assistant page timer warning and time-expired state in each language
- [ ] Test recruiter contact form validation errors in each language
- [ ] Verify no missing translation keys (no `[key]` fallback text visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)