### PR TITLE
feat(i18n): DeepL auto-translation for job listings + sync script

### DIFF
--- a/frontend-next/package.json
+++ b/frontend-next/package.json
@@ -10,7 +10,8 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "sync-translations": "node ../scripts/sync-translations.mjs"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
+import { useJobTranslation } from "@/hooks/use-job-translation";
 import { createClient } from "@/lib/supabase/client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
@@ -75,6 +76,7 @@ export default function JobsPage() {
   const [selectedCity, setSelectedCity] = useState("");
   const [contractType, setContractType] = useState("");
   const [jobs, setJobs] = useState<Job[]>([]);
+  const { translatedJobs, isTranslating } = useJobTranslation(jobs);
   const [visibleJobsCount, setVisibleJobsCount] = useState(0);
   const [correctedQuery, setCorrectedQuery] = useState<string | null>(null);
   const [selectedJob, setSelectedJob] = useState<Job | null>(null);
@@ -650,7 +652,8 @@ export default function JobsPage() {
 
   // Split jobs into visible and blurred
   // Progressive reveal: only show jobs up to visibleJobsCount
-  const progressiveJobs = jobs.slice(0, visibleJobsCount);
+  // Use translatedJobs for display (auto-translated when locale ≠ fr)
+  const progressiveJobs = translatedJobs.slice(0, visibleJobsCount);
   const visibleJobs = progressiveJobs.slice(0, jobsVisibleLimit);
   const blurredJobsCount = Math.max(0, jobs.length - jobsVisibleLimit);
   const showBlurredCards = isFreePlan && blurredJobsCount > 0;

--- a/frontend-next/src/hooks/use-job-translation.ts
+++ b/frontend-next/src/hooks/use-job-translation.ts
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * useJobTranslation
+ *
+ * Auto-translates job listings (title + description) when the user's locale
+ * is not French. Uses the /api/translate endpoint which leverages DeepL with
+ * Translation Memory caching (Supabase → DeepL → MyMemory fallback).
+ *
+ * Fields translated: title, description
+ * Fields kept as-is: company, location, salary, url, source (proper nouns / metadata)
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { useLocale } from "next-intl";
+import type { Job } from "@/lib/api/huntzen-client";
+
+interface UseJobTranslationResult {
+  translatedJobs: Job[];
+  isTranslating: boolean;
+}
+
+export function useJobTranslation(jobs: Job[]): UseJobTranslationResult {
+  const locale = useLocale();
+  const [translatedJobs, setTranslatedJobs] = useState<Job[]>(jobs);
+  const [isTranslating, setIsTranslating] = useState(false);
+
+  // Track which job IDs have already been translated to avoid re-translating
+  // identical result sets (e.g. when parent re-renders without jobs changing)
+  const translatedCacheRef = useRef<Map<string, { title: string; description: string }>>(
+    new Map()
+  );
+
+  useEffect(() => {
+    // No translation needed for French (source language)
+    if (locale === "fr" || jobs.length === 0) {
+      setTranslatedJobs(jobs);
+      return;
+    }
+
+    // Check which jobs still need translation
+    const jobsToTranslate = jobs.filter(
+      (job) => !translatedCacheRef.current.has(job.id)
+    );
+
+    // If all jobs are cached, apply cache immediately without API call
+    if (jobsToTranslate.length === 0) {
+      setTranslatedJobs(
+        jobs.map((job) => {
+          const cached = translatedCacheRef.current.get(job.id);
+          return cached ? { ...job, title: cached.title, description: cached.description } : job;
+        })
+      );
+      return;
+    }
+
+    let cancelled = false;
+
+    const translate = async () => {
+      setIsTranslating(true);
+
+      try {
+        // Build a flat array: [title1, desc1, title2, desc2, ...]
+        // This lets us send a single batch request for all fields
+        const texts: string[] = [];
+        for (const job of jobsToTranslate) {
+          texts.push(job.title || "");
+          texts.push(job.description || "");
+        }
+
+        const response = await fetch("/api/translate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: texts,
+            targetLang: locale, // 'en' | 'es' | 'pt'
+            sourceLang: "fr",
+          }),
+        });
+
+        if (!response.ok || cancelled) return;
+
+        const data = await response.json();
+        const translated: string[] = data.translated;
+
+        // Map translated strings back to jobs
+        // [title1, desc1, title2, desc2, ...] → job objects
+        for (let i = 0; i < jobsToTranslate.length; i++) {
+          const job = jobsToTranslate[i];
+          translatedCacheRef.current.set(job.id, {
+            title: translated[i * 2] ?? job.title,
+            description: translated[i * 2 + 1] ?? job.description,
+          });
+        }
+
+        if (!cancelled) {
+          // Merge cache with original jobs (preserve all other fields)
+          setTranslatedJobs(
+            jobs.map((job) => {
+              const cached = translatedCacheRef.current.get(job.id);
+              return cached
+                ? { ...job, title: cached.title, description: cached.description }
+                : job;
+            })
+          );
+        }
+      } catch (err) {
+        // Non-critical: on failure, show original French content
+        console.warn("[useJobTranslation] Translation failed, using originals:", err);
+        if (!cancelled) {
+          setTranslatedJobs(jobs);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsTranslating(false);
+        }
+      }
+    };
+
+    translate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [jobs, locale]);
+
+  return { translatedJobs, isTranslating };
+}

--- a/scripts/sync-translations.mjs
+++ b/scripts/sync-translations.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * sync-translations.mjs
+ *
+ * Reads fr.json (source of truth), finds missing keys in en/es/pt JSON files,
+ * calls DeepL API (with MyMemory fallback) to translate them, then writes back.
+ *
+ * Usage (from project root):
+ *   DEEPL_API_KEY=your-key node scripts/sync-translations.mjs
+ *
+ * Usage (from frontend-next/):
+ *   npm run sync-translations
+ *
+ * Without DEEPL_API_KEY: falls back to MyMemory (free, 1000 words/day)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const MESSAGES_DIR = join(__dirname, "../frontend-next/messages");
+const TARGET_LOCALES = ["en", "es", "pt"];
+
+const DEEPL_LANG_MAP = {
+  en: "EN-GB",
+  es: "ES",
+  pt: "PT-BR",
+};
+
+const ISO_LANG_MAP = {
+  en: "en",
+  es: "es",
+  pt: "pt",
+};
+
+// ============================================================================
+// Helpers: flatten / unflatten nested JSON
+// ============================================================================
+
+function flatten(obj, prefix = "") {
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+      Object.assign(result, flatten(value, fullKey));
+    } else {
+      result[fullKey] = value;
+    }
+  }
+  return result;
+}
+
+function setNested(obj, path, value) {
+  const keys = path.split(".");
+  let current = obj;
+  for (let i = 0; i < keys.length - 1; i++) {
+    if (!(keys[i] in current) || typeof current[keys[i]] !== "object") {
+      current[keys[i]] = {};
+    }
+    current = current[keys[i]];
+  }
+  current[keys[keys.length - 1]] = value;
+}
+
+// ============================================================================
+// DeepL API
+// ============================================================================
+
+async function translateBatchDeepL(texts, targetLang) {
+  const apiKey = process.env.DEEPL_API_KEY;
+  if (!apiKey) throw new Error("DEEPL_API_KEY not set");
+
+  const response = await fetch("https://api-free.deepl.com/v2/translate", {
+    method: "POST",
+    headers: {
+      Authorization: `DeepL-Auth-Key ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      text: texts,
+      target_lang: DEEPL_LANG_MAP[targetLang],
+      source_lang: "FR",
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`DeepL ${response.status}: ${body}`);
+  }
+
+  const data = await response.json();
+  return data.translations.map((t) => t.text);
+}
+
+// ============================================================================
+// MyMemory API (free fallback, no key needed)
+// ============================================================================
+
+async function translateMyMemory(text, targetLang) {
+  const langPair = `fr|${ISO_LANG_MAP[targetLang]}`;
+  const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text)}&langpair=${langPair}`;
+
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`MyMemory ${response.status}`);
+
+  const data = await response.json();
+  if (data.responseStatus !== 200) {
+    throw new Error(`MyMemory: ${data.responseDetails}`);
+  }
+
+  return data.responseData.translatedText;
+}
+
+async function translateBatchMyMemory(texts, targetLang) {
+  const results = [];
+  for (let i = 0; i < texts.length; i++) {
+    try {
+      const translated = await translateMyMemory(texts[i], targetLang);
+      results.push(translated);
+      process.stdout.write(
+        `\r  MyMemory: ${i + 1}/${texts.length} strings...`
+      );
+      // Rate-limit: 200ms between requests to avoid 429
+      if (i < texts.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    } catch (err) {
+      console.warn(`\n  ⚠ MyMemory failed for string ${i + 1}: ${err.message}`);
+      results.push(texts[i]); // Keep original as last resort
+    }
+  }
+  process.stdout.write("\n");
+  return results;
+}
+
+// ============================================================================
+// Translate batch with DeepL → MyMemory fallback
+// ============================================================================
+
+async function translateBatch(texts, targetLang) {
+  if (texts.length === 0) return [];
+
+  // Try DeepL first (batch, fast)
+  if (process.env.DEEPL_API_KEY) {
+    try {
+      const results = await translateBatchDeepL(texts, targetLang);
+      console.log(`  ✓ DeepL translated ${texts.length} strings`);
+      return results;
+    } catch (err) {
+      console.warn(`  ⚠ DeepL failed: ${err.message}`);
+      console.warn("  → Falling back to MyMemory...");
+    }
+  } else {
+    console.warn("  ⚠ No DEEPL_API_KEY — using MyMemory fallback");
+  }
+
+  // Fallback: MyMemory (sequential, rate-limited)
+  return translateBatchMyMemory(texts, targetLang);
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  console.log("🔄 sync-translations.mjs — Syncing missing i18n keys\n");
+  console.log(`📁 Messages directory: ${MESSAGES_DIR}\n`);
+
+  if (!existsSync(MESSAGES_DIR)) {
+    console.error(`❌ Messages directory not found: ${MESSAGES_DIR}`);
+    process.exit(1);
+  }
+
+  // Load source of truth (fr.json)
+  const frPath = join(MESSAGES_DIR, "fr.json");
+  if (!existsSync(frPath)) {
+    console.error(`❌ fr.json not found: ${frPath}`);
+    process.exit(1);
+  }
+
+  const frJson = JSON.parse(readFileSync(frPath, "utf8"));
+  const frFlat = flatten(frJson);
+  const totalKeys = Object.keys(frFlat).length;
+  console.log(`📖 Source fr.json: ${totalKeys} keys\n`);
+
+  let totalTranslated = 0;
+
+  for (const locale of TARGET_LOCALES) {
+    const targetPath = join(MESSAGES_DIR, `${locale}.json`);
+
+    // Load target locale (or start from empty if missing)
+    let targetJson = {};
+    if (existsSync(targetPath)) {
+      targetJson = JSON.parse(readFileSync(targetPath, "utf8"));
+    } else {
+      console.warn(`  ⚠ ${locale}.json not found — will create from scratch`);
+    }
+
+    const targetFlat = flatten(targetJson);
+
+    // Find missing keys (keys in fr.json but not in target)
+    const missingKeys = Object.keys(frFlat).filter(
+      (key) => !(key in targetFlat) && typeof frFlat[key] === "string"
+    );
+
+    if (missingKeys.length === 0) {
+      console.log(`✅ ${locale}.json — All ${totalKeys} keys present, nothing to do\n`);
+      continue;
+    }
+
+    console.log(
+      `🌍 ${locale}.json — ${missingKeys.length} missing keys out of ${totalKeys}:`
+    );
+
+    const textsToTranslate = missingKeys.map((key) => frFlat[key]);
+
+    // Translate in batches of 50 (DeepL max per request)
+    const BATCH_SIZE = 50;
+    const allTranslated = [];
+
+    for (let i = 0; i < textsToTranslate.length; i += BATCH_SIZE) {
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const totalBatches = Math.ceil(textsToTranslate.length / BATCH_SIZE);
+      const batch = textsToTranslate.slice(i, i + BATCH_SIZE);
+      console.log(
+        `  Batch ${batchNum}/${totalBatches} (${batch.length} strings)...`
+      );
+      const translated = await translateBatch(batch, locale);
+      allTranslated.push(...translated);
+    }
+
+    // Merge translated values into target JSON
+    for (let i = 0; i < missingKeys.length; i++) {
+      setNested(targetJson, missingKeys[i], allTranslated[i]);
+    }
+
+    // Write back with consistent formatting
+    writeFileSync(
+      targetPath,
+      JSON.stringify(targetJson, null, 2) + "\n",
+      "utf8"
+    );
+
+    totalTranslated += missingKeys.length;
+    console.log(
+      `  ✅ Wrote ${missingKeys.length} new translations to ${locale}.json\n`
+    );
+  }
+
+  if (totalTranslated > 0) {
+    console.log(`🎉 Done! Added ${totalTranslated} translations across ${TARGET_LOCALES.length} locales.\n`);
+  } else {
+    console.log("🎉 Done! All locale files are already up to date.\n");
+  }
+}
+
+main().catch((err) => {
+  console.error("❌ Fatal error:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **`scripts/sync-translations.mjs`** — CLI script that reads `fr.json` as source of truth, finds all missing keys in `en/es/pt` JSON files, and auto-fills them via DeepL API (with MyMemory as free fallback). Supports batching (50 strings/request). Run with `npm run sync-translations` from `frontend-next/`.
- **`src/hooks/use-job-translation.ts`** — React hook that batch-translates job `title` + `description` fields via `/api/translate` when the user's locale is not French. Uses an in-memory cache (per session) to avoid duplicate API calls. Silently falls back to original French content if translation fails.
- **`jobs/page.tsx`** — Integrated `useJobTranslation` hook: `progressiveJobs` now uses `translatedJobs` for display while the raw `jobs` state is preserved for quota/count logic.

## How it works

```
User locale = EN/ES/PT
  → useJobTranslation hook detects non-FR locale
  → POST /api/translate { text: [title1, desc1, title2, desc2, ...], targetLang: "en" }
  → /api/translate checks Supabase TM cache → DeepL → MyMemory fallback
  → Returns translated strings, merged back into Job objects
  → Jobs render with translated title + description
```

## Test plan

- [ ] Switch locale to EN/ES/PT via language switcher
- [ ] Search for jobs — titles and descriptions should appear in selected language
- [ ] Switch back to FR — original French content restored
- [ ] Run `DEEPL_API_KEY=xxx npm run sync-translations` — should fill missing keys in en/es/pt JSON files

🤖 Generated with [Claude Code](https://claude.com/claude-code)