### PR TITLE
fix: React #310 hooks order + canUse quota guard in JobDetailsModal

### DIFF
--- a/frontend-next/src/components/jobs/job-details-modal.tsx
+++ b/frontend-next/src/components/jobs/job-details-modal.tsx
@@ -63,7 +63,7 @@ export function JobDetailsModal({
   const [recruiterDrawerOpen, setRecruiterDrawerOpen] = React.useState(false);
 
   // All hooks must be called before any conditional return (Rules of Hooks)
-  const { openPricingModal } = useSubscription();
+  const { canUse, openPricingModal } = useSubscription();
   const { authenticatedFetch } = useAuthenticatedFetch();
   const { description: fullDescription, loading: loadingDescription } =
     useFullJobDescription(job?.url, job?.source);
@@ -365,7 +365,13 @@ export function JobDetailsModal({
                         <Button
                           size="lg"
                           className="bg-blue-600 hover:bg-blue-700 text-white font-semibold"
-                          onClick={() => setApplyModalOpen(true)}
+                          onClick={() => {
+                            if (!canUse("cv_analysis")) {
+                              openPricingModal("cv_analysis");
+                              return;
+                            }
+                            setApplyModalOpen(true);
+                          }}
                         >
                           <Sparkles className="mr-2 h-4 w-4" />
                           Générer CV + lettre adaptés

--- a/frontend-next/src/components/jobs/job-details-modal.tsx
+++ b/frontend-next/src/components/jobs/job-details-modal.tsx
@@ -62,20 +62,16 @@ export function JobDetailsModal({
   const [applyModalOpen, setApplyModalOpen] = React.useState(false);
   const [recruiterDrawerOpen, setRecruiterDrawerOpen] = React.useState(false);
 
+  // All hooks must be called before any conditional return (Rules of Hooks)
+  const { openPricingModal } = useSubscription();
+  const { authenticatedFetch } = useAuthenticatedFetch();
+  const { description: fullDescription, loading: loadingDescription } =
+    useFullJobDescription(job?.url, job?.source);
+
   if (!job) return null;
 
   // Format source for display
   const displaySource = formatJobSource(job.source);
-
-  // Get subscription context for quota checks
-  const { canUse, openPricingModal } = useSubscription();
-
-  // Get authenticated fetch function
-  const { authenticatedFetch } = useAuthenticatedFetch();
-
-  // Fetch full description when modal opens
-  const { description: fullDescription, loading: loadingDescription } =
-    useFullJobDescription(job.url, job.source);
 
   // Use full description if available, fallback to job.description
   const displayDescription = fullDescription || job.description;


### PR DESCRIPTION
## Fixes

Closes #61

## Changements

### 1. React error #310 — hooks order
Les hooks `useSubscription`, `useAuthenticatedFetch` et `useFullJobDescription` étaient appelés **après** un `if (!job) return null`, violant les Rules of Hooks.

→ Tous les hooks déplacés avant le guard conditionnel. Arguments mis à jour avec optional chaining (`job?.url`, `job?.source`).

### 2. Quota guard sur "Générer CV + lettre adaptés"
Le bouton ouvre maintenant le modal pricing si l'utilisateur a dépassé son quota `cv_analysis` au lieu d'ouvrir directement l'ApplyModal.

```tsx
onClick={() => {
  if (!canUse("cv_analysis")) {
    openPricingModal("cv_analysis");
    return;
  }
  setApplyModalOpen(true);
}}
```

## Test
- [ ] Ouvrir une offre → plus de React error #310 en console
- [ ] Avec quota cv_analysis épuisé → clic sur bouton ouvre le modal pricing
- [ ] Avec quota disponible → clic ouvre normalement l'ApplyModal