### PR TITLE
fix: eliminate false 'Session expirée' warning on page load

### DIFF
--- a/frontend-next/src/hooks/use-subscription-api.ts
+++ b/frontend-next/src/hooks/use-subscription-api.ts
@@ -1,66 +1,66 @@
-'use client'
+"use client";
 
-import { useState, useEffect, useCallback, useRef } from 'react'
-import { useAuth } from '@/contexts/auth-context'
-import { tokenRefreshService } from '@/lib/auth/token-refresh-service'
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useAuth } from "@/contexts/auth-context";
+import { tokenRefreshService } from "@/lib/auth/token-refresh-service";
 
 // Types from backend API response
 interface UserData {
-  id: string
-  email: string
-  full_name: string | null
-  avatar_url: string | null
-  created_at: string | null
+  id: string;
+  email: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  created_at: string | null;
 }
 
 interface SubscriptionData {
-  plan_name: 'free' | 'starter' | 'pro' | 'premium'
-  plan_display_name: string
-  price_monthly: number
-  status: string
-  current_period_end: string | null
+  plan_name: "free" | "starter" | "pro" | "premium";
+  plan_display_name: string;
+  price_monthly: number;
+  status: string;
+  current_period_end: string | null;
 }
 
 interface QuotaData {
-  limit: number
-  used: number
-  remaining: number
-  percentage: number
-  has_access: boolean
-  reset_at: string
+  limit: number;
+  used: number;
+  remaining: number;
+  percentage: number;
+  has_access: boolean;
+  reset_at: string;
 }
 
 interface QuotasData {
-  cv_analysis: QuotaData
-  coach: QuotaData
-  job_search: QuotaData
+  cv_analysis: QuotaData;
+  coach: QuotaData;
+  job_search: QuotaData;
 }
 
 interface ApiResponse {
-  success: boolean
-  user: UserData
-  subscription: SubscriptionData
-  quotas: QuotasData
-  error?: string
+  success: boolean;
+  user: UserData;
+  subscription: SubscriptionData;
+  quotas: QuotasData;
+  error?: string;
 }
 
 interface SubscriptionApiData {
-  user: UserData | null
-  subscription: SubscriptionData | null
-  quotas: QuotasData | null
-  isLoading: boolean
-  error: string | null
-  refetch: () => Promise<void>
-  isFromCache: boolean
+  user: UserData | null;
+  subscription: SubscriptionData | null;
+  quotas: QuotasData | null;
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+  isFromCache: boolean;
 }
 
-const CACHE_KEY = 'huntzen_subscription_cache'
-const CACHE_EXPIRY_KEY = 'huntzen_subscription_cache_expiry'
+const CACHE_KEY = "huntzen_subscription_cache";
+const CACHE_EXPIRY_KEY = "huntzen_subscription_cache_expiry";
 // Cache TTL: 5 min fallback (était 24h)
 // Invalidation principale = événements (webhooks, actions utilisateur)
 // TTL 5 min = filet de sécurité si événements ratés
-const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes (FALLBACK)
-const REFRESH_INTERVAL = 5 * 60 * 1000 // 5 minutes
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes (FALLBACK)
+const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Hook to fetch subscription data from backend API /api/auth/me
@@ -69,56 +69,59 @@ const REFRESH_INTERVAL = 5 * 60 * 1000 // 5 minutes
  * - Handles token expiration and errors
  */
 export function useSubscriptionApi(): SubscriptionApiData {
-  const { session, loading: authLoading } = useAuth()
-  const [data, setData] = useState<Omit<SubscriptionApiData, 'refetch'>>({
+  const { session, loading: authLoading } = useAuth();
+  const [data, setData] = useState<Omit<SubscriptionApiData, "refetch">>({
     user: null,
     subscription: null,
     quotas: null,
     isLoading: true,
     error: null,
     isFromCache: false,
-  })
+  });
 
   // Use ref to avoid recreating interval on every render
-  const intervalRef = useRef<NodeJS.Timeout | null>(null)
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   /**
    * Load cached data from localStorage
    */
   const loadCache = useCallback((): ApiResponse | null => {
     try {
-      const cached = localStorage.getItem(CACHE_KEY)
-      const expiry = localStorage.getItem(CACHE_EXPIRY_KEY)
+      const cached = localStorage.getItem(CACHE_KEY);
+      const expiry = localStorage.getItem(CACHE_EXPIRY_KEY);
 
-      if (!cached || !expiry) return null
+      if (!cached || !expiry) return null;
 
       // Check if cache expired
-      const expiryTime = parseInt(expiry, 10)
+      const expiryTime = parseInt(expiry, 10);
       if (Date.now() > expiryTime) {
         // Cache expired, remove it
-        localStorage.removeItem(CACHE_KEY)
-        localStorage.removeItem(CACHE_EXPIRY_KEY)
-        return null
+        localStorage.removeItem(CACHE_KEY);
+        localStorage.removeItem(CACHE_EXPIRY_KEY);
+        return null;
       }
 
-      return JSON.parse(cached)
+      return JSON.parse(cached);
     } catch (error) {
-      console.error('[SubscriptionAPI] Error loading cache:', error)
-      return null
+      console.error("[SubscriptionAPI] Error loading cache:", error);
+      return null;
     }
-  }, [])
+  }, []);
 
   /**
    * Save data to localStorage cache
    */
   const saveCache = useCallback((apiData: ApiResponse) => {
     try {
-      localStorage.setItem(CACHE_KEY, JSON.stringify(apiData))
-      localStorage.setItem(CACHE_EXPIRY_KEY, (Date.now() + CACHE_DURATION).toString())
+      localStorage.setItem(CACHE_KEY, JSON.stringify(apiData));
+      localStorage.setItem(
+        CACHE_EXPIRY_KEY,
+        (Date.now() + CACHE_DURATION).toString(),
+      );
     } catch (error) {
-      console.error('[SubscriptionAPI] Error saving cache:', error)
+      console.error("[SubscriptionAPI] Error saving cache:", error);
     }
-  }, [])
+  }, []);
 
   /**
    * Fetch subscription data from backend API
@@ -126,15 +129,20 @@ export function useSubscriptionApi(): SubscriptionApiData {
   const fetchSubscription = useCallback(async () => {
     // CRITICAL FIX: Wait for auth to finish loading before checking session
     if (authLoading) {
-      console.log('[SubscriptionAPI] Waiting for auth to finish loading...')
-      return
+      console.log("[SubscriptionAPI] Waiting for auth to finish loading...");
+      return;
     }
 
     try {
-      // If no session, try to use cache
+      // If session object exists but token is not yet available, stay in loading
+      // state — this is a brief race condition during Supabase session hydration.
+      if (session && !session.access_token) {
+        return;
+      }
+
+      // If no session at all, try to use cache
       if (!session?.access_token) {
-        console.warn('[SubscriptionAPI] No session token, using cache')
-        const cachedData = loadCache()
+        const cachedData = loadCache();
         if (cachedData) {
           setData({
             user: cachedData.user,
@@ -143,23 +151,23 @@ export function useSubscriptionApi(): SubscriptionApiData {
             isLoading: false,
             error: null,
             isFromCache: true,
-          })
+          });
         } else {
           setData({
             user: null,
             subscription: null,
             quotas: null,
             isLoading: false,
-            error: 'Session expirée - veuillez vous reconnecter',
+            error: null,
             isFromCache: false,
-          })
+          });
         }
-        return
+        return;
       }
 
       // Fetch from backend
       if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
-        throw new Error('NEXT_PUBLIC_BACKEND_URL is not configured')
+        throw new Error("NEXT_PUBLIC_BACKEND_URL is not configured");
       }
 
       const response = await fetch(
@@ -167,23 +175,27 @@ export function useSubscriptionApi(): SubscriptionApiData {
         {
           headers: {
             Authorization: `Bearer ${session.access_token}`,
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
-        }
-      )
+        },
+      );
 
       if (!response.ok) {
         // Handle 401 - Token expired, use centralized refresh service
         if (response.status === 401) {
-          console.warn('[SubscriptionAPI] Token expired (401), getting new token...')
+          console.warn(
+            "[SubscriptionAPI] Token expired (401), getting new token...",
+          );
 
-          const newToken = await tokenRefreshService.getValidToken()
+          const newToken = await tokenRefreshService.getValidToken();
 
           if (!newToken) {
             // Fallback to cache if available
-            const cachedData = loadCache()
+            const cachedData = loadCache();
             if (cachedData) {
-              console.warn('[SubscriptionAPI] Using cached data as fallback after token refresh failed')
+              console.warn(
+                "[SubscriptionAPI] Using cached data as fallback after token refresh failed",
+              );
               setData({
                 user: cachedData.user,
                 subscription: cachedData.subscription,
@@ -191,8 +203,8 @@ export function useSubscriptionApi(): SubscriptionApiData {
                 isLoading: false,
                 error: null,
                 isFromCache: true,
-              })
-              return
+              });
+              return;
             }
 
             setData({
@@ -200,13 +212,13 @@ export function useSubscriptionApi(): SubscriptionApiData {
               subscription: null,
               quotas: null,
               isLoading: false,
-              error: 'Session expirée - veuillez vous reconnecter',
+              error: "Session expirée - veuillez vous reconnecter",
               isFromCache: false,
-            })
-            return
+            });
+            return;
           }
 
-          console.log('[SubscriptionAPI] Got new token, retrying request...')
+          console.log("[SubscriptionAPI] Got new token, retrying request...");
 
           // Retry with new token
           const retryResponse = await fetch(
@@ -214,16 +226,16 @@ export function useSubscriptionApi(): SubscriptionApiData {
             {
               headers: {
                 Authorization: `Bearer ${newToken}`,
-                'Content-Type': 'application/json',
+                "Content-Type": "application/json",
               },
-            }
-          )
+            },
+          );
 
           if (retryResponse.ok) {
-            const retryData: ApiResponse = await retryResponse.json()
+            const retryData: ApiResponse = await retryResponse.json();
 
             if (retryData.success) {
-              saveCache(retryData)
+              saveCache(retryData);
               setData({
                 user: retryData.user,
                 subscription: retryData.subscription,
@@ -231,23 +243,25 @@ export function useSubscriptionApi(): SubscriptionApiData {
                 isLoading: false,
                 error: null,
                 isFromCache: false,
-              })
-              return
+              });
+              return;
             }
           }
         }
 
-        throw new Error(`Erreur ${response.status}: ${response.statusText}`)
+        throw new Error(`Erreur ${response.status}: ${response.statusText}`);
       }
 
-      const apiData: ApiResponse = await response.json()
+      const apiData: ApiResponse = await response.json();
 
       if (!apiData.success) {
-        throw new Error(apiData.error || 'Erreur lors du chargement des données')
+        throw new Error(
+          apiData.error || "Erreur lors du chargement des données",
+        );
       }
 
       // Save to cache
-      saveCache(apiData)
+      saveCache(apiData);
 
       // Update state
       setData({
@@ -257,69 +271,73 @@ export function useSubscriptionApi(): SubscriptionApiData {
         isLoading: false,
         error: null,
         isFromCache: false,
-      })
+      });
     } catch (error) {
-      console.error('[SubscriptionAPI] Fetch error:', error)
+      console.error("[SubscriptionAPI] Fetch error:", error);
 
       // Try to use cache as fallback
-      const cachedData = loadCache()
+      const cachedData = loadCache();
       if (cachedData) {
-        console.warn('[SubscriptionAPI] Using cached data as fallback')
+        console.warn("[SubscriptionAPI] Using cached data as fallback");
         setData({
           user: cachedData.user,
           subscription: cachedData.subscription,
           quotas: cachedData.quotas,
           isLoading: false,
-          error: 'Données en cache (mode hors ligne)',
+          error: "Données en cache (mode hors ligne)",
           isFromCache: true,
-        })
+        });
       } else {
         setData({
           user: null,
           subscription: null,
           quotas: null,
           isLoading: false,
-          error: error instanceof Error ? error.message : 'Erreur inconnue',
+          error: error instanceof Error ? error.message : "Erreur inconnue",
           isFromCache: false,
-        })
+        });
       }
     }
-  }, [session?.access_token, authLoading, loadCache, saveCache])
+  }, [session?.access_token, authLoading, loadCache, saveCache]);
 
   // Initial fetch and auto-refresh setup
   useEffect(() => {
     // Wait for auth to finish loading
     if (authLoading) {
-      console.log('[SubscriptionAPI] Auth still loading, waiting...')
-      return
+      console.log("[SubscriptionAPI] Auth still loading, waiting...");
+      return;
     }
 
     // Initial fetch
-    fetchSubscription()
+    fetchSubscription();
 
     // Setup auto-refresh interval (5 minutes)
     // Only if we have a session
     if (session?.access_token) {
       intervalRef.current = setInterval(() => {
-        console.log('[SubscriptionAPI] Auto-refresh triggered')
-        fetchSubscription()
-      }, REFRESH_INTERVAL)
+        console.log("[SubscriptionAPI] Auto-refresh triggered");
+        fetchSubscription();
+      }, REFRESH_INTERVAL);
     }
 
     // Cleanup interval on unmount
     return () => {
       if (intervalRef.current) {
-        clearInterval(intervalRef.current)
-        intervalRef.current = null
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
       }
-    }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authLoading, session ? 'logged-in' : 'logged-out']) // Re-run when auth finishes loading or login state changes
+  }, [
+    authLoading,
+    session ? "logged-in" : "logged-out",
+    !!session?.access_token,
+  ]); // Re-run when token becomes available after hydration
 
   return {
     ...data,
     refetch: fetchSubscription,
-  }
+  };
 }
 
 /**
@@ -338,35 +356,38 @@ export function useSubscriptionApi(): SubscriptionApiData {
  * ```
  */
 export function useSubscriptionSync() {
-  const { refetch } = useSubscriptionApi()
+  const { refetch } = useSubscriptionApi();
 
   useEffect(() => {
     const handleSubscriptionChange = () => {
-      console.log('[SubscriptionSync] Subscription changed event detected')
+      console.log("[SubscriptionSync] Subscription changed event detected");
 
       // Clear localStorage cache immediately
-      localStorage.removeItem(CACHE_KEY)
-      localStorage.removeItem(CACHE_EXPIRY_KEY)
+      localStorage.removeItem(CACHE_KEY);
+      localStorage.removeItem(CACHE_EXPIRY_KEY);
 
       // Refetch fresh data from API
-      refetch()
+      refetch();
 
-      console.log('[SubscriptionSync] Cache invalidated and refetch triggered')
-    }
+      console.log("[SubscriptionSync] Cache invalidated and refetch triggered");
+    };
 
     // Listen for custom subscription-changed event
     // Dispatched from payment/success page after Stripe webhook processes
-    window.addEventListener('subscription-changed', handleSubscriptionChange)
+    window.addEventListener("subscription-changed", handleSubscriptionChange);
 
-    console.log('[SubscriptionSync] Event listener registered')
+    console.log("[SubscriptionSync] Event listener registered");
 
     return () => {
-      window.removeEventListener('subscription-changed', handleSubscriptionChange)
-      console.log('[SubscriptionSync] Event listener removed')
-    }
-  }, [refetch])
+      window.removeEventListener(
+        "subscription-changed",
+        handleSubscriptionChange,
+      );
+      console.log("[SubscriptionSync] Event listener removed");
+    };
+  }, [refetch]);
 
   return {
     invalidateCache: refetch,
-  }
+  };
 }


### PR DESCRIPTION
## Problème

À chaque chargement de page, la console affichait :
```
[Subscription] API error: "Session expirée - veuillez vous reconnecter"
[SUBSCRIPTION] Inconsistency detected: authenticated but no subscription data
```

Alors que l'utilisateur était bien authentifié.

## Cause

Race condition lors de l'hydratation Supabase :
1. `session` object existe (`hasSession: true`)
2. Mais `session.access_token` est momentanément vide pendant que Supabase récupère le token depuis le storage
3. Le hook voyait `!session?.access_token` → loggait "Session expirée" et settait l'erreur
4. Le `useEffect` ne se relançait pas quand le token arrivait (dépendance `session ? 'logged-in' : 'logged-out'` ne change pas)

## Fix

**1. Guard race condition** — si `session` existe mais `access_token` vide → `return` (stay in loading) au lieu de setter une erreur

**2. Dépendance `useEffect`** — ajout de `!!session?.access_token` pour que l'effet se relance quand le token devient disponible

## Résultat

- Plus de warning "Session expirée" en console au chargement
- Plus de toast "Erreur de chargement de votre abonnement" intempestif
- L'API est bien appelée une fois le token disponible