### PR TITLE
fix: move useEffect before early return in job-details-modal (#310)

### DIFF
--- a/frontend-next/src/components/jobs/job-details-modal.tsx
+++ b/frontend-next/src/components/jobs/job-details-modal.tsx
@@ -68,39 +68,7 @@ export function JobDetailsModal({
   const { description: fullDescription, loading: loadingDescription } =
     useFullJobDescription(job?.url, job?.source);
 
-  if (!job) return null;
-
-  // Format source for display
-  const displaySource = formatJobSource(job.source);
-
-  // Use full description if available, fallback to job.description
-  const displayDescription = fullDescription || job.description;
-
-  // Sanitize HTML to prevent XSS
-  const sanitizedDescription = DOMPurify.sanitize(displayDescription || "", {
-    ALLOWED_TAGS: [
-      "h1",
-      "h2",
-      "h3",
-      "h4",
-      "h5",
-      "h6",
-      "p",
-      "br",
-      "strong",
-      "em",
-      "u",
-      "ul",
-      "ol",
-      "li",
-      "a",
-      "span",
-      "div",
-    ],
-    ALLOWED_ATTR: ["href", "target", "rel", "class"],
-  });
-
-  // Track job view when modal opens (Issue 5 Fix)
+  // Track job view when modal opens — must be before early return (Rules of Hooks)
   React.useEffect(() => {
     if (!open || !job) return;
 
@@ -154,6 +122,38 @@ export function JobDetailsModal({
 
     trackView();
   }, [open, job, openPricingModal, onOpenChange, authenticatedFetch]);
+
+  if (!job) return null;
+
+  // Format source for display
+  const displaySource = formatJobSource(job.source);
+
+  // Use full description if available, fallback to job.description
+  const displayDescription = fullDescription || job.description;
+
+  // Sanitize HTML to prevent XSS
+  const sanitizedDescription = DOMPurify.sanitize(displayDescription || "", {
+    ALLOWED_TAGS: [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "p",
+      "br",
+      "strong",
+      "em",
+      "u",
+      "ul",
+      "ol",
+      "li",
+      "a",
+      "span",
+      "div",
+    ],
+    ALLOWED_ATTR: ["href", "target", "rel", "class"],
+  });
 
   return (
     <>


### PR DESCRIPTION
## Summary

- PR #62 moved most hooks before `if (!job) return null` but missed the `React.useEffect` for job view tracking (line 104)
- This caused React error #310 every time a job card was opened: `job=null` rendered 5 hooks, `job=Job` rendered 6 → hook count mismatch
- Fix: moved the useEffect before the early return guard — the `if (!open || !job) return` inside the effect callback is safe (not a hook violation)

## Test plan

- [ ] Ouvrir `/jobs`, faire une recherche
- [ ] Cliquer "Voir détails" sur une offre
- [ ] Console : aucune erreur #310 "Rendered more hooks than during previous render"
- [ ] Fermer et rouvrir plusieurs fois → toujours propre
- [ ] Cliquer "Générer CV + lettre adaptés" → ApplyModal s'ouvre normalement

Closes #69