### PR TITLE
feat(jobs): full descriptions + school offer filter

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -42,3 +42,6 @@ pycountry==24.6.1  # ISO 3166 country codes
 geonamescache==2.1.2  # Local cities fallback
 
 sentry-sdk[fastapi]==2.19.2
+
+# HTML Parsing (job description scraping)
+beautifulsoup4

--- a/backend/src/agents/job_scout/main_agent.py
+++ b/backend/src/agents/job_scout/main_agent.py
@@ -32,6 +32,35 @@ from src.utils.cache import redis_cache
 
 logger = logging.getLogger(__name__)
 
+# Known school/training-org company names (case-insensitive partial match)
+_SCHOOL_COMPANY_KEYWORDS = [
+    "iscod", "pigier", "studi", "jedha", "wild code school", "le reacteur",
+    "openclassrooms", "efap", "idrac", "epsi", "esgi", "mybtssio", "mybts",
+    "formapro", "infa", "groupe igs", "sup de vente", "iseg", "ifag",
+    "isefac", "isfa", "cfa cnam", "coding temple", "ynov campus",
+    "webacademie", "digital campus", "ion school", "iris school",
+]
+
+# Phrases in title/description that reveal a school recruiting students
+_SCHOOL_CONTENT_PATTERNS = [
+    "notre école",
+    "notre formation",
+    "notre centre de formation",
+    "notre organisme de formation",
+    "rejoignez notre cursus",
+    "rejoignez notre formation",
+    "frais de scolarité",
+    "titre rncp niveau",
+    "certification rncp niveau",
+    "notre bts",
+    "notre bachelor",
+    "notre mastère",
+    "intégrez notre école",
+    "vous serez formé au sein de notre",
+    "organisme de formation enregistré",
+    "programme de formation en alternance",
+]
+
 
 class JobScoutAgent(BaseAgent):
     """
@@ -170,7 +199,10 @@ class JobScoutAgent(BaseAgent):
             # Step 3.5: Pre-filter by relevance (safety net)
             filtered_jobs = self._pre_filter_by_relevance(unique_jobs, search_query)
             logger.info(f"[{self.name}] Pre-filter: {len(unique_jobs)} → {len(filtered_jobs)} jobs")
-            
+
+            # Step 3.6: Filter school/training-org offers disguised as employers
+            filtered_jobs = self._filter_school_offers(filtered_jobs)
+
             # Step 4: Rank with AI (sample for performance)
             ranked_jobs = await self._rank_jobs(filtered_jobs[:max_results * 2], job_title)
             
@@ -350,9 +382,50 @@ class JobScoutAgent(BaseAgent):
         if not filtered:
             logger.warning(f"[JobScout] Pre-filter removed ALL jobs, falling back to original list")
             return jobs
-        
+
         return filtered
-    
+
+    @staticmethod
+    def _filter_school_offers(jobs: list[dict]) -> list[dict]:
+        """
+        Filter out school/training-organization offers disguised as employer job postings.
+
+        Detects two patterns:
+        1. Company name matches a known school operator keyword
+        2. Title or description contains school-recruitment language (e.g. "notre formation")
+        """
+        filtered = []
+        removed_count = 0
+
+        for job in jobs:
+            company = (job.get("company") or "").lower()
+            title = (job.get("title") or "").lower()
+            description = (job.get("description") or "").lower()
+            content = f"{title} {description}"
+
+            # Check 1: known school company name
+            is_school = any(kw in company for kw in _SCHOOL_COMPANY_KEYWORDS)
+
+            # Check 2: content patterns (one strong signal is enough)
+            if not is_school:
+                is_school = any(pattern in content for pattern in _SCHOOL_CONTENT_PATTERNS)
+
+            if is_school:
+                removed_count += 1
+                logger.debug(
+                    f"[SchoolFilter] Removed: '{job.get('title')}' @ '{job.get('company')}'"
+                )
+            else:
+                filtered.append(job)
+
+        if removed_count > 0:
+            logger.info(
+                f"[SchoolFilter] Filtered {removed_count} school offers "
+                f"out of {len(jobs) + removed_count}"
+            )
+
+        return filtered
+
     async def refine_query(self, query: str) -> dict:
         """
         Public method to refine search query.

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -284,29 +284,63 @@ async def get_market_insights(
 @router.post("/description")
 async def get_job_description(request: Request):
     """
-    Get full job description from a job URL.
+    Get full job description by scraping the job URL.
 
-    Note: Currently returns empty description.
-    Full scraping implementation to be added in future sprint.
+    Fetches the page and extracts the job description section using common
+    CSS selectors, then falls back to the longest paragraph block.
     """
+    import httpx
+    from bs4 import BeautifulSoup
+
     try:
         body = await request.json()
         url = body.get("url", "")
-        source = body.get("source", "")
 
-        # TODO: Implement actual scraping logic in future sprint
-        # For now, return empty to prevent 404 errors
-        return {
-            "success": True,
-            "description": "",
-            "message": "Full description scraping not yet implemented"
-        }
-    except Exception as e:
-        return {
-            "success": False,
-            "description": "",
-            "error": str(e)
-        }
+        if not url:
+            return {"success": False, "description": ""}
+
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            headers = {"User-Agent": "Mozilla/5.0 (compatible; HuntZen/1.0)"}
+            response = await client.get(url, headers=headers)
+
+        if response.status_code != 200:
+            return {"success": False, "description": ""}
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Remove noisy elements
+        for tag in soup(["script", "style", "nav", "header", "footer"]):
+            tag.decompose()
+
+        # Try common job description selectors (most specific first)
+        selectors = [
+            '[class*="job-description"]',
+            '[class*="jobDescription"]',
+            '[class*="job_description"]',
+            '[id*="job-description"]',
+            '[class*="description"]',
+            'article',
+            'main',
+        ]
+        text = ""
+        for selector in selectors:
+            el = soup.select_one(selector)
+            if el:
+                text = el.get_text(separator="\n", strip=True)
+                if len(text) > 200:
+                    break
+
+        # Fallback: join longest paragraph blocks
+        if not text or len(text) < 200:
+            paragraphs = soup.find_all("p")
+            text = "\n".join(
+                p.get_text(strip=True) for p in paragraphs if len(p.get_text()) > 50
+            )
+
+        return {"success": True, "description": text[:5000]}
+
+    except Exception:
+        return {"success": False, "description": ""}
 
 
 @router.post("/track-view")

--- a/backend/src/services/job_providers/france_travail.py
+++ b/backend/src/services/job_providers/france_travail.py
@@ -180,7 +180,7 @@ class FranceTravailProvider(BaseJobProvider):
             "title": item.get("intitule", ""),
             "company": company,
             "location": location,
-            "description": (item.get("description") or "")[:500],
+            "description": (item.get("description") or "")[:5000],
             "url": url,
             "salary": salary,
             "contract_type": contract,

--- a/backend/src/services/job_providers/jsearch.py
+++ b/backend/src/services/job_providers/jsearch.py
@@ -174,7 +174,7 @@ class JSearchProvider(BaseJobProvider):
             "title": title,
             "company": item.get("employer_name") or "Unknown",
             "location": job_location,
-            "description": (item.get("job_description") or "")[:500],
+            "description": (item.get("job_description") or "")[:5000],
             "url": url,
             "salary": salary,
             "contract_type": contract,


### PR DESCRIPTION
Closes #71

## Summary

- **Supprime la troncature 500 chars** sur JSearch et France Travail (descriptions complètes jusqu'à 5000 chars)
- **Implémente le scraping** dans `/api/jobs/description` : httpx + BeautifulSoup4 pour fetcher la page réelle du job (sélecteurs CSS communs + fallback paragraphes)
- **Filtre école** : `_filter_school_offers()` inséré dans le pipeline scout, après `_pre_filter_by_relevance` et avant le ranker IA — élimine les ISCOD, Pigier, STUDI, Jedha etc. qui se font passer pour des employeurs via blacklist noms + patterns de contenu

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `jsearch.py` | `[:500]` → `[:5000]` |
| `france_travail.py` | `[:500]` → `[:5000]` |
| `jobs.py` | Scraping httpx+BS4 dans `/description` |
| `main_agent.py` | `_filter_school_offers()` + constantes module-level |
| `requirements.txt` | Ajout `beautifulsoup4` |

## Test plan

- [ ] Rechercher un job → vérifier description > 500 chars en base JSearch/France Travail
- [ ] Ouvrir modal offre → vérifier que `/api/jobs/description` retourne du texte non vide
- [ ] Rechercher "commercial alternance" → vérifier absence d'offres ISCOD/Pigier
- [ ] Logs backend : `[SchoolFilter] Filtered X school offers`