### PR TITLE
feat(streaming): progressive job search via SSE with lock-first-3 pattern

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ docling
 # HTTP Clients
 httpx
 aiohttp
+sse-starlette  # Server-Sent Events streaming responses
 
 # Configuration
 pydantic

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -4,12 +4,19 @@ Job Search API Routes
 Endpoints for AI-powered job searching.
 """
 
+import asyncio
+import hashlib
+import json
+import time
 from typing import List
 from fastapi import APIRouter, HTTPException, status, Query, Request
+from sse_starlette.sse import EventSourceResponse
 
 from src.api.deps import ScoutAgentDep
 from src.api.middleware import limiter
 from src.models.schemas import JobSearchRequest, JobSearchResponse, SearchMetadata, Job
+from src.utils.cache import get_redis
+from src.agents.job_scout.main_agent import JobScoutAgent
 
 router = APIRouter()
 
@@ -241,6 +248,167 @@ async def search_jobs_get(
         result['metadata']['total_before_filters'] = len(jobs)
 
     return result
+
+
+@router.get("/search/stream")
+async def search_jobs_stream(
+    request: Request,
+    q: str = Query(..., description="Job title to search", min_length=2),
+    country: str = Query(default="fr"),
+    city: str = Query(default=""),
+    contract: str = Query(default=""),
+    limit: int = Query(default=50, ge=5, le=200),
+    radius: int = Query(default=None, ge=1, le=100),
+    include_remote: bool = Query(default=True),
+    agent: ScoutAgentDep = ...,
+):
+    """
+    Stream job results via SSE. Results appear as each provider responds.
+
+    SSE event types:
+    - query:  refined search query from LLM (~1s)
+    - jobs:   batch of jobs from one provider (multiple events, ~3-30s)
+    - ranked: AI-ranked full result list after all providers complete
+    - done:   metadata + signals stream end
+    - error:  fatal error during search
+
+    Redis cache: instant response on cache hit; saved after ranking on miss.
+    """
+    cache_key = "stream:" + hashlib.md5(
+        f"{q}|{country}|{city}|{contract}|{limit}|{radius}|{include_remote}".encode()
+    ).hexdigest()
+
+    async def event_generator():
+        start_time = time.time()
+
+        try:
+            # ── Cache check ──────────────────────────────────────────────────
+            redis = await get_redis()
+            if redis:
+                try:
+                    cached = await redis.get(cache_key)
+                    if cached:
+                        data = json.loads(cached)
+                        yield {
+                            "event": "jobs",
+                            "data": json.dumps({"source": "cache", "jobs": data["jobs"]}),
+                        }
+                        yield {
+                            "event": "done",
+                            "data": json.dumps({
+                                "total_raw": len(data["jobs"]),
+                                "sources_used": data.get("sources_used", []),
+                                "search_time_ms": int((time.time() - start_time) * 1000),
+                                "from_cache": True,
+                            }),
+                        }
+                        return
+                except Exception:
+                    pass  # Redis error → proceed normally
+
+            # ── Step 1: Refine query (LLM ~1-2s) ────────────────────────────
+            refined = await agent._refine_query(q)
+            search_query = refined.get("corrected_query", q)
+
+            yield {
+                "event": "query",
+                "data": json.dumps({"original_query": q, "refined_query": search_query}),
+            }
+
+            # ── Step 2: Determine active providers ───────────────────────────
+            active_providers = list(agent.providers)
+            if country.lower() == "fr":
+                active_providers.append(agent.france_travail)
+            if not include_remote:
+                active_providers = [p for p in active_providers if p.name != "remoteok"]
+
+            # ── Step 3: Per-provider search wrapper ──────────────────────────
+            async def search_one(provider):
+                kwargs = {
+                    "query": search_query,
+                    "location": city,
+                    "country_code": country,
+                    "max_results": limit,
+                }
+                if provider.name == "adzuna":
+                    kwargs["max_days"] = 7
+                    kwargs["contract_type"] = contract
+                if radius:
+                    kwargs["radius_km"] = radius
+                jobs = await provider.search(**kwargs)
+                return provider.name, jobs
+
+            # ── Step 4: Stream batches as providers complete ──────────────────
+            seen_ids: set[str] = set()
+            all_filtered: list[dict] = []
+            sources_used: list[str] = []
+            total_raw = 0
+
+            tasks = [asyncio.create_task(search_one(p)) for p in active_providers]
+
+            for coro in asyncio.as_completed(tasks):
+                if await request.is_disconnected():
+                    return
+
+                source_name, raw_batch = await coro
+                total_raw += len(raw_batch)
+
+                # Deduplicate across providers
+                new_jobs = [j for j in raw_batch if j.get("id") not in seen_ids]
+                seen_ids.update(j.get("id", "") for j in new_jobs if j.get("id"))
+
+                # School filter + relevance pre-filter
+                new_jobs = JobScoutAgent._filter_school_offers(new_jobs)
+                new_jobs = JobScoutAgent._pre_filter_by_relevance(new_jobs, search_query)
+
+                if new_jobs:
+                    sources_used.append(source_name)
+                    all_filtered.extend(new_jobs)
+                    yield {
+                        "event": "jobs",
+                        "data": json.dumps({"source": source_name, "jobs": new_jobs}),
+                    }
+
+            # ── Step 5: AI ranking on ALL collected jobs ──────────────────────
+            if all_filtered:
+                ranked = await agent._rank_jobs(all_filtered[: limit * 2], q)
+                final_jobs = ranked[:limit]
+            else:
+                final_jobs = []
+
+            yield {
+                "event": "ranked",
+                "data": json.dumps({"jobs": final_jobs}),
+            }
+
+            # ── Step 6: Done + cache save ─────────────────────────────────────
+            elapsed_ms = int((time.time() - start_time) * 1000)
+            yield {
+                "event": "done",
+                "data": json.dumps({
+                    "total_raw": total_raw,
+                    "total_unique": len(seen_ids),
+                    "sources_used": sources_used,
+                    "search_time_ms": elapsed_ms,
+                    "from_cache": False,
+                }),
+            }
+
+            # Save ranked result to Redis (15min TTL, graceful fail)
+            if redis and final_jobs:
+                try:
+                    await redis.setex(
+                        cache_key,
+                        900,
+                        json.dumps({"jobs": final_jobs, "sources_used": sources_used}),
+                    )
+                except Exception:
+                    pass
+
+        except Exception as e:
+            yield {"event": "error", "data": json.dumps({"error": str(e)})}
+
+    return EventSourceResponse(event_generator())
 
 
 @router.post("/analyze-query")

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -43,6 +43,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { huntzenApi, type Job } from "@/lib/api/huntzen-client";
+import { useStreamingJobSearch } from "@/hooks/use-streaming-job-search";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSubscription } from "@/contexts/subscription-context";
 import { useOptionalAuth } from "@/contexts/auth-context";
@@ -75,7 +76,15 @@ export default function JobsPage() {
   const [selectedCountry, setSelectedCountry] = useState("");
   const [selectedCity, setSelectedCity] = useState("");
   const [contractType, setContractType] = useState("");
-  const [jobs, setJobs] = useState<Job[]>([]);
+  const {
+    jobs,
+    isLoading: searchLoading,
+    isRankingPending,
+    isDone: searchDone,
+    error: searchError,
+    refinedQuery: streamRefinedQuery,
+    search: startSearch,
+  } = useStreamingJobSearch();
   const { translatedJobs, isTranslating } = useJobTranslation(jobs);
   const [visibleJobsCount, setVisibleJobsCount] = useState(0);
   const [correctedQuery, setCorrectedQuery] = useState<string | null>(null);
@@ -368,142 +377,41 @@ export default function JobsPage() {
     setCitySearch(city);
   };
 
-  // Search state for caching with React Query
-  const [jobSearchParams, setJobSearchParams] = useState<SearchParams | null>(
-    null,
-  );
-
-  /**
-   * Tracks whether quota has been incremented for current search params.
-   * Reset when search parameters change to allow quota counting for new searches.
-   *
-   * @internal
-   * @see https://tanstack.com/query/latest/docs/react/guides/caching
-   */
+  // Quota increment — fires once per completed search (not on cache hits)
   const hasIncrementedQuotaRef = useRef(false);
-
-  // Search query with intelligent caching
-  const searchQuery = useQuery({
-    queryKey: [
-      "job-search",
-      jobSearchParams?.query,
-      jobSearchParams?.country,
-      jobSearchParams?.location,
-      jobSearchParams?.radiusKm,
-      jobSearchParams?.includeRemote,
-      contractType,
-      advancedFilters,
-    ],
-    queryFn: async () => {
-      if (!jobSearchParams?.query.trim() || !jobSearchParams?.country) {
-        throw new Error("Veuillez remplir le titre du poste et le pays");
-      }
-
-      // Debug: Log search parameters
-      console.log("🔍 [SEARCH] Paramètres de recherche:", {
-        query: jobSearchParams.query,
-        location: jobSearchParams.location,
-        country: jobSearchParams.country,
-        radiusKm: jobSearchParams.radiusKm,
-        includeRemote: jobSearchParams.includeRemote,
-        contractType,
-      });
-
-      const data = await huntzenApi.searchJobs({
-        job_title: jobSearchParams.query,
-        country_code: jobSearchParams.country,
-        city: jobSearchParams.location,
-        contract_type: contractType,
-        radiusKm: jobSearchParams.radiusKm,
-        includeRemote: jobSearchParams.includeRemote,
-        // Advanced filters (Premium feature)
-        industries: advancedFilters.industries?.join(","),
-        keywords: advancedFilters.keywords?.join(","),
-        experienceLevel: advancedFilters.experienceLevel,
-        salaryMin: advancedFilters.salaryMin,
-        salaryMax: advancedFilters.salaryMax,
-        companySize: advancedFilters.companySize,
-      });
-
-      console.log("✅ [SEARCH] Résultats reçus:", {
-        totalJobs: data.jobs.length,
-        correctedQuery: data.corrected_query,
-      });
-
-      return data;
-    },
-    enabled: !!jobSearchParams, // Simplified: no need for shouldSearch flag
-    staleTime: 1000 * 60 * 5, // 5 minutes - results stay fresh
-    gcTime: 1000 * 60 * 15, // 15 minutes - keep in cache for reuse
-    retry: 1,
-  });
-
-  /**
-   * Reset quota increment flag when search parameters change.
-   * This allows a new search with different params to increment quota again.
-   */
   useEffect(() => {
     hasIncrementedQuotaRef.current = false;
-  }, [jobSearchParams]);
-
-  /**
-   * Increments user's job_search quota when a NEW fetch completes successfully.
-   *
-   * Rules:
-   * - ✅ Count on first successful fetch
-   * - ❌ Don't count on cache hits (isFetched && !isFetching check)
-   * - ✅ Count on refetch after staleTime expiration
-   * - ❌ Don't count on API errors (isSuccess check)
-   *
-   * @example
-   * // First search: "dev" → Quota++
-   * // Repeat search: "dev" → Quota unchanged (cache hit)
-   * // New search: "designer" → Quota++
-   */
+  }, [streamRefinedQuery]);
   useEffect(() => {
-    if (
-      searchQuery.isSuccess && // Fetch succeeded
-      searchQuery.data && // Data available
-      searchQuery.isFetched && // At least 1 fetch completed
-      !searchQuery.isFetching && // Not currently fetching
-      !hasIncrementedQuotaRef.current // Not already counted
-    ) {
-      console.log("📊 [QUOTA] Incrementing usage for job_search");
+    if (searchDone && jobs.length > 0 && !hasIncrementedQuotaRef.current) {
       incrementUsage("job_search");
       hasIncrementedQuotaRef.current = true;
     }
-  }, [
-    searchQuery.isSuccess,
-    searchQuery.data,
-    searchQuery.isFetched,
-    searchQuery.isFetching,
-    incrementUsage,
-  ]);
+  }, [searchDone, jobs.length, incrementUsage]);
 
-  // Handle search query results
+  // Sync corrected query from SSE stream
   useEffect(() => {
-    if (searchQuery.data) {
-      setJobs(searchQuery.data.jobs);
-      setVisibleJobsCount(0); // Reset counter for progressive reveal
-      setCorrectedQuery(searchQuery.data.corrected_query || null);
-    }
-  }, [searchQuery.data]);
+    setCorrectedQuery(streamRefinedQuery ?? null);
+  }, [streamRefinedQuery]);
 
   const handleSearch = (params: SearchParams) => {
-    // Check if user can search (quota check)
     if (!canUse("job_search")) {
       openPricingModal("job_searches_per_day");
       return;
     }
-
-    // Update form state for backward compatibility
     setJobTitle(params.query);
     setSelectedCountry(params.country);
     setSelectedCity(params.location);
-
-    // Trigger search with caching
-    // Setting params will enable the query and trigger fetch
-    setJobSearchParams(params);
+    setVisibleJobsCount(0);
+    startSearch({
+      query: params.query,
+      country: params.country,
+      city: params.location,
+      contract: contractType,
+      radius: params.radiusKm,
+      includeRemote: params.includeRemote,
+      limit: 50,
+    });
   };
 
   const handleSearchLegacy = (e: React.FormEvent) => {
@@ -721,7 +629,7 @@ export default function JobsPage() {
         {featureFlags.useJobsV2 ? (
           <SearchFormInline
             onSearch={handleSearch}
-            isLoading={searchQuery.isFetching}
+            isLoading={searchLoading}
             disabled={false}
             initialQuery={popularQuery}
           />
@@ -780,13 +688,13 @@ export default function JobsPage() {
                   size="lg"
                   className="w-full md:w-auto bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:from-[#00C4EA] hover:to-[#00B3D9] text-white font-bold shadow-lg hover:shadow-xl hover:shadow-[#00D9FF]/40 transition-all h-12 px-8"
                   disabled={
-                    searchQuery.isFetching ||
+                    searchLoading ||
                     !jobTitle.trim() ||
                     !selectedCountry ||
                     (!canUse("job_search") && isFreePlan)
                   }
                 >
-                  {searchQuery.isFetching ? (
+                  {searchLoading ? (
                     <>
                       <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                       {t("form.searching")}
@@ -1085,13 +993,13 @@ export default function JobsPage() {
                     size="lg"
                     className="w-full md:w-auto bg-gradient-to-r from-[#00D9FF] to-[#00C4EA] hover:from-[#00C4EA] hover:to-[#00B3D9] text-white font-bold shadow-lg hover:shadow-xl hover:shadow-[#00D9FF]/40 transition-all h-12 px-8"
                     disabled={
-                      searchQuery.isFetching ||
+                      searchLoading ||
                       !jobTitle.trim() ||
                       !selectedCountry ||
                       (!canUse("job_search") && isFreePlan)
                     }
                   >
-                    {searchQuery.isFetching ? (
+                    {searchLoading ? (
                       <>
                         <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                         {t("form.searching")}
@@ -1136,24 +1044,19 @@ export default function JobsPage() {
       </ErrorBoundary>
 
       {/* Error */}
-      {searchQuery.isError &&
-        searchQuery.error?.message !== "Limite de recherches atteinte" && (
-          <div className="rounded-lg bg-red-50 p-5 border-l-4 border-red-500">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
-              <div>
-                <h3 className="font-semibold text-red-700 mb-1">
-                  {t("error.title")}
-                </h3>
-                <p className="text-sm text-red-600">
-                  {searchQuery.error instanceof Error
-                    ? searchQuery.error.message
-                    : t("error.generic")}
-                </p>
-              </div>
+      {searchError && searchError !== "Limite de recherches atteinte" && (
+        <div className="rounded-lg bg-red-50 p-5 border-l-4 border-red-500">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+            <div>
+              <h3 className="font-semibold text-red-700 mb-1">
+                {t("error.title")}
+              </h3>
+              <p className="text-sm text-red-600">{searchError}</p>
             </div>
           </div>
-        )}
+        </div>
+      )}
 
       {/* Query correction */}
       <AnimatePresence>
@@ -1183,7 +1086,7 @@ export default function JobsPage() {
       </AnimatePresence>
 
       {/* Skeleton grid — shown while fetching (before results arrive) */}
-      {searchQuery.isFetching && (
+      {searchLoading && (
         <div
           className={`grid gap-6 auto-rows-fr ${
             featureFlags.useJobsV2
@@ -1226,7 +1129,7 @@ export default function JobsPage() {
 
       {/* Results */}
 
-      {!searchQuery.isFetching && jobs.length > 0 && (
+      {!searchLoading && jobs.length > 0 && (
         <ErrorBoundary
           fallback={
             <Card className="p-8 text-center bg-white border-slate-200">
@@ -1263,57 +1166,20 @@ export default function JobsPage() {
                         ? t("results.count_one", { count: jobs.length })
                         : t("results.count_other", { count: jobs.length })}
                     </h2>
-                    {/* Cache badge - Shows when data is from cache */}
-                    {searchQuery.isFetched &&
-                      !searchQuery.isFetching &&
-                      searchQuery.dataUpdatedAt && (
-                        <Badge
-                          variant="outline"
-                          className="text-xs bg-blue-50 text-blue-700 border-blue-200"
-                        >
-                          💾 Cache
-                        </Badge>
-                      )}
+                    {isRankingPending && (
+                      <Badge
+                        variant="outline"
+                        className="text-xs bg-amber-50 text-amber-700 border-amber-200 animate-pulse"
+                      >
+                        ✨ Ranking IA...
+                      </Badge>
+                    )}
                   </div>
                   <p className="text-sm text-emerald-600 font-medium">
-                    {searchQuery.isFetching
-                      ? "Actualisation en cours..."
-                      : searchQuery.dataUpdatedAt
-                        ? (() => {
-                            const now = Date.now();
-                            const updatedAt = searchQuery.dataUpdatedAt;
-                            const diffMs = now - updatedAt;
-                            const diffMinutes = Math.floor(diffMs / 60000);
-
-                            // Determine staleness level
-                            const isStale = diffMinutes >= 5;
-                            const isVeryStale = diffMinutes >= 10;
-
-                            let timeText = "";
-                            if (diffMinutes < 1) {
-                              timeText = "à l'instant";
-                            } else if (diffMinutes === 1) {
-                              timeText = "il y a 1 minute";
-                            } else {
-                              timeText = `il y a ${diffMinutes} minutes`;
-                            }
-
-                            return (
-                              <span
-                                className={
-                                  isVeryStale
-                                    ? "text-orange-600"
-                                    : isStale
-                                      ? "text-yellow-600"
-                                      : ""
-                                }
-                              >
-                                {isVeryStale ? "⚠️ " : isStale ? "⏰ " : "✓ "}
-                                Actualisé {timeText}
-                                {isStale && " - Actualisation recommandée"}
-                              </span>
-                            );
-                          })()
+                    {searchLoading
+                      ? "Chargement en cours..."
+                      : isRankingPending
+                        ? "Classement IA des résultats..."
                         : "Résultats récents et pertinents"}
                   </p>
                 </div>
@@ -1322,19 +1188,22 @@ export default function JobsPage() {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    console.log(
-                      "🔄 [REFRESH] Forcing refetch (bypassing cache)",
-                    );
-                    searchQuery.refetch();
+                    if (jobTitle && selectedCountry) {
+                      handleSearch({
+                        query: jobTitle,
+                        country: selectedCountry,
+                        location: selectedCity,
+                      });
+                    }
                   }}
-                  disabled={searchQuery.isFetching}
+                  disabled={searchLoading || isRankingPending}
                   className="ml-4 gap-2 bg-white border-emerald-300 text-emerald-700 hover:bg-emerald-50 hover:border-emerald-400"
-                  title="Actualiser les résultats depuis le serveur"
+                  title="Relancer la recherche"
                 >
                   <RefreshCw
                     className={cn(
                       "w-4 h-4",
-                      searchQuery.isFetching && "animate-spin",
+                      (searchLoading || isRankingPending) && "animate-spin",
                     )}
                   />
                   <span className="hidden sm:inline">
@@ -1530,6 +1399,39 @@ export default function JobsPage() {
                   </motion.div>
                 ))}
 
+              {/* Skeleton cards while AI ranking is in progress (lock-first-3 pattern) */}
+              {isRankingPending &&
+                Array.from({ length: 6 }).map((_, i) => (
+                  <motion.div
+                    key={`ranking-skeleton-${i}`}
+                    initial={{ opacity: 0, y: 16 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: i * 0.07 }}
+                  >
+                    <Card className="flex flex-col border border-slate-200 overflow-hidden h-full bg-white">
+                      <CardHeader className="pb-4 bg-gradient-to-br from-slate-50 to-white border-b border-slate-100">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1 space-y-3">
+                            <Skeleton className="h-6 w-3/4" />
+                            <div className="flex items-center gap-2">
+                              <Skeleton className="h-9 w-9 rounded-xl" />
+                              <Skeleton className="h-4 w-1/2" />
+                            </div>
+                          </div>
+                          <Skeleton className="h-6 w-16 rounded-full" />
+                        </div>
+                      </CardHeader>
+                      <CardContent className="flex-1 flex flex-col pt-4 space-y-3">
+                        <Skeleton className="h-8 w-full rounded-lg" />
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-5/6" />
+                        <Skeleton className="h-4 w-4/6" />
+                        <Skeleton className="h-11 w-full rounded-md mt-auto" />
+                      </CardContent>
+                    </Card>
+                  </motion.div>
+                ))}
+
               {/* Gradient job cards for free users */}
               {showBlurredCards && (
                 <>
@@ -1557,49 +1459,45 @@ export default function JobsPage() {
       )}
 
       {/* Placeholder avant première recherche - NOUVEAU */}
-      {!searchQuery.isFetching &&
-        !searchQuery.isSuccess &&
-        jobs.length === 0 && (
-          <JobsPlaceholder
-            onSearchClick={(popularJobTitle) => {
-              setPopularQuery(popularJobTitle);
-              setTimeout(() => {
-                const input =
-                  document.getElementById("query-inline") ??
-                  document.getElementById("query-mobile");
-                input?.scrollIntoView({ behavior: "smooth", block: "center" });
-                input?.focus();
-              }, 50);
-            }}
-          />
-        )}
+      {!searchLoading && !searchDone && jobs.length === 0 && (
+        <JobsPlaceholder
+          onSearchClick={(popularJobTitle) => {
+            setPopularQuery(popularJobTitle);
+            setTimeout(() => {
+              const input =
+                document.getElementById("query-inline") ??
+                document.getElementById("query-mobile");
+              input?.scrollIntoView({ behavior: "smooth", block: "center" });
+              input?.focus();
+            }, 50);
+          }}
+        />
+      )}
 
-      {!searchQuery.isFetching &&
-        searchQuery.isSuccess &&
-        jobs.length === 0 && (
-          <Card className="border-2 border-dashed border-slate-300 bg-white">
-            <CardContent className="py-16 text-center">
-              <div className="w-20 h-20 mx-auto rounded-full bg-slate-100 flex items-center justify-center mb-6">
-                <Search className="h-10 w-10 text-muted-foreground/50" />
-              </div>
-              <h3 className="text-2xl font-bold text-slate-700 mb-2">
-                {t("empty.title")}
-              </h3>
-              <p className="text-base text-muted-foreground mb-6 max-w-md mx-auto">
-                {t("empty.subtitle")}
-              </p>
-              <div className="space-y-2 text-sm text-muted-foreground max-w-lg mx-auto">
-                <p className="font-semibold">{t("empty.tips")}</p>
-                <ul className="text-left space-y-1 inline-block">
-                  <li>• {t("empty.tip1")}</li>
-                  <li>• {t("empty.tip2")}</li>
-                  <li>• {t("empty.tip3")}</li>
-                  <li>• {t("empty.tip4")}</li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
-        )}
+      {!searchLoading && searchDone && jobs.length === 0 && (
+        <Card className="border-2 border-dashed border-slate-300 bg-white">
+          <CardContent className="py-16 text-center">
+            <div className="w-20 h-20 mx-auto rounded-full bg-slate-100 flex items-center justify-center mb-6">
+              <Search className="h-10 w-10 text-muted-foreground/50" />
+            </div>
+            <h3 className="text-2xl font-bold text-slate-700 mb-2">
+              {t("empty.title")}
+            </h3>
+            <p className="text-base text-muted-foreground mb-6 max-w-md mx-auto">
+              {t("empty.subtitle")}
+            </p>
+            <div className="space-y-2 text-sm text-muted-foreground max-w-lg mx-auto">
+              <p className="font-semibold">{t("empty.tips")}</p>
+              <ul className="text-left space-y-1 inline-block">
+                <li>• {t("empty.tip1")}</li>
+                <li>• {t("empty.tip2")}</li>
+                <li>• {t("empty.tip3")}</li>
+                <li>• {t("empty.tip4")}</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Job Details Modal */}
       <JobDetailsModal

--- a/frontend-next/src/hooks/use-streaming-job-search.ts
+++ b/frontend-next/src/hooks/use-streaming-job-search.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+import { type Job } from "@/lib/api/huntzen-client";
+
+const LOCK_SIZE = 3; // First N jobs shown immediately, never reordered
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
+
+export interface StreamSearchParams {
+  query: string;
+  country: string;
+  city?: string;
+  contract?: string;
+  limit?: number;
+  radius?: number;
+  includeRemote?: boolean;
+}
+
+interface StreamingState {
+  lockedJobs: Job[];         // First LOCK_SIZE — displayed immediately, never reordered
+  rankedJobs: Job[];         // Remaining — replaces skeletons after AI ranking
+  isLoading: boolean;        // Providers still running
+  isRankingPending: boolean; // All providers done, ranking in progress → show skeletons
+  isDone: boolean;
+  error: string | null;
+  refinedQuery: string | null;
+  searchTimeMs: number | null;
+}
+
+const INITIAL_STATE: StreamingState = {
+  lockedJobs: [],
+  rankedJobs: [],
+  isLoading: false,
+  isRankingPending: false,
+  isDone: false,
+  error: null,
+  refinedQuery: null,
+  searchTimeMs: null,
+};
+
+export function useStreamingJobSearch() {
+  const [state, setState] = useState<StreamingState>(INITIAL_STATE);
+  const esRef = useRef<EventSource | null>(null);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+  // Buffer for jobs arriving after lock is full (before ranked event)
+  const pendingJobsRef = useRef<Job[]>([]);
+
+  const search = useCallback((params: StreamSearchParams) => {
+    // Close any existing connection
+    esRef.current?.close();
+    esRef.current = null;
+    seenIdsRef.current = new Set();
+    pendingJobsRef.current = [];
+    setState({ ...INITIAL_STATE, isLoading: true });
+
+    const qs = new URLSearchParams({
+      q: params.query,
+      country: params.country,
+      city: params.city ?? "",
+      contract: params.contract ?? "",
+      limit: String(params.limit ?? 50),
+      include_remote: String(params.includeRemote ?? true),
+    });
+    if (params.radius) qs.set("radius", String(params.radius));
+
+    const url = `${BACKEND_URL}/api/jobs/search/stream?${qs}`;
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    // ── event:query — refined search query ──────────────────────────────────
+    es.addEventListener("query", (e: MessageEvent) => {
+      const data = JSON.parse(e.data);
+      setState((prev) => ({ ...prev, refinedQuery: data.refined_query ?? null }));
+    });
+
+    // ── event:jobs — batch from one provider ────────────────────────────────
+    es.addEventListener("jobs", (e: MessageEvent) => {
+      const data = JSON.parse(e.data);
+      const incoming: Job[] = (data.jobs ?? []).filter((j: Job) => {
+        if (seenIdsRef.current.has(j.id)) return false;
+        seenIdsRef.current.add(j.id);
+        return true;
+      });
+      if (incoming.length === 0) return;
+
+      setState((prev) => {
+        // Lock slots not yet full — fill them first
+        if (prev.lockedJobs.length < LOCK_SIZE) {
+          const needed = LOCK_SIZE - prev.lockedJobs.length;
+          const toLock = incoming.slice(0, needed);
+          const rest = incoming.slice(needed);
+          // Accumulate overflow for later
+          if (rest.length > 0) {
+            pendingJobsRef.current.push(...rest);
+          }
+          const newLocked = [...prev.lockedJobs, ...toLock];
+          return {
+            ...prev,
+            lockedJobs: newLocked,
+            // Show skeletons once lock slots are filled
+            isRankingPending: newLocked.length >= LOCK_SIZE,
+          };
+        }
+        // Lock is already full — accumulate in background, don't show yet
+        pendingJobsRef.current.push(...incoming);
+        return { ...prev, isRankingPending: true };
+      });
+    });
+
+    // ── event:ranked — AI ranking complete, fills skeletons ─────────────────
+    es.addEventListener("ranked", (e: MessageEvent) => {
+      const { jobs: ranked }: { jobs: Job[] } = JSON.parse(e.data);
+      setState((prev) => {
+        const lockedIds = new Set(prev.lockedJobs.map((j) => j.id));
+        return {
+          ...prev,
+          rankedJobs: ranked.filter((j) => !lockedIds.has(j.id)),
+          isRankingPending: false,
+        };
+      });
+      // Clear pending buffer (ranked replaces it entirely)
+      pendingJobsRef.current = [];
+    });
+
+    // ── event:done — stream complete ────────────────────────────────────────
+    es.addEventListener("done", (e: MessageEvent) => {
+      const data = JSON.parse(e.data);
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        isRankingPending: false,
+        isDone: true,
+        searchTimeMs: data.search_time_ms ?? null,
+      }));
+      es.close();
+      esRef.current = null;
+    });
+
+    // ── event:error — server-side error ─────────────────────────────────────
+    es.addEventListener("error", (e: MessageEvent) => {
+      let message = "Erreur lors de la recherche";
+      try {
+        const data = JSON.parse((e as MessageEvent).data ?? "{}");
+        message = data.error ?? message;
+      } catch {
+        // ignore parse error
+      }
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        isRankingPending: false,
+        isDone: true,
+        error: message,
+      }));
+      es.close();
+      esRef.current = null;
+    });
+
+    // ── native onerror — connection dropped ─────────────────────────────────
+    es.onerror = () => {
+      if (es.readyState === EventSource.CLOSED) return;
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        isRankingPending: false,
+        isDone: true,
+        error: "Connexion interrompue",
+      }));
+      es.close();
+      esRef.current = null;
+    };
+  }, []);
+
+  const cancel = useCallback(() => {
+    esRef.current?.close();
+    esRef.current = null;
+    setState((prev) => ({ ...prev, isLoading: false, isRankingPending: false }));
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => () => { esRef.current?.close(); }, []);
+
+  // Combined view: locked (stable, shown first) + ranked (fills skeletons)
+  const jobs = [...state.lockedJobs, ...state.rankedJobs];
+
+  return { ...state, jobs, search, cancel };
+}


### PR DESCRIPTION
## Summary

- **Backend**: New `GET /api/jobs/search/stream` endpoint using SSE (`sse-starlette`). Uses `asyncio.as_completed()` so each provider streams its results as they arrive. AI ranking fires after all providers complete (`event:ranked`). Redis cache: instant reply on hit, save after ranking on miss (15min TTL).
- **Frontend**: New `use-streaming-job-search.ts` hook with **lock-first-3** pattern — first 3 jobs appear immediately (~3s) and never reorder. Skeleton cards show while AI ranking runs. Ranked results fill skeletons without list jank.
- `jobs/page.tsx`: Replace `useQuery` (incompatible with SSE) with the streaming hook. All SSE states wired (`isLoading`, `isRankingPending`, `isDone`, `searchError`).

## SSE Event Flow

```
event:query   (~1s)   — refined query from LLM
event:jobs    (~3s)   — first provider batch → frontend locks first 3
event:jobs    (~8s)   — more providers...
event:ranked  (~12s)  — AI ranked list → fills skeletons
event:done            — metadata, triggers cache save
```

## Test Plan

- [ ] Search triggers SSE connection (`text/event-stream` in Network tab)
- [ ] First 3 jobs appear ~3s, never reorder
- [ ] Skeleton cards visible while ranking runs
- [ ] Ranked jobs fill skeletons after `event:ranked`
- [ ] Repeat search = instant cache hit (single `event:jobs` + `event:done`)
- [ ] Quota incremented once after `isDone`
- [ ] Error state displays on connection failure