### PR TITLE
fix(deps): add sse-starlette to pyproject.toml — fixes Railway crash

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     
     # HTTP & Scraping
     "beautifulsoup4>=4.12.0",
+    "sse-starlette>=1.6.0",  # Server-Sent Events for /search/stream endpoint
     
     # Database (Optional)
     "supabase>=2.3.0",


### PR DESCRIPTION
## Problème

Railway crashait au démarrage avec `ModuleNotFoundError: No module named 'sse_starlette'`.

## Cause racine

Le Dockerfile build les dépendances depuis `pyproject.toml` via `pip install -e .` — **pas** depuis `requirements.txt`. `sse-starlette` avait été ajouté uniquement dans `requirements.txt` (PR #73), donc Railway ne l'installait pas.

```
COPY pyproject.toml .
RUN pip install --no-cache-dir -e .   ← lit pyproject.toml, pas requirements.txt
```

## Fix

Ajout de `"sse-starlette>=1.6.0"` dans la section `dependencies` de `pyproject.toml`.

## Test Plan

- [ ] Railway build réussit sans `ModuleNotFoundError`
- [ ] Workers gunicorn démarrent normalement
- [ ] `GET /api/jobs/search/stream` répond en `text/event-stream`