### PR TITLE
fix: missing advancedFilters.cancelButton key + CV PDF wrong endpoint

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -831,7 +831,8 @@
     "companySizeEnterprise": "Major Group",
     "salaryMin": "Salary min",
     "salaryMax": "Max Salary",
-    "premiumFeature": "Premium Feature"
+    "premiumFeature": "Premium Feature",
+    "cancelButton": "Cancel"
   },
   "gradientJobCard": {
     "lockedOffer": "Offer Locked",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -831,7 +831,8 @@
     "companySizeEnterprise": "Sector económico/grupo principal",
     "salaryMin": "Salario mínimo",
     "salaryMax": "Salario máximo",
-    "premiumFeature": "Funcionalidad Premium"
+    "premiumFeature": "Funcionalidad Premium",
+    "cancelButton": "Cancelar"
   },
   "gradientJobCard": {
     "lockedOffer": "Oferta bloqueada",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -814,6 +814,7 @@
     "companySizeLabel": "Taille d'entreprise",
     "applyButton": "Appliquer les filtres",
     "resetButton": "Réinitialiser",
+    "cancelButton": "Annuler",
     "industryTechIT": "Tech / IT",
     "industryFinance": "Finance",
     "industryMarketing": "Marketing",

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -831,7 +831,8 @@
     "companySizeEnterprise": "Grupo Principal",
     "salaryMin": "Salário Mínimo",
     "salaryMax": "Salário Máximo",
-    "premiumFeature": "Recurso Premium"
+    "premiumFeature": "Recurso Premium",
+    "cancelButton": "Cancelar"
   },
   "gradientJobCard": {
     "lockedOffer": "Oferta bloqueada",

--- a/frontend-next/src/components/jobs/apply-modal.tsx
+++ b/frontend-next/src/components/jobs/apply-modal.tsx
@@ -198,7 +198,7 @@ export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
 
       const [cvPdfResponse, lmPdfResponse] = await Promise.all([
         // CV adapté en PDF
-        fetch(`${BACKEND_URL}/api/cv-adapter/pdf`, {
+        fetch(`${BACKEND_URL}/api/cv-adapter/generate-pdf`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({


### PR DESCRIPTION
Fixes #79

## Problems Fixed

### 1. Missing translation key (console spam)
`advancedFilters.cancelButton` was used in `advanced-filters-modal.tsx` (line 467) but missing from `fr.json`, causing repeated `MISSING_MESSAGE` errors on every render.

**Fix:** Added `"cancelButton": "Annuler"` to the `advancedFilters` namespace + re-synced en/es/pt.

### 2. CV generation blocked (wrong API endpoint)
`apply-modal.tsx` was calling `/api/cv-adapter/pdf` (non-existent) to generate the CV PDF from structured `cv_data`.

**Fix:** Changed to the correct endpoint `/api/cv-adapter/generate-pdf` which accepts `{ cv_data, template, language }` JSON body.

| Step | Endpoint | Status |
|------|----------|--------|
| Upload + adapt CV | `/api/cv-adapter/adapt/upload` | ✅ was already correct |
| Generate CV PDF | `/api/cv-adapter/generate-pdf` | ✅ fixed (was `/pdf`) |
| Generate cover letter PDF | `/api/cv-adapter/generate-cover-letter` | ✅ was already correct |