### PR TITLE
fix: show typing prompt in country/city dropdowns when input is empty

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -804,7 +804,12 @@
     "radiusKm": "Radius (Km)",
     "searchesRemaining": "{count} search(s) left today",
     "searchButton": "News Search",
-    "advancedFilters": "Advanced filters"
+    "advancedFilters": "Advanced filters",
+    "typeYourCountry": "Your country",
+    "typeYourCity": "Type your city.",
+    "noCountryFound": "No country found",
+    "noCityFound": "No cities found.",
+    "selectCountryFirst": "Select a country first"
   },
   "advancedFilters": {
     "title": "Advanced filters",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -804,7 +804,12 @@
     "radiusKm": "{RADIUS} km",
     "searchesRemaining": "{count} búsqueda(es) restante(s) hoy",
     "searchButton": "Buscar",
-    "advancedFilters": "Filtros avanzados"
+    "advancedFilters": "Filtros avanzados",
+    "typeYourCountry": "Escriba su país",
+    "typeYourCity": "Escribe tu ciudad",
+    "noCountryFound": "No se ha encontrado ningún país",
+    "noCityFound": "No se ha encontrado ninguna ciudad",
+    "selectCountryFirst": "Primero selecciona un país"
   },
   "advancedFilters": {
     "title": "Filtros avanzados",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -804,7 +804,12 @@
     "radiusKm": "{radius} km",
     "searchesRemaining": "{count} recherche(s) restante(s) aujourd'hui",
     "searchButton": "Rechercher",
-    "advancedFilters": "Filtres avancés"
+    "advancedFilters": "Filtres avancés",
+    "typeYourCountry": "Tapez votre pays",
+    "typeYourCity": "Tapez votre ville",
+    "noCountryFound": "Aucun pays trouvé",
+    "noCityFound": "Aucune ville trouvée",
+    "selectCountryFirst": "Sélectionnez d'abord un pays"
   },
   "advancedFilters": {
     "title": "Filtres avancés",

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -804,7 +804,12 @@
     "radiusKm": "{radius} km",
     "searchesRemaining": "{count} pesquisa(s) restante(s) hoje",
     "searchButton": "Pesquisar",
-    "advancedFilters": "Filtros Avançados"
+    "advancedFilters": "Filtros Avançados",
+    "typeYourCountry": "Introduza o seu país",
+    "typeYourCity": "Escreva a sua cidade",
+    "noCountryFound": "Nenhum país encontrado",
+    "noCityFound": "Nenhuma cidade encontrada",
+    "selectCountryFirst": "Escolha um país primeiro"
   },
   "advancedFilters": {
     "title": "Filtros Avançados",

--- a/frontend-next/src/components/jobs/search-form-inline.tsx
+++ b/frontend-next/src/components/jobs/search-form-inline.tsx
@@ -263,6 +263,8 @@ export function SearchFormInline({
               icon={<Globe className="h-5 w-5" />}
               error={!!errors.country}
               helperText={errors.country}
+              typingPromptMessage={t("typeYourCountry")}
+              emptyMessage={t("noCountryFound")}
               required
             />
           </div>
@@ -276,10 +278,11 @@ export function SearchFormInline({
               onSearch={fetchCities}
               disabled={disabled || isLoading || !isCountryValid}
               icon={<MapPin className="h-5 w-5" />}
+              typingPromptMessage={
+                !isCountryValid ? undefined : t("typeYourCity")
+              }
               emptyMessage={
-                !isCountryValid
-                  ? "Sélectionnez d'abord un pays"
-                  : "Aucune ville trouvée"
+                !isCountryValid ? t("selectCountryFirst") : t("noCityFound")
               }
             />
           </div>
@@ -406,6 +409,8 @@ export function SearchFormInline({
           icon={<Globe className="h-5 w-5" />}
           error={!!errors.country}
           helperText={errors.country}
+          typingPromptMessage={t("typeYourCountry")}
+          emptyMessage={t("noCountryFound")}
           required
         />
 
@@ -417,10 +422,9 @@ export function SearchFormInline({
           onSearch={fetchCities}
           disabled={disabled || isLoading || !isCountryValid}
           icon={<MapPin className="h-5 w-5" />}
+          typingPromptMessage={!isCountryValid ? undefined : t("typeYourCity")}
           emptyMessage={
-            !isCountryValid
-              ? "Sélectionnez d'abord un pays"
-              : "Aucune ville trouvée"
+            !isCountryValid ? t("selectCountryFirst") : t("noCityFound")
           }
         />
 

--- a/frontend-next/src/components/ui/autocomplete-input.tsx
+++ b/frontend-next/src/components/ui/autocomplete-input.tsx
@@ -3,53 +3,55 @@
  * Solves z-index issues, adds loading states, improves accessibility
  */
 
-'use client'
+"use client";
 
-import * as React from 'react'
-import * as PopoverPrimitive from '@radix-ui/react-popover'
-import { Command as CommandPrimitive } from 'cmdk'
-import { Check, ChevronDown, Loader2, Search, X } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { Command as CommandPrimitive } from "cmdk";
+import { Check, ChevronDown, Loader2, Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
 export interface AutocompleteOption {
-  value: string
-  label: string
-  description?: string
+  value: string;
+  label: string;
+  description?: string;
 }
 
 export interface AutocompleteInputProps {
   /** Input label */
-  label?: string
+  label?: string;
   /** Current value */
-  value: string
+  value: string;
   /** Change handler */
-  onChange: (value: string) => void
+  onChange: (value: string) => void;
   /** Options to display */
-  options?: AutocompleteOption[]
+  options?: AutocompleteOption[];
   /** Loading state */
-  loading?: boolean
+  loading?: boolean;
   /** Error state */
-  error?: boolean
+  error?: boolean;
   /** Helper text */
-  helperText?: string
+  helperText?: string;
   /** Placeholder */
-  placeholder?: string
+  placeholder?: string;
   /** Disabled state */
-  disabled?: boolean
+  disabled?: boolean;
   /** Required field */
-  required?: boolean
+  required?: boolean;
   /** Icon to display */
-  icon?: React.ReactNode
-  /** Empty state message */
-  emptyMessage?: string
+  icon?: React.ReactNode;
+  /** Empty state message (when user typed but no results found) */
+  emptyMessage?: string;
+  /** Prompt shown when input is empty (before user types anything) */
+  typingPromptMessage?: string;
   /** Fetch options function (for async) */
-  onSearch?: (query: string) => Promise<AutocompleteOption[]>
+  onSearch?: (query: string) => Promise<AutocompleteOption[]>;
   /** Debounce delay for search (ms) */
-  debounceMs?: number
+  debounceMs?: number;
 }
 
 // ============================================================================
@@ -69,100 +71,102 @@ export const AutocompleteInput = React.forwardRef<
       loading: externalLoading = false,
       error = false,
       helperText,
-      placeholder = 'Rechercher...',
+      placeholder = "Rechercher...",
       disabled = false,
       required = false,
       icon,
-      emptyMessage = 'Aucun résultat trouvé',
+      emptyMessage = "Aucun résultat trouvé",
+      typingPromptMessage,
       onSearch,
       debounceMs = 300,
     },
-    ref
+    ref,
   ) => {
-    const [open, setOpen] = React.useState(false)
-    const [search, setSearch] = React.useState(value)
+    const [open, setOpen] = React.useState(false);
+    const [search, setSearch] = React.useState(value);
     const [internalOptions, setInternalOptions] = React.useState<
       AutocompleteOption[]
-    >([])
-    const [internalLoading, setInternalLoading] = React.useState(false)
-    const inputRef = React.useRef<HTMLInputElement>(null)
-    const debounceRef = React.useRef<NodeJS.Timeout>()
-    const isSelectionRef = React.useRef(false)
+    >([]);
+    const [internalLoading, setInternalLoading] = React.useState(false);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    const debounceRef = React.useRef<NodeJS.Timeout>();
+    const isSelectionRef = React.useRef(false);
 
     // Combine refs
-    React.useImperativeHandle(ref, () => inputRef.current!)
+    React.useImperativeHandle(ref, () => inputRef.current!);
 
     // Use external options or internal fetched options
-    const options = externalOptions.length > 0 ? externalOptions : internalOptions
-    const loading = externalLoading || internalLoading
+    const options =
+      externalOptions.length > 0 ? externalOptions : internalOptions;
+    const loading = externalLoading || internalLoading;
 
     // Sync search with value (sauf si c'est une sélection)
     React.useEffect(() => {
       if (!isSelectionRef.current) {
-        setSearch(value)
+        setSearch(value);
       }
-      isSelectionRef.current = false
-    }, [value])
+      isSelectionRef.current = false;
+    }, [value]);
 
     // Debounced search
     React.useEffect(() => {
-      if (!onSearch) return
+      if (!onSearch) return;
       if (search.length === 0) {
-        setInternalOptions([])
-        return
+        setInternalOptions([]);
+        return;
       }
 
       // Clear previous timeout
       if (debounceRef.current) {
-        clearTimeout(debounceRef.current)
+        clearTimeout(debounceRef.current);
       }
 
       // Set new timeout
       debounceRef.current = setTimeout(async () => {
-        setInternalLoading(true)
+        setInternalLoading(true);
         try {
-          const results = await onSearch(search)
-          setInternalOptions(results)
+          const results = await onSearch(search);
+          setInternalOptions(results);
         } catch (error) {
-          console.error('Autocomplete search error:', error)
-          setInternalOptions([])
+          console.error("Autocomplete search error:", error);
+          setInternalOptions([]);
         } finally {
-          setInternalLoading(false)
+          setInternalLoading(false);
         }
-      }, debounceMs)
+      }, debounceMs);
 
       return () => {
         if (debounceRef.current) {
-          clearTimeout(debounceRef.current)
+          clearTimeout(debounceRef.current);
         }
-      }
-    }, [search, onSearch, debounceMs])
+      };
+    }, [search, onSearch, debounceMs]);
 
     // Handle input change
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value
-      setSearch(newValue)
-      onChange(newValue)
-      if (!open) setOpen(true)
-    }
+      const newValue = e.target.value;
+      setSearch(newValue);
+      onChange(newValue);
+      if (!open) setOpen(true);
+    };
 
     // Handle option select
     const handleSelect = (selectedValue: string) => {
-      const selectedOption = options.find((opt) => opt.value === selectedValue)
+      const selectedOption = options.find((opt) => opt.value === selectedValue);
       if (selectedOption) {
-        isSelectionRef.current = true
-        setSearch(selectedOption.label)
-        onChange(selectedOption.value)
-        setOpen(false)
+        isSelectionRef.current = true;
+        setSearch(selectedOption.label);
+        onChange(selectedOption.value);
+        setOpen(false);
       }
-    }
+    };
 
     // Clear input
     const handleClear = () => {
-      setSearch('')
-      onChange('')
-      inputRef.current?.focus()
-    }
+      setSearch("");
+      onChange("");
+      inputRef.current?.focus();
+    };
 
     return (
       <div className="w-full space-y-1.5">
@@ -170,9 +174,9 @@ export const AutocompleteInput = React.forwardRef<
         {label && (
           <label
             className={cn(
-              'block text-sm font-semibold transition-colors',
-              error ? 'text-error' : 'text-gray-700',
-              disabled && 'opacity-60'
+              "block text-sm font-semibold transition-colors",
+              error ? "text-error" : "text-gray-700",
+              disabled && "opacity-60",
             )}
           >
             {label}
@@ -198,47 +202,51 @@ export const AutocompleteInput = React.forwardRef<
                 value={search}
                 onChange={handleInputChange}
                 onFocus={() => {
-                  if (search.length > 0 || options.length > 0) {
-                    setOpen(true)
+                  if (
+                    search.length > 0 ||
+                    options.length > 0 ||
+                    !!typingPromptMessage
+                  ) {
+                    setOpen(true);
                   }
                 }}
                 disabled={disabled}
                 placeholder={placeholder}
                 className={cn(
                   // Base styles
-                  'w-full h-11 px-4',
-                  icon && 'pl-10',
-                  (search.length > 0 || loading) && 'pr-20',
-                  'rounded-xl',
-                  'font-normal text-base',
-                  'transition-all duration-250 ease-smooth',
-                  'outline-none',
+                  "w-full h-11 px-4",
+                  icon && "pl-10",
+                  (search.length > 0 || loading) && "pr-20",
+                  "rounded-xl",
+                  "font-normal text-base",
+                  "transition-all duration-250 ease-smooth",
+                  "outline-none",
 
                   // Border states
-                  'border-2',
+                  "border-2",
                   error
-                    ? 'border-error-light focus:border-error'
+                    ? "border-error-light focus:border-error"
                     : disabled
-                    ? 'border-gray-200'
-                    : 'border-gray-200 hover:border-gray-300 focus:border-ocean-500',
+                      ? "border-gray-200"
+                      : "border-gray-200 hover:border-gray-300 focus:border-ocean-500",
 
                   // Background
-                  disabled ? 'bg-gray-100' : 'bg-white',
+                  disabled ? "bg-gray-100" : "bg-white",
 
                   // Text color
-                  disabled ? 'text-gray-400' : 'text-gray-900',
+                  disabled ? "text-gray-400" : "text-gray-900",
 
                   // Placeholder
-                  'placeholder:text-gray-400',
+                  "placeholder:text-gray-400",
 
                   // Focus ring
-                  !error && !disabled && 'focus:ring-4 focus:ring-ocean-100',
+                  !error && !disabled && "focus:ring-4 focus:ring-ocean-100",
 
                   // Error ring
-                  error && 'focus:ring-4 focus:ring-error-light',
+                  error && "focus:ring-4 focus:ring-error-light",
 
                   // Disabled cursor
-                  disabled && 'cursor-not-allowed'
+                  disabled && "cursor-not-allowed",
                 )}
                 aria-label={label}
                 aria-expanded={open}
@@ -262,9 +270,9 @@ export const AutocompleteInput = React.forwardRef<
                     type="button"
                     onClick={handleClear}
                     className={cn(
-                      'p-0.5 rounded hover:bg-gray-100',
-                      'text-gray-400 hover:text-gray-600',
-                      'transition-colors'
+                      "p-0.5 rounded hover:bg-gray-100",
+                      "text-gray-400 hover:text-gray-600",
+                      "transition-colors",
                     )}
                     aria-label="Effacer"
                   >
@@ -274,8 +282,8 @@ export const AutocompleteInput = React.forwardRef<
 
                 <ChevronDown
                   className={cn(
-                    'size-4 text-gray-400 transition-transform duration-200',
-                    open && 'rotate-180'
+                    "size-4 text-gray-400 transition-transform duration-200",
+                    open && "rotate-180",
                   )}
                   aria-hidden="true"
                 />
@@ -290,14 +298,14 @@ export const AutocompleteInput = React.forwardRef<
               align="start"
               sideOffset={4}
               className={cn(
-                'z-popover w-[var(--radix-popover-trigger-width)]',
-                'bg-white rounded-xl border-2 border-gray-200',
-                'shadow-lg',
-                'p-1',
-                'animate-scale-in origin-top',
-                'max-h-[300px] overflow-auto',
+                "z-popover w-[var(--radix-popover-trigger-width)]",
+                "bg-white rounded-xl border-2 border-gray-200",
+                "shadow-lg",
+                "p-1",
+                "animate-scale-in origin-top",
+                "max-h-[300px] overflow-auto",
                 // Custom scrollbar
-                'scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent'
+                "scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent",
               )}
               onOpenAutoFocus={(e) => e.preventDefault()}
             >
@@ -313,7 +321,9 @@ export const AutocompleteInput = React.forwardRef<
                   ) : options.length === 0 ? (
                     <div className="py-6 text-center text-sm text-gray-500">
                       <Search className="size-5 mx-auto mb-2 text-gray-400" />
-                      {emptyMessage}
+                      {search.length === 0 && typingPromptMessage
+                        ? typingPromptMessage
+                        : emptyMessage}
                     </div>
                   ) : (
                     <CommandPrimitive.Group>
@@ -323,13 +333,13 @@ export const AutocompleteInput = React.forwardRef<
                           value={option.value}
                           onSelect={handleSelect}
                           className={cn(
-                            'relative flex items-center gap-2 px-3 py-2.5',
-                            'rounded-lg cursor-pointer',
-                            'text-sm text-gray-900',
-                            'transition-colors',
-                            'hover:bg-ocean-50',
-                            'data-[selected=true]:bg-ocean-100',
-                            'outline-none'
+                            "relative flex items-center gap-2 px-3 py-2.5",
+                            "rounded-lg cursor-pointer",
+                            "text-sm text-gray-900",
+                            "transition-colors",
+                            "hover:bg-ocean-50",
+                            "data-[selected=true]:bg-ocean-100",
+                            "outline-none",
                           )}
                         >
                           <div className="flex-1 min-w-0">
@@ -363,18 +373,18 @@ export const AutocompleteInput = React.forwardRef<
         {helperText && (
           <p
             className={cn(
-              'text-xs',
-              error ? 'text-error' : 'text-gray-500',
-              'transition-colors'
+              "text-xs",
+              error ? "text-error" : "text-gray-500",
+              "transition-colors",
             )}
-            role={error ? 'alert' : undefined}
+            role={error ? "alert" : undefined}
           >
             {helperText}
           </p>
         )}
       </div>
-    )
-  }
-)
+    );
+  },
+);
 
-AutocompleteInput.displayName = 'AutocompleteInput'
+AutocompleteInput.displayName = "AutocompleteInput";


### PR DESCRIPTION
Fixes #81

## Problem
Country and city dropdowns showed "Aucun pays trouvé" / "Aucune ville trouvée" immediately on focus (before the user types anything), creating the impression that the feature was broken.

## Fix

### `AutocompleteInput` component
- Added `typingPromptMessage` prop: shown when `search.length === 0`
- `emptyMessage` now only shows when the user has typed but no results were found
- Dropdown now opens on focus when `typingPromptMessage` is set

### `search-form-inline.tsx` (desktop + mobile)
| State | Country | City |
|-------|---------|------|
| Input empty | "Tapez votre pays" | "Tapez votre ville" |
| No country selected | — | "Sélectionnez d'abord un pays" |
| Typed, no result | "Aucun pays trouvé" | "Aucune ville trouvée" |

### Translations
5 new keys added to `searchForm` namespace in `fr.json` + synced to en/es/pt.