### PR TITLE
fix: CORS headers on 500 errors + cv-adapter upload robustness

### DIFF
--- a/backend/src/api/middleware.py
+++ b/backend/src/api/middleware.py
@@ -138,10 +138,14 @@ def setup_middleware(app: FastAPI) -> None:
     app.add_middleware(SlowAPIMiddleware)
 
     # CORS
+    # Note: allow_credentials=True + allow_origins=["*"] is invalid per the
+    # CORS spec. When origins are unrestricted use allow_credentials=False;
+    # when explicit origins are configured credentials can be enabled.
+    allow_all = settings.cors_origins == ["*"]
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.cors_origins,
-        allow_credentials=True,
+        allow_credentials=not allow_all,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/backend/src/api/routes/cv_adapter.py
+++ b/backend/src/api/routes/cv_adapter.py
@@ -200,14 +200,21 @@ async def adapt_cv_from_file(
     
     # Extract text using CV Analyzer agent
     cv_analyzer = get_cv_agent()
-    
-    if filename.endswith(".pdf"):
-        cv_text = await cv_analyzer.extract_text_from_pdf(content)
-    else:
-        from docx import Document
-        doc = Document(io.BytesIO(content))
-        cv_text = "\n".join([para.text for para in doc.paragraphs])
-    
+
+    try:
+        if filename.endswith(".pdf"):
+            cv_text = await cv_analyzer.extract_text_from_pdf(content)
+        else:
+            from docx import Document
+            doc = Document(io.BytesIO(content))
+            cv_text = "\n".join([para.text for para in doc.paragraphs])
+    except Exception as exc:
+        logger.error(f"File text extraction failed for {filename}: {exc}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Could not extract text from file: {str(exc)}",
+        )
+
     if not cv_text or len(cv_text) < 100:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -17,7 +17,8 @@ import logging
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from src.api import router
@@ -76,6 +77,33 @@ app = FastAPI(
 
 # Setup middleware
 setup_middleware(app)
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """
+    Global fallback exception handler.
+
+    Ensures CORS headers are present even on unhandled 500 errors so the
+    browser can read the error detail instead of seeing a CORS violation.
+    """
+    origin = request.headers.get("origin", "")
+    cors_headers: dict[str, str] = {}
+    if origin:
+        cors_headers["Access-Control-Allow-Origin"] = origin
+        cors_headers["Access-Control-Allow-Credentials"] = "true"
+        cors_headers["Vary"] = "Origin"
+
+    logger.error(
+        f"Unhandled exception on {request.method} {request.url.path}: {exc}",
+        exc_info=True,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+        headers=cors_headers,
+    )
+
 
 # Mount static files (if directory exists)
 try:


### PR DESCRIPTION
Fixes #83

## Changes

### 1. Global exception handler (`main.py`)
Adds `Access-Control-Allow-Origin` to ALL unhandled 500 responses so the browser can read the actual error instead of seeing a CORS violation masking the real issue.

### 2. Fix CORS middleware (`middleware.py`)
`allow_credentials=True` + `allow_origins=["*"]` is invalid per the CORS spec. When origins are unrestricted (`"*"`) credentials are now disabled; when explicit origins are configured (production `CORS_ORIGINS` env var) credentials remain enabled.

### 3. Better error handling in `adapt/upload` (`cv_adapter.py`)
PDF/DOCX text extraction (docling) is now wrapped in try/except. Failures return a clean **422** with the error detail instead of an unhandled 500 that previously triggered the CORS masking issue.

## Note for Railway config
If `CORS_ORIGINS` env var is set in Railway, make sure it includes **both** `https://huntzenjobs.com` and `https://www.huntzenjobs.com` (comma-separated).