### PR TITLE
feat(#85): offload PDF extraction to Modal — fix Railway OOM on adapt/upload

### DIFF
--- a/backend/modal_pdf_extractor_app.py
+++ b/backend/modal_pdf_extractor_app.py
@@ -1,0 +1,85 @@
+"""
+Modal App: PDF Text Extraction with Docling
+============================================
+Serverless PDF extraction that offloads heavy Docling ML models
+to Modal Labs, freeing Railway from memory constraints.
+
+Deploy with:
+    modal deploy backend/modal_pdf_extractor_app.py
+
+The webhook URL will be:
+    https://<workspace>--huntzen-pdf-extractor-extract-pdf-text.modal.run
+
+Set this URL as MODAL_PDF_EXTRACT_URL in Railway environment variables.
+"""
+
+import modal
+
+app = modal.App("huntzen-pdf-extractor")
+
+# Image with docling installed (loads heavy ML models once per container)
+docling_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install(["libgomp1"])  # Required by some docling dependencies
+    .pip_install([
+        "docling>=2.0.0",
+        "docling-core>=2.0.0",
+    ])
+)
+
+
+@app.function(
+    image=docling_image,
+    cpu=2,
+    memory=4096,   # 4GB — docling needs ~2-4GB for ML models
+    timeout=120,   # 2 min max per extraction
+    retries=modal.Retries(max_retries=1, backoff_coefficient=1.0, initial_delay=2.0),
+)
+@modal.web_endpoint(method="POST")
+async def extract_pdf_text(body: dict) -> dict:
+    """
+    Extract text from PDF bytes using Docling.
+
+    Input (JSON body):
+        { "pdf_bytes": "<base64-encoded PDF bytes>" }
+
+    Output (JSON):
+        { "success": true, "text": "<markdown text>" }
+        { "success": false, "error": "<error message>" }
+    """
+    import base64
+    import os
+    import tempfile
+    from docling.document_converter import DocumentConverter
+
+    pdf_bytes_b64 = body.get("pdf_bytes")
+    if not pdf_bytes_b64:
+        return {"success": False, "error": "Missing required field: pdf_bytes"}
+
+    try:
+        pdf_bytes = base64.b64decode(pdf_bytes_b64)
+    except Exception as e:
+        return {"success": False, "error": f"Invalid base64 encoding: {str(e)}"}
+
+    tmp_path = None
+    try:
+        # Write bytes to temp file (docling requires a file path)
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
+            tmp.write(pdf_bytes)
+            tmp_path = tmp.name
+
+        converter = DocumentConverter()
+        result = converter.convert(tmp_path)
+        text = result.document.export_to_markdown()
+
+        if not text or len(text.strip()) < 20:
+            return {"success": False, "error": "Docling extracted empty or near-empty text"}
+
+        return {"success": True, "text": text}
+
+    except Exception as e:
+        return {"success": False, "error": f"Docling extraction failed: {str(e)}"}
+
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)

--- a/backend/src/api/routes/cv_adapter.py
+++ b/backend/src/api/routes/cv_adapter.py
@@ -197,13 +197,28 @@ async def adapt_cv_from_file(
     
     # Read file
     content = await file.read()
-    
-    # Extract text using CV Analyzer agent
-    cv_analyzer = get_cv_agent()
 
+    # Extract text — PDF via Modal (if configured) to avoid Railway OOM from docling
     try:
         if filename.endswith(".pdf"):
-            cv_text = await cv_analyzer.extract_text_from_pdf(content)
+            from src.services.modal_pdf_extractor import (
+                extract_text_via_modal,
+                is_modal_pdf_enabled,
+            )
+
+            if is_modal_pdf_enabled():
+                try:
+                    cv_text = await extract_text_via_modal(content)
+                    logger.info("[cv_adapter] PDF text extracted via Modal")
+                except Exception as modal_exc:
+                    logger.warning(
+                        f"[cv_adapter] Modal extraction failed, falling back to local: {modal_exc}"
+                    )
+                    cv_analyzer = get_cv_agent()
+                    cv_text = await cv_analyzer.extract_text_from_pdf(content)
+            else:
+                cv_analyzer = get_cv_agent()
+                cv_text = await cv_analyzer.extract_text_from_pdf(content)
         else:
             from docx import Document
             doc = Document(io.BytesIO(content))

--- a/backend/src/services/modal_pdf_extractor.py
+++ b/backend/src/services/modal_pdf_extractor.py
@@ -1,0 +1,122 @@
+"""
+Modal PDF Extractor Client
+===========================
+Calls the Modal webhook to extract text from PDFs using Docling.
+
+Usage:
+    from src.services.modal_pdf_extractor import extract_text_via_modal, is_modal_pdf_enabled
+
+    if is_modal_pdf_enabled():
+        cv_text = await extract_text_via_modal(pdf_bytes)
+    else:
+        cv_text = await local_extraction(pdf_bytes)  # fallback
+
+Configuration:
+    Set MODAL_PDF_EXTRACT_URL env var to the deployed Modal webhook URL.
+    Example: https://huntzenproject--huntzen-pdf-extractor-extract-pdf-text.modal.run
+"""
+
+import base64
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Modal webhook URL — set in Railway environment variables
+MODAL_PDF_EXTRACT_URL = os.getenv("MODAL_PDF_EXTRACT_URL", "")
+
+# Max PDF size to send to Modal (10MB)
+MAX_PDF_SIZE_BYTES = 10 * 1024 * 1024
+
+# Timeout for Modal call (2 minutes — docling cold start can take ~30-60s)
+MODAL_TIMEOUT_SECONDS = 120.0
+
+
+def is_modal_pdf_enabled() -> bool:
+    """Check if Modal PDF extraction is configured."""
+    return bool(MODAL_PDF_EXTRACT_URL)
+
+
+async def extract_text_via_modal(pdf_bytes: bytes) -> str:
+    """
+    Extract text from PDF bytes by calling the Modal Docling webhook.
+
+    The PDF bytes are base64-encoded and sent in the JSON body.
+    Modal decodes, runs docling, and returns the extracted markdown text.
+
+    Args:
+        pdf_bytes: Raw PDF file bytes (max 10MB)
+
+    Returns:
+        Extracted text as markdown string
+
+    Raises:
+        RuntimeError: If Modal is not configured, call fails, or extraction errors
+    """
+    if not MODAL_PDF_EXTRACT_URL:
+        raise RuntimeError(
+            "MODAL_PDF_EXTRACT_URL not configured — cannot use Modal PDF extraction"
+        )
+
+    if len(pdf_bytes) > MAX_PDF_SIZE_BYTES:
+        raise RuntimeError(
+            f"PDF too large for Modal extraction ({len(pdf_bytes) / 1024 / 1024:.1f}MB > 10MB limit)"
+        )
+
+    # Encode PDF as base64 for JSON transport
+    pdf_b64 = base64.b64encode(pdf_bytes).decode("utf-8")
+    payload_size_kb = len(pdf_b64) // 1024
+
+    logger.info(
+        f"[ModalPDF] Calling Modal PDF extraction webhook "
+        f"(payload: ~{payload_size_kb}KB, timeout: {MODAL_TIMEOUT_SECONDS}s)"
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=MODAL_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                MODAL_PDF_EXTRACT_URL,
+                json={"pdf_bytes": pdf_b64},
+            )
+
+        if response.status_code != 200:
+            logger.error(
+                f"[ModalPDF] Webhook returned HTTP {response.status_code}: {response.text[:200]}"
+            )
+            raise RuntimeError(
+                f"Modal PDF extraction failed (HTTP {response.status_code})"
+            )
+
+        data = response.json()
+
+        if not data.get("success"):
+            error_msg = data.get("error", "Unknown Modal extraction error")
+            logger.error(f"[ModalPDF] Extraction error: {error_msg}")
+            raise RuntimeError(f"Modal PDF extraction error: {error_msg}")
+
+        text = data.get("text", "")
+        if not text or len(text.strip()) < 20:
+            raise RuntimeError("Modal returned empty or near-empty text")
+
+        logger.info(
+            f"[ModalPDF] Extraction successful — {len(text)} chars extracted"
+        )
+        return text
+
+    except httpx.TimeoutException:
+        logger.error(
+            f"[ModalPDF] Webhook timed out after {MODAL_TIMEOUT_SECONDS}s"
+        )
+        raise RuntimeError(
+            f"Modal PDF extraction timed out after {MODAL_TIMEOUT_SECONDS}s — "
+            "try again (cold start) or check Modal deployment"
+        )
+
+    except RuntimeError:
+        raise
+
+    except Exception as e:
+        logger.error(f"[ModalPDF] Unexpected error: {type(e).__name__}: {e}")
+        raise RuntimeError(f"Modal PDF extraction failed: {str(e)}")


### PR DESCRIPTION
## Problem

`POST /api/cv-adapter/adapt/upload` was crashing on Railway with OOM/500 errors because **docling** (IBM's PDF extraction library) loads ~2-4GB of ML models — exceeding Railway's memory limit.

This caused CV+LM generation to silently fail in the apply modal.

## Solution

Offload PDF text extraction to **Modal Labs** (same approach as CV analysis):

```
Frontend → Railway (adapt/upload) → Modal (docling, 4GB) → Railway (CVAdapterAgent via Groq) → Frontend
```

Only the heavy docling part runs on Modal. The `CVAdapterAgent.run()` (Groq API calls) stays on Railway — it's lightweight.

## Files Changed

| File | Description |
|------|-------------|
| `backend/modal_pdf_extractor_app.py` | New Modal app — deploy with `modal deploy backend/modal_pdf_extractor_app.py` |
| `backend/src/services/modal_pdf_extractor.py` | Railway client — sends PDF bytes (base64) to Modal webhook |
| `backend/src/api/routes/cv_adapter.py` | Uses Modal when `MODAL_PDF_EXTRACT_URL` is set, falls back to local docling |

## Setup Required After Merge

1. **Deploy the Modal function:**
   ```bash
   modal deploy backend/modal_pdf_extractor_app.py
   ```
   Note the webhook URL from the output (format: `https://<workspace>--huntzen-pdf-extractor-extract-pdf-text.modal.run`)

2. **Add env var in Railway:**
   ```
   MODAL_PDF_EXTRACT_URL=<webhook URL from step 1>
   ```

## Behavior

- `MODAL_PDF_EXTRACT_URL` set → PDF extraction via Modal (4GB memory, ~30-60s cold start)
- `MODAL_PDF_EXTRACT_URL` not set → Falls back to local docling (current behavior)
- Modal fails → Falls back to local docling (graceful degradation)
- DOCX files → Unaffected, continue using python-docx locally

Closes #85