### PR TITLE
fix(auth): forgot password + signup confirmation flow + email enumeration protection

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -446,7 +446,9 @@
       "emailNotConfirmed": "Please confirm your email address. We sent you a confirmation email when you signed up. Check your inbox (and spam folder).",
       "invalidCredentials": "Invalid email or password",
       "timeout": "The request is taking too long. Check your internet connection and try again.",
-      "signupFailed": "Failed to create account"
+      "signupFailed": "Failed to create account",
+      "resetPasswordFailed": "Could not send reset link",
+      "resendConfirmationFailed": "Not possible to resend the confirmation email"
     },
     "forgotPassword": {
       "title": "Forgot Password",

--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -433,7 +433,9 @@
         "checkEmailDesc": "(and spam) to confirm your email address before logging in.",
         "goToLogin": "Go to login",
         "close": "Close",
-        "noEmail": "Didn't receive the email? Wait a few minutes or check your spam."
+        "noEmail": "Didn't receive the email? Wait a few minutes or check your spam.",
+        "resendButton": "Resend Email Confirmation",
+        "resendSuccess": "Email resent! Check your mailbox."
       },
       "timeout": {
         "title": "Slow connection detected",
@@ -445,6 +447,33 @@
       "invalidCredentials": "Invalid email or password",
       "timeout": "The request is taking too long. Check your internet connection and try again.",
       "signupFailed": "Failed to create account"
+    },
+    "forgotPassword": {
+      "title": "Forgot Password",
+      "subtitle": "Enter your email address and we'll send you a reset link.",
+      "emailLabel": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "submitButton": "Send the link",
+      "loading": "Sending in progress...",
+      "successTitle": "Email sent!",
+      "successMessage": "If an account exists with this address, you will receive a reset email in a few minutes. Check your spam.",
+      "backToLogin": "Return Login"
+    },
+    "resetPassword": {
+      "title": "New password",
+      "subtitle": "Choose a secure password for your account.",
+      "passwordLabel": "New password",
+      "passwordPlaceholder": "Minimum 6 characters",
+      "confirmLabel": "Confirm Password",
+      "confirmPlaceholder": "Re-enter new password",
+      "submitButton": "Update password",
+      "loading": "Update...",
+      "successMessage": "Password updated successfully.",
+      "mismatchError": "The passwords are not matching",
+      "tooShortError": "Password should be getter than 6 character",
+      "expiredError": "The reset link has expired. Please try again.",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password"
     }
   },
   "dashboard": {

--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -457,7 +457,7 @@
       "loading": "Sending in progress...",
       "successTitle": "Email sent!",
       "successMessage": "If an account exists with this address, you will receive a reset email in a few minutes. Check your spam.",
-      "backToLogin": "Return Login"
+      "backToLogin": "Return to login"
     },
     "resetPassword": {
       "title": "New password",
@@ -470,7 +470,7 @@
       "loading": "Update...",
       "successMessage": "Password updated successfully.",
       "mismatchError": "The passwords are not matching",
-      "tooShortError": "Password should be getter than 6 character",
+      "tooShortError": "Password must be at least 6 characters",
       "expiredError": "The reset link has expired. Please try again.",
       "showPassword": "Show password",
       "hidePassword": "Hide password"

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -433,7 +433,9 @@
         "checkEmailDesc": "(y spam) para confirmar tu correo antes de iniciar sesión.",
         "goToLogin": "Ir al inicio de sesión",
         "close": "Cerrar",
-        "noEmail": "¿No recibiste el correo? Espera unos minutos o revisa tu spam."
+        "noEmail": "¿No recibiste el correo? Espera unos minutos o revisa tu spam.",
+        "resendButton": "Reenviar correo electrónico de confirmación",
+        "resendSuccess": "Correo electrónico reenviado! Compruebe su buzón de correo electrónico."
       },
       "timeout": {
         "title": "Conexión lenta detectada",
@@ -445,6 +447,33 @@
       "invalidCredentials": "Correo o contraseña inválidos",
       "timeout": "La solicitud está tardando demasiado. Verifique su conexión a Internet e inténtelo de nuevo.",
       "signupFailed": "Error al crear la cuenta"
+    },
+    "forgotPassword": {
+      "title": "Contraseña olvidada",
+      "subtitle": "Introduzca su dirección de correo electrónico y le enviaremos un enlace de restablecimiento.",
+      "emailLabel": "Correo electrónico",
+      "emailPlaceholder": "vous@example.com",
+      "submitButton": "Enviar enlace",
+      "loading": "Enviando...",
+      "successTitle": "Correo electrónico enviado",
+      "successMessage": "Si existe una cuenta con esta dirección, recibirá un correo electrónico de restablecimiento en unos minutos. Comprueba tu spam.",
+      "backToLogin": "Volver al inicio de sesión"
+    },
+    "resetPassword": {
+      "title": "Nueva contraseña",
+      "subtitle": "Elige una contraseña segura para tu cuenta.",
+      "passwordLabel": "Nueva contraseña",
+      "passwordPlaceholder": "Mínimo 6 caracteres",
+      "confirmLabel": "Confirmar la contraseña",
+      "confirmPlaceholder": "Vuelva a escribir su nueva contraseña:",
+      "submitButton": "Actualizar cifrada",
+      "loading": "Actualización...",
+      "successMessage": "¡Contraseña actualizada con éxito!",
+      "mismatchError": "Las contraseñas no coinciden ",
+      "tooShortError": "La contraseña debe tener 6 caracteres mínimo.",
+      "expiredError": "El enlace de restablecimiento ha caducado. Por favor, vuelva a intentarlo.",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña"
     }
   },
   "dashboard": {

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -466,7 +466,7 @@
       "passwordPlaceholder": "Mínimo 6 caracteres",
       "confirmLabel": "Confirmar la contraseña",
       "confirmPlaceholder": "Vuelva a escribir su nueva contraseña:",
-      "submitButton": "Actualizar cifrada",
+      "submitButton": "Actualizar contraseña",
       "loading": "Actualización...",
       "successMessage": "¡Contraseña actualizada con éxito!",
       "mismatchError": "Las contraseñas no coinciden ",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -452,7 +452,7 @@
       "title": "Contraseña olvidada",
       "subtitle": "Introduzca su dirección de correo electrónico y le enviaremos un enlace de restablecimiento.",
       "emailLabel": "Correo electrónico",
-      "emailPlaceholder": "vous@example.com",
+      "emailPlaceholder": "tu@ejemplo.com",
       "submitButton": "Enviar enlace",
       "loading": "Enviando...",
       "successTitle": "Correo electrónico enviado",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -446,7 +446,9 @@
       "emailNotConfirmed": "Por favor confirme su dirección de correo. Le enviamos un correo de confirmación al registrarse. Revise su bandeja de entrada (y spam).",
       "invalidCredentials": "Correo o contraseña inválidos",
       "timeout": "La solicitud está tardando demasiado. Verifique su conexión a Internet e inténtelo de nuevo.",
-      "signupFailed": "Error al crear la cuenta"
+      "signupFailed": "Error al crear la cuenta",
+      "resetPasswordFailed": "No se ha podido enviar el enlace de restablecimiento",
+      "resendConfirmationFailed": "No se ha podido devolver el correo electrónico de confirmación"
     },
     "forgotPassword": {
       "title": "Contraseña olvidada",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -433,12 +433,41 @@
         "checkEmailDesc": "(et vos spams) pour confirmer votre adresse email avant de vous connecter.",
         "goToLogin": "Aller à la connexion",
         "close": "Fermer",
-        "noEmail": "Vous n'avez pas reçu l'email ? Attendez quelques minutes ou vérifiez vos spams."
+        "noEmail": "Vous n'avez pas reçu l'email ? Attendez quelques minutes ou vérifiez vos spams.",
+        "resendButton": "Renvoyer l'email de confirmation",
+        "resendSuccess": "Email renvoyé ! Vérifiez votre boîte mail."
       },
       "timeout": {
         "title": "Connexion lente détectée",
         "description": "La requête a pris trop de temps. Vérifiez votre connexion internet et réessayez dans quelques instants."
       }
+    },
+    "forgotPassword": {
+      "title": "Mot de passe oublié",
+      "subtitle": "Saisissez votre adresse email et nous vous enverrons un lien de réinitialisation.",
+      "emailLabel": "Adresse email",
+      "emailPlaceholder": "vous@example.com",
+      "submitButton": "Envoyer le lien",
+      "loading": "Envoi en cours...",
+      "successTitle": "Email envoyé !",
+      "successMessage": "Si un compte existe avec cette adresse, vous recevrez un email de réinitialisation dans quelques minutes. Vérifiez vos spams.",
+      "backToLogin": "Retour à la connexion"
+    },
+    "resetPassword": {
+      "title": "Nouveau mot de passe",
+      "subtitle": "Choisissez un mot de passe sécurisé pour votre compte.",
+      "passwordLabel": "Nouveau mot de passe",
+      "passwordPlaceholder": "Minimum 6 caractères",
+      "confirmLabel": "Confirmer le mot de passe",
+      "confirmPlaceholder": "Retapez votre mot de passe",
+      "submitButton": "Mettre à jour le mot de passe",
+      "loading": "Mise à jour...",
+      "successMessage": "Mot de passe mis à jour avec succès !",
+      "mismatchError": "Les mots de passe ne correspondent pas",
+      "tooShortError": "Le mot de passe doit contenir au moins 6 caractères",
+      "expiredError": "Le lien de réinitialisation a expiré. Veuillez recommencer.",
+      "showPassword": "Afficher le mot de passe",
+      "hidePassword": "Masquer le mot de passe"
     },
     "errors": {
       "emailNotConfirmed": "Veuillez confirmer votre adresse email. Nous vous avons envoyé un email de confirmation lors de votre inscription. Vérifiez votre boîte mail (et vos spams).",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -473,7 +473,9 @@
       "emailNotConfirmed": "Veuillez confirmer votre adresse email. Nous vous avons envoyé un email de confirmation lors de votre inscription. Vérifiez votre boîte mail (et vos spams).",
       "invalidCredentials": "Email ou mot de passe invalide",
       "timeout": "La requête prend trop de temps. Vérifiez votre connexion internet et réessayez.",
-      "signupFailed": "Échec de la création du compte"
+      "signupFailed": "Échec de la création du compte",
+      "resetPasswordFailed": "Impossible d'envoyer le lien de réinitialisation",
+      "resendConfirmationFailed": "Impossible de renvoyer l'email de confirmation"
     }
   },
   "dashboard": {

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -452,7 +452,7 @@
       "title": "Esqueci-me da palavra-passe",
       "subtitle": "Introduza o seu endereço de e-mail e enviar-lhe-emos uma ligação de reposição.",
       "emailLabel": "Endereço de e-mail",
-      "emailPlaceholder": "vous@example.com",
+      "emailPlaceholder": "voce@exemplo.com",
       "submitButton": "Enviar Hiperligação",
       "loading": "Envio em curso...",
       "successTitle": "E-mail enviado",
@@ -472,7 +472,7 @@
       "mismatchError": "As palavras-passe não coincidem",
       "tooShortError": "A palavra-passe deve conter pelo menos 8 carateres.",
       "expiredError": "O link de redefinição expirou. Tente novamente.",
-      "showPassword": "Mostrar a & senha",
+      "showPassword": "Mostrar senha",
       "hidePassword": "Ocultar palavra-passe"
     }
   },

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -433,7 +433,9 @@
         "checkEmailDesc": "(e spam) para confirmar seu email antes de fazer login.",
         "goToLogin": "Ir para o login",
         "close": "Fechar",
-        "noEmail": "Não recebeu o email? Aguarde alguns minutos ou verifique o spam."
+        "noEmail": "Não recebeu o email? Aguarde alguns minutos ou verifique o spam.",
+        "resendButton": "Reenviar e-mail de confirmação",
+        "resendSuccess": "E-mail reenviado! Verifique a sua caixa de correio."
       },
       "timeout": {
         "title": "Conexão lenta detectada",
@@ -445,6 +447,33 @@
       "invalidCredentials": "E-mail ou senha inválidos",
       "timeout": "A solicitação está demorando muito. Verifique sua conexão com a Internet e tente novamente.",
       "signupFailed": "Falha ao criar a conta"
+    },
+    "forgotPassword": {
+      "title": "Esqueci-me da palavra-passe",
+      "subtitle": "Introduza o seu endereço de e-mail e enviar-lhe-emos uma ligação de reposição.",
+      "emailLabel": "Endereço de e-mail",
+      "emailPlaceholder": "vous@example.com",
+      "submitButton": "Enviar Hiperligação",
+      "loading": "Envio em curso...",
+      "successTitle": "E-mail enviado",
+      "successMessage": "Se existir uma conta com este endereço, receberá um e-mail de redefinição dentro de alguns minutos. Verifique o seu spam.",
+      "backToLogin": "Voltar ao Início de sessão"
+    },
+    "resetPassword": {
+      "title": "Nova palavra-passe",
+      "subtitle": "Escolha uma palavra-passe segura para a sua conta.",
+      "passwordLabel": "Nova palavra-passe",
+      "passwordPlaceholder": "Mínimo de 6 caracteres",
+      "confirmLabel": "Confirmar a palavra-passe",
+      "confirmPlaceholder": "Reintroduza a sua nova palavra-passe",
+      "submitButton": "Actualizar como cifrada",
+      "loading": "Atualização...",
+      "successMessage": "Palavra-passe atualizada com sucesso!",
+      "mismatchError": "As palavras-passe não coincidem",
+      "tooShortError": "A palavra-passe deve conter pelo menos 8 carateres.",
+      "expiredError": "O link de redefinição expirou. Tente novamente.",
+      "showPassword": "Mostrar a & senha",
+      "hidePassword": "Ocultar palavra-passe"
     }
   },
   "dashboard": {

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -446,7 +446,9 @@
       "emailNotConfirmed": "Por favor confirme seu endereço de e-mail. Enviamos um e-mail de confirmação quando você se cadastrou. Verifique sua caixa de entrada (e spam).",
       "invalidCredentials": "E-mail ou senha inválidos",
       "timeout": "A solicitação está demorando muito. Verifique sua conexão com a Internet e tente novamente.",
-      "signupFailed": "Falha ao criar a conta"
+      "signupFailed": "Falha ao criar a conta",
+      "resetPasswordFailed": "Não foi possível enviar o link de redefinição",
+      "resendConfirmationFailed": "Não foi possível reenviar o e-mail de confirmação"
     },
     "forgotPassword": {
       "title": "Esqueci-me da palavra-passe",

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -466,7 +466,7 @@
       "passwordPlaceholder": "Mínimo de 6 caracteres",
       "confirmLabel": "Confirmar a palavra-passe",
       "confirmPlaceholder": "Reintroduza a sua nova palavra-passe",
-      "submitButton": "Actualizar como cifrada",
+      "submitButton": "Atualizar senha",
       "loading": "Atualização...",
       "successMessage": "Palavra-passe atualizada com sucesso!",
       "mismatchError": "As palavras-passe não coincidem",

--- a/frontend-next/src/app/auth/callback/route.ts
+++ b/frontend-next/src/app/auth/callback/route.ts
@@ -56,7 +56,11 @@ export async function GET(request: NextRequest) {
 
       // Password reset flow: redirect to reset-password page
       if (type === "recovery") {
-        return NextResponse.redirect(`${origin}/reset-password`);
+        const recoveryResponse = NextResponse.redirect(
+          `${origin}/reset-password`,
+        );
+        recoveryResponse.cookies.delete("huntzen_redirect_after_auth");
+        return recoveryResponse;
       }
 
       // OAuth / email confirmation flow: redirect to final destination

--- a/frontend-next/src/app/auth/callback/route.ts
+++ b/frontend-next/src/app/auth/callback/route.ts
@@ -3,79 +3,87 @@
  * Handles OAuth redirect from Google/Email confirmation
  */
 
-import { createClient } from '@/lib/supabase/server'
-import { NextResponse } from 'next/server'
-import type { NextRequest } from 'next/server'
-import { logSecurityEvent } from '@/lib/security/logger'
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { logSecurityEvent } from "@/lib/security/logger";
 
 export async function GET(request: NextRequest) {
-  const requestUrl = new URL(request.url)
-  const code = requestUrl.searchParams.get('code')
-  const error = requestUrl.searchParams.get('error')
-  const errorDescription = requestUrl.searchParams.get('error_description')
-  const origin = requestUrl.origin
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const error = requestUrl.searchParams.get("error");
+  const errorDescription = requestUrl.searchParams.get("error_description");
+  const origin = requestUrl.origin;
 
   // Read redirect cookie set before OAuth flow
-  const redirectCookie = request.cookies.get('huntzen_redirect_after_auth')
-  const redirectTo = redirectCookie?.value ? decodeURIComponent(redirectCookie.value) : null
+  const redirectCookie = request.cookies.get("huntzen_redirect_after_auth");
+  const redirectTo = redirectCookie?.value
+    ? decodeURIComponent(redirectCookie.value)
+    : null;
 
   // Handle OAuth errors from Google
   if (error) {
     await logSecurityEvent({
-      eventType: 'auth.oauth_callback_error',
-      severity: 'warning',
-      metadata: { error, error_description: errorDescription }
-    })
+      eventType: "auth.oauth_callback_error",
+      severity: "warning",
+      metadata: { error, error_description: errorDescription },
+    });
 
     return NextResponse.redirect(
-      `${origin}/login?error=${encodeURIComponent(errorDescription || error)}`
-    )
+      `${origin}/login?error=${encodeURIComponent(errorDescription || error)}`,
+    );
   }
 
   if (code) {
-    const supabase = await createClient()
+    const supabase = await createClient();
+    const type = requestUrl.searchParams.get("type");
 
     // Exchange code for session
-    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error && data.session) {
       // Log successful OAuth callback
       await logSecurityEvent({
-        eventType: 'auth.oauth_callback_success',
-        severity: 'info',
+        eventType: "auth.oauth_callback_success",
+        severity: "info",
         userId: data.user.id,
         metadata: {
           email: data.user.email,
-          provider: data.user.app_metadata?.provider
-        }
-      })
+          provider: data.user.app_metadata?.provider,
+          type: type || "oauth",
+        },
+      });
 
-      // Determine final redirect destination from cookie or default to /jobs
-      const finalRedirect = redirectTo && redirectTo.startsWith('/')
-        ? redirectTo
-        : '/jobs'
+      // Password reset flow: redirect to reset-password page
+      if (type === "recovery") {
+        return NextResponse.redirect(`${origin}/reset-password`);
+      }
 
-      const response = NextResponse.redirect(`${origin}${finalRedirect}`)
+      // OAuth / email confirmation flow: redirect to final destination
+      const finalRedirect =
+        redirectTo && redirectTo.startsWith("/") ? redirectTo : "/jobs";
+
+      const response = NextResponse.redirect(`${origin}${finalRedirect}`);
 
       // Delete cookie after successful use
-      response.cookies.delete('huntzen_redirect_after_auth')
+      response.cookies.delete("huntzen_redirect_after_auth");
 
-      return response
+      return response;
     }
 
     // Log session exchange failure
     await logSecurityEvent({
-      eventType: 'auth.session_exchange_failed',
-      severity: 'critical',
-      metadata: { error: error?.message }
-    })
+      eventType: "auth.session_exchange_failed",
+      severity: "critical",
+      metadata: { error: error?.message },
+    });
 
     // Auth error, redirect to login with generic error
     return NextResponse.redirect(
-      `${origin}/login?error=Authentication failed. Please try again.`
-    )
+      `${origin}/login?error=Authentication failed. Please try again.`,
+    );
   }
 
   // No code provided, redirect to login
-  return NextResponse.redirect(`${origin}/login`)
+  return NextResponse.redirect(`${origin}/login`);
 }

--- a/frontend-next/src/app/forgot-password/page.tsx
+++ b/frontend-next/src/app/forgot-password/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { useAuth } from "@/contexts/auth-context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Loader2, Mail, CheckCircle2, ArrowLeft } from "lucide-react";
+import { AuthLayout } from "@/components/auth/auth-layout";
+import { useTranslations } from "next-intl";
+
+export default function ForgotPasswordPage() {
+  const { resetPasswordForEmail } = useAuth();
+  const t = useTranslations("auth.forgotPassword");
+
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      await resetPasswordForEmail(email);
+    } catch {
+      // resetPasswordForEmail never throws (prevents email enumeration)
+    } finally {
+      // Always show success to prevent email enumeration attacks
+      setSuccess(true);
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <AuthLayout>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-6 text-center"
+        >
+          <div className="flex justify-center">
+            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+              <CheckCircle2 className="w-10 h-10 text-green-600" />
+            </div>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">{t("successTitle")}</h1>
+          <p className="text-gray-600 leading-relaxed">{t("successMessage")}</p>
+          <Link href="/login">
+            <Button className="w-full h-12 bg-[#00D9FF] hover:bg-[#00C4EA] text-white font-bold rounded-xl">
+              {t("backToLogin")}
+            </Button>
+          </Link>
+        </motion.div>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout>
+      <div className="space-y-8">
+        <div>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 mb-6 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            {t("backToLogin")}
+          </Link>
+          <motion.h1
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-3xl font-bold text-gray-900 mb-2"
+          >
+            {t("title")}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="text-gray-600"
+          >
+            {t("subtitle")}
+          </motion.p>
+        </div>
+
+        <motion.form
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          onSubmit={handleSubmit}
+          className="space-y-4"
+        >
+          <div className="space-y-2">
+            <Label htmlFor="email" className="text-sm font-medium text-gray-700">
+              {t("emailLabel")}
+            </Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Input
+                id="email"
+                type="email"
+                placeholder={t("emailPlaceholder")}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={loading}
+                className="pl-10 h-12 bg-white border-gray-300 focus:border-[#00D9FF] focus:ring-[#00D9FF]"
+              />
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full h-12 bg-[#00D9FF] hover:bg-[#00C4EA] text-white font-bold shadow-lg shadow-[#00D9FF]/30 transition-all mt-6 rounded-xl"
+            size="lg"
+            disabled={loading}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                {t("loading")}
+              </>
+            ) : (
+              t("submitButton")
+            )}
+          </Button>
+        </motion.form>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend-next/src/app/reset-password/page.tsx
+++ b/frontend-next/src/app/reset-password/page.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Loader2,
+  Lock as LockIcon,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+} from "lucide-react";
+import { AuthLayout } from "@/components/auth/auth-layout";
+import { useTranslations } from "next-intl";
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const t = useTranslations("auth.resetPassword");
+  const tForgot = useTranslations("auth.forgotPassword");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError(t("mismatchError"));
+      return;
+    }
+
+    if (password.length < 6) {
+      setError(t("tooShortError"));
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const supabase = createClient();
+      const { error: updateError } = await supabase.auth.updateUser({
+        password,
+      });
+
+      if (updateError) {
+        if (
+          updateError.message.toLowerCase().includes("expired") ||
+          updateError.message.toLowerCase().includes("invalid")
+        ) {
+          setError(t("expiredError"));
+        } else {
+          setError(updateError.message);
+        }
+        return;
+      }
+
+      setSuccess(true);
+      // Auto-redirect to login after 2s
+      setTimeout(() => router.push("/login"), 2000);
+    } catch (err: any) {
+      setError(err.message || "Failed to update password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <AuthLayout>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-6 text-center"
+        >
+          <div className="flex justify-center">
+            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+              <CheckCircle2 className="w-10 h-10 text-green-600" />
+            </div>
+          </div>
+          <p className="text-lg font-semibold text-gray-900">
+            {t("successMessage")}
+          </p>
+          <Link href="/login">
+            <Button className="w-full h-12 bg-[#00D9FF] hover:bg-[#00C4EA] text-white font-bold rounded-xl">
+              {tForgot("backToLogin")}
+            </Button>
+          </Link>
+        </motion.div>
+      </AuthLayout>
+    );
+  }
+
+  return (
+    <AuthLayout>
+      <div className="space-y-8">
+        <div>
+          <motion.h1
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="text-3xl font-bold text-gray-900 mb-2"
+          >
+            {t("title")}
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="text-gray-600"
+          >
+            {t("subtitle")}
+          </motion.p>
+        </div>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <motion.form
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          onSubmit={handleSubmit}
+          className="space-y-4"
+        >
+          <div className="space-y-2">
+            <Label
+              htmlFor="password"
+              className="text-sm font-medium text-gray-700"
+            >
+              {t("passwordLabel")}
+            </Label>
+            <div className="relative">
+              <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                placeholder={t("passwordPlaceholder")}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={loading}
+                minLength={6}
+                className="pl-10 pr-10 h-12 bg-white border-gray-300 focus:border-[#00D9FF] focus:ring-[#00D9FF]"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label={showPassword ? t("hidePassword") : t("showPassword")}
+              >
+                {showPassword ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label
+              htmlFor="confirmPassword"
+              className="text-sm font-medium text-gray-700"
+            >
+              {t("confirmLabel")}
+            </Label>
+            <div className="relative">
+              <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <Input
+                id="confirmPassword"
+                type={showConfirm ? "text" : "password"}
+                placeholder={t("confirmPlaceholder")}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                disabled={loading}
+                className="pl-10 pr-10 h-12 bg-white border-gray-300 focus:border-[#00D9FF] focus:ring-[#00D9FF]"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirm(!showConfirm)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label={showConfirm ? t("hidePassword") : t("showPassword")}
+              >
+                {showConfirm ? (
+                  <EyeOff className="w-5 h-5" />
+                ) : (
+                  <Eye className="w-5 h-5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full h-12 bg-[#00D9FF] hover:bg-[#00C4EA] text-white font-bold shadow-lg shadow-[#00D9FF]/30 transition-all mt-6 rounded-xl"
+            size="lg"
+            disabled={loading}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                {t("loading")}
+              </>
+            ) : (
+              t("submitButton")
+            )}
+          </Button>
+        </motion.form>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/frontend-next/src/app/signup/page.tsx
+++ b/frontend-next/src/app/signup/page.tsx
@@ -31,8 +31,14 @@ import { useTranslations } from "next-intl";
 function SignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { user, signInWithGoogle, signUpWithEmail, error, clearError } =
-    useAuth();
+  const {
+    user,
+    signInWithGoogle,
+    signUpWithEmail,
+    resendConfirmationEmail,
+    error,
+    clearError,
+  } = useAuth();
   const t = useTranslations("auth.signup");
 
   // Detect CV analysis redirect
@@ -55,6 +61,22 @@ function SignupForm() {
   const [isTimeout, setIsTimeout] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [resendSuccess, setResendSuccess] = useState(false);
+
+  const handleResendEmail = async () => {
+    const emailToResend = emailFromUrl || email;
+    if (!emailToResend || resendLoading || resendSuccess) return;
+    try {
+      setResendLoading(true);
+      await resendConfirmationEmail(emailToResend);
+      setResendSuccess(true);
+    } catch {
+      // Error is handled by auth-context and shown via the error state
+    } finally {
+      setResendLoading(false);
+    }
+  };
 
   // Close modal and clean URL
   const closeSuccessModal = () => {
@@ -104,7 +126,10 @@ function SignupForm() {
     } catch (err: any) {
       console.error("[SIGNUP] Error:", err);
 
-      if (err.message?.includes("prend trop de temps") || err.message?.includes("timeout")) {
+      if (
+        err.message?.includes("prend trop de temps") ||
+        err.message?.includes("timeout")
+      ) {
         setIsTimeout(true);
       }
     } finally {
@@ -186,10 +211,31 @@ function SignupForm() {
                 </Button>
               </div>
 
-              {/* Help text */}
-              <p className="text-xs text-center text-gray-500 mt-4">
-                {t("success.noEmail")}
-              </p>
+              {/* Resend email */}
+              <div className="mt-4 text-center">
+                {resendSuccess ? (
+                  <p className="text-sm text-green-600 font-medium">
+                    {t("success.resendSuccess")}
+                  </p>
+                ) : (
+                  <>
+                    <p className="text-xs text-gray-500 mb-2">
+                      {t("success.noEmail")}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleResendEmail}
+                      disabled={resendLoading}
+                      className="text-sm text-[#00D9FF] hover:text-[#00C4EA] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
+                    >
+                      {resendLoading && (
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                      )}
+                      {t("success.resendButton")}
+                    </button>
+                  </>
+                )}
+              </div>
             </motion.div>
           </motion.div>
         )}
@@ -286,7 +332,10 @@ function SignupForm() {
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
           >
-            <Alert variant="destructive" className="border-orange-200 bg-orange-50">
+            <Alert
+              variant="destructive"
+              className="border-orange-200 bg-orange-50"
+            >
               <AlertCircle className="h-4 w-4 text-orange-600" />
               <AlertDescription className="text-orange-800">
                 <strong>{t("timeout.title")}</strong>
@@ -425,7 +474,9 @@ function SignupForm() {
                 type="button"
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                aria-label={showPassword ? t("hidePassword") : t("showPassword")}
+                aria-label={
+                  showPassword ? t("hidePassword") : t("showPassword")
+                }
               >
                 {showPassword ? (
                   <EyeOff className="w-5 h-5" />
@@ -459,7 +510,9 @@ function SignupForm() {
                 type="button"
                 onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                aria-label={showConfirmPassword ? t("hidePassword") : t("showPassword")}
+                aria-label={
+                  showConfirmPassword ? t("hidePassword") : t("showPassword")
+                }
               >
                 {showConfirmPassword ? (
                   <EyeOff className="w-5 h-5" />

--- a/frontend-next/src/components/layout/sidebar.tsx
+++ b/frontend-next/src/components/layout/sidebar.tsx
@@ -152,11 +152,7 @@ export function Sidebar({ className }: SidebarProps) {
   const SidebarContent = () => (
     <div className="flex flex-col h-full bg-[#0D1F3C]">
       {/* Header with Logo */}
-      <motion.div
-        initial={{ opacity: 0, y: -10 }}
-        animate={{ opacity: 1, y: 0 }}
-        className="sidebar-header flex items-center justify-between p-6 border-b border-white/10"
-      >
+      <div className="sidebar-header flex items-center justify-between p-6 border-b border-white/10">
         <Link href="/" className="sidebar-logo flex items-center gap-2.5 group">
           <TextLogo
             size="md"
@@ -171,18 +167,14 @@ export function Sidebar({ className }: SidebarProps) {
         >
           <X className="w-5 h-5" />
         </button>
-      </motion.div>
+      </div>
 
       {/* Navigation */}
       <nav className="flex-1 py-6 overflow-y-auto">
         <div className="px-4">
-          <motion.span
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="nav-section-label block text-white/40 text-[0.65rem] font-bold tracking-widest px-3 mb-4"
-          >
+          <span className="nav-section-label block text-white/40 text-[0.65rem] font-bold tracking-widest px-3 mb-4">
             {t("label")}
-          </motion.span>
+          </span>
 
           {navigation.map((item, index) => {
             const isActive =
@@ -190,12 +182,7 @@ export function Sidebar({ className }: SidebarProps) {
             const isLocked = item.premium && (!user || isFreePlan);
 
             return (
-              <motion.div
-                key={item.name}
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: index * 0.05 }}
-              >
+              <div key={item.name}>
                 <Link
                   href={isLocked ? (user ? "#" : "/login") : item.href}
                   onClick={(e) => {
@@ -242,16 +229,13 @@ export function Sidebar({ className }: SidebarProps) {
                   )}
                   {isLocked && <Lock className="w-4 h-4 text-white/30" />}
                 </Link>
-              </motion.div>
+              </div>
             );
           })}
 
           {/* Mon Utilisation button - only show if logged in */}
           {user && (
-            <motion.button
-              initial={{ opacity: 0, x: -20 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: navigation.length * 0.05 }}
+            <button
               onClick={() => {
                 setIsUsageModalOpen(true);
                 setIsMobileMenuOpen(false);
@@ -262,19 +246,15 @@ export function Sidebar({ className }: SidebarProps) {
               <span className="nav-label flex-1 text-left">
                 {t("nav.myUsage")}
               </span>
-            </motion.button>
+            </button>
           )}
         </div>
 
         {/* Usage summary for free users - only show if logged in */}
         {user && isFreePlan && (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="px-4 mt-6"
-          >
+          <div className="px-4 mt-6">
             <UsageSummary className="p-4 rounded-xl bg-white/5 border border-white/10" />
-          </motion.div>
+          </div>
         )}
       </nav>
 
@@ -289,10 +269,7 @@ export function Sidebar({ className }: SidebarProps) {
             </div>
           </div>
         ) : user ? (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
+          <div>
             <Link
               href="/profile"
               onClick={() => setIsMobileMenuOpen(false)}
@@ -323,12 +300,9 @@ export function Sidebar({ className }: SidebarProps) {
                 <p className="text-xs text-white/50 truncate">{user.email}</p>
               </div>
             </Link>
-          </motion.div>
+          </div>
         ) : (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
+          <div>
             <Link
               href="/login"
               className="nav-item flex items-center gap-3 px-4 py-3 mb-1 rounded-xl text-sm font-medium transition-all text-white/70 hover:bg-white/8 hover:text-white w-full group"
@@ -338,7 +312,7 @@ export function Sidebar({ className }: SidebarProps) {
                 {t("footer.login")}
               </span>
             </Link>
-          </motion.div>
+          </div>
         )}
 
         {/* Upgrade button for free users - only show if logged in */}

--- a/frontend-next/src/contexts/auth-context.tsx
+++ b/frontend-next/src/contexts/auth-context.tsx
@@ -41,6 +41,8 @@ interface AuthContextType {
     fullName: string,
   ) => Promise<void>;
   signOut: () => Promise<void>;
+  resetPasswordForEmail: (email: string) => Promise<void>;
+  resendConfirmationEmail: (email: string) => Promise<void>;
   error: string | null;
   clearError: () => void;
 }
@@ -316,14 +318,16 @@ export function AuthProvider({
         });
       }
 
-      // Show success message
       setError(null);
-
-      // Reset loading AVANT la redirection
       setLoading(false);
 
-      // Redirect to signup success (will show modal)
-      router.push("/signup?success=true&email=" + encodeURIComponent(email));
+      // If session exists, email confirmation is disabled → user is already logged in
+      // If session is null, email confirmation is required → show success modal
+      if (data?.session) {
+        router.push("/jobs");
+      } else {
+        router.push("/signup?success=true&email=" + encodeURIComponent(email));
+      }
     } catch (err: any) {
       devError("Sign up error:", err);
 
@@ -332,6 +336,38 @@ export function AuthProvider({
 
       setError(errorMessage);
       setLoading(false);
+      throw err;
+    }
+  };
+
+  const resetPasswordForEmail = async (email: string) => {
+    try {
+      setError(null);
+      const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
+      });
+      if (error) throw error;
+    } catch (err: any) {
+      devError("Reset password error:", err);
+      setError(err.message || "Failed to send reset email");
+      throw err;
+    }
+  };
+
+  const resendConfirmationEmail = async (email: string) => {
+    try {
+      setError(null);
+      const { error } = await supabaseClient.auth.resend({
+        type: "signup",
+        email,
+        options: {
+          emailRedirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+      if (error) throw error;
+    } catch (err: any) {
+      devError("Resend confirmation error:", err);
+      setError(err.message || "Failed to resend confirmation email");
       throw err;
     }
   };
@@ -387,6 +423,8 @@ export function AuthProvider({
         signInWithEmail,
         signUpWithEmail,
         signOut,
+        resetPasswordForEmail,
+        resendConfirmationEmail,
         error,
         clearError,
       }}

--- a/frontend-next/src/contexts/auth-context.tsx
+++ b/frontend-next/src/contexts/auth-context.tsx
@@ -341,16 +341,13 @@ export function AuthProvider({
   };
 
   const resetPasswordForEmail = async (email: string) => {
-    try {
-      setError(null);
-      const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
-      });
-      if (error) throw error;
-    } catch (err: any) {
-      devError("Reset password error:", err);
-      setError(err.message || "Failed to send reset email");
-      throw err;
+    setError(null);
+    const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
+    });
+    // Log in dev only — never expose to user to prevent email enumeration
+    if (error) {
+      devError("Reset password error (not surfaced):", error);
     }
   };
 
@@ -367,7 +364,7 @@ export function AuthProvider({
       if (error) throw error;
     } catch (err: any) {
       devError("Resend confirmation error:", err);
-      setError(err.message || "Failed to resend confirmation email");
+      setError(err.message || tErr("resendConfirmationFailed"));
       throw err;
     }
   };

--- a/frontend-next/src/hooks/use-subscription-api.ts
+++ b/frontend-next/src/hooks/use-subscription-api.ts
@@ -165,6 +165,10 @@ export function useSubscriptionApi(): SubscriptionApiData {
         return;
       }
 
+      // Signal loading immediately — prevents race condition where
+      // auth.session is set but isLoading is still false from previous state
+      setData((prev) => ({ ...prev, isLoading: true, error: null }));
+
       // Fetch from backend
       if (!process.env.NEXT_PUBLIC_BACKEND_URL) {
         throw new Error("NEXT_PUBLIC_BACKEND_URL is not configured");
@@ -358,34 +362,32 @@ export function useSubscriptionApi(): SubscriptionApiData {
 export function useSubscriptionSync() {
   const { refetch } = useSubscriptionApi();
 
+  // Keep ref always up-to-date so the listener can call the latest refetch
+  // without needing to re-register itself every time refetch changes
+  const refetchRef = useRef<() => Promise<void>>(refetch);
+  useEffect(() => {
+    refetchRef.current = refetch;
+  });
+
+  // Register listener ONCE — never re-registers even if refetch changes
   useEffect(() => {
     const handleSubscriptionChange = () => {
       console.log("[SubscriptionSync] Subscription changed event detected");
-
-      // Clear localStorage cache immediately
       localStorage.removeItem(CACHE_KEY);
       localStorage.removeItem(CACHE_EXPIRY_KEY);
-
-      // Refetch fresh data from API
-      refetch();
-
+      refetchRef.current();
       console.log("[SubscriptionSync] Cache invalidated and refetch triggered");
     };
 
-    // Listen for custom subscription-changed event
-    // Dispatched from payment/success page after Stripe webhook processes
     window.addEventListener("subscription-changed", handleSubscriptionChange);
-
-    console.log("[SubscriptionSync] Event listener registered");
 
     return () => {
       window.removeEventListener(
         "subscription-changed",
         handleSubscriptionChange,
       );
-      console.log("[SubscriptionSync] Event listener removed");
     };
-  }, [refetch]);
+  }, []); // empty deps — registers exactly once on mount
 
   return {
     invalidateCache: refetch,


### PR DESCRIPTION
Closes #87

## Summary

- **404 on `/forgot-password`**: created `/forgot-password` page with email enumeration protection (always shows success, never reveals if email exists)
- **No signup success screen**: fixed `signUpWithEmail` to check `data?.session` before redirecting — when email confirmation is disabled, Supabase returns a session immediately and the user is redirected to `/jobs` instead of being stuck at the success modal blocked by middleware
- **Password reset flow**: new `/reset-password` page + `type=recovery` detection in `/auth/callback` → redirects to reset-password instead of `/jobs`
- **Resend confirmation email**: button added to the signup success modal
- **i18n**: `forgotPassword` + `resetPassword` namespaces in fr/en/es/pt

## Files changed

- `src/app/forgot-password/page.tsx` — new page
- `src/app/reset-password/page.tsx` — new page
- `src/app/signup/page.tsx` — resend button in success modal
- `src/app/auth/callback/route.ts` — `type=recovery` handling + cookie cleanup
- `src/contexts/auth-context.tsx` — `resetPasswordForEmail` + `resendConfirmationEmail` + signup session check
- `messages/fr.json` + `en.json` + `es.json` + `pt.json` — auth i18n keys

## Test plan

- [ ] Click "Mot de passe oublié ?" on login page → `/forgot-password` loads (no 404)
- [ ] Submit email → success screen shown regardless of whether email exists
- [ ] Click reset link in email → redirected to `/reset-password`, not `/jobs`
- [ ] Set new password → success + auto-redirect to login after 2s
- [ ] Sign up with new email → success modal appears (email confirmation enabled)
- [ ] Sign up when email confirmation disabled → directly to `/jobs`
- [ ] Click "Renvoyer l'email" in modal → loading spinner → "Email renvoyé !" green text
- [ ] All text displays correctly in fr/en/es/pt