### PR TITLE
fix(auth): /auth/recovery page to handle password reset email links (PKCE + implicit)

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -393,3 +393,48 @@ async def get_current_user(authorization: Optional[str] = Header(None)) -> dict:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"Authentication failed: {str(e)}"
         )
+
+
+CurrentUserDep = Annotated[dict, Depends(get_current_user)]
+
+
+async def get_current_admin(current_user: dict = Depends(get_current_user)) -> dict:
+    """
+    Verify the current user has admin privileges (is_admin = TRUE in profiles).
+
+    Raises:
+        HTTPException 403: If user is not an admin
+    """
+    supabase = get_supabase_client()
+    user_id = current_user["id"]
+
+    try:
+        result = supabase.table("profiles").select("is_admin").eq("id", user_id).single().execute()
+        if not result.data or not result.data.get("is_admin"):
+            # Log unauthorized admin access attempt
+            try:
+                supabase.rpc("log_security_event", {
+                    "p_event_type": "api.unauthorized_access",
+                    "p_severity": "warning",
+                    "p_user_id": user_id,
+                    "p_event_data": {"resource": "admin_panel", "user_id": user_id}
+                }).execute()
+            except Exception:
+                pass  # Don't fail the request if logging fails
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin access required"
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Admin check failed for user {user_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access verification failed"
+        )
+
+    return {**current_user, "is_admin": True}
+
+
+AdminUserDep = Annotated[dict, Depends(get_current_admin)]

--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -22,6 +22,7 @@ from src.api.routes.stripe import router as stripe_router
 from src.api.routes.subscription import router as subscription_router
 from src.api.routes.health import router as health_router
 from src.api.routes.admin_cleanup import router as admin_cleanup_router
+from src.api.routes.admin import router as admin_router
 from src.api.routes.branding import router as branding_router
 from src.api.routes.recruiter_finder import router as recruiter_finder_router
 from src.api.routes.documents import router as documents_router
@@ -44,6 +45,7 @@ router.include_router(events_router, prefix="/api/job-fairs", tags=["Job Fairs"]
 router.include_router(stripe_router, prefix="/api/stripe", tags=["Stripe Payments"])
 router.include_router(subscription_router, prefix="/api/subscription", tags=["Subscription Management"])
 router.include_router(admin_cleanup_router, prefix="/api/admin", tags=["Admin Cleanup"])
+router.include_router(admin_router, prefix="/api/admin", tags=["Admin"])
 router.include_router(branding_router, prefix="/api/branding", tags=["Personal Branding"])
 router.include_router(health_router, prefix="/api/health", tags=["Health & Monitoring"])
 router.include_router(recruiter_finder_router, prefix="/api/recruiter-finder", tags=["Recruiter Finder"])

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1,0 +1,809 @@
+"""
+Admin Routes
+=============
+Complete admin API for user management, plan editing, analytics, and logs.
+All endpoints require is_admin = TRUE in profiles table.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import stripe as stripe_lib
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel
+from structlog import get_logger
+
+from src.api.deps import AdminUserDep, get_supabase_client
+from src.config.settings import get_settings
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+# ============================================================
+# PYDANTIC SCHEMAS
+# ============================================================
+
+class SuspendUserRequest(BaseModel):
+    reason: str
+
+
+class ForcePlanRequest(BaseModel):
+    plan_id: str
+
+
+class ResetPasswordRequest(BaseModel):
+    pass  # no body needed
+
+
+class DeleteUserRequest(BaseModel):
+    confirm: bool = False
+
+
+def _log_admin_action(
+    supabase,
+    admin_id: str,
+    event_type: str,
+    target_user_id: Optional[str] = None,
+    event_data: Optional[dict] = None,
+):
+    """Log an admin action to security_events. Best-effort, never raises."""
+    try:
+        supabase.rpc("log_security_event", {
+            "p_event_type": event_type,
+            "p_severity": "warning",
+            "p_user_id": admin_id,
+            "p_event_data": {
+                "admin_id": admin_id,
+                "target_user_id": target_user_id,
+                **(event_data or {}),
+            }
+        }).execute()
+    except Exception as e:
+        logger.warning(f"Failed to log admin action {event_type}: {e}")
+
+
+# ============================================================
+# USER MANAGEMENT
+# ============================================================
+
+@router.get("/users")
+async def list_users(
+    admin: AdminUserDep,
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=25, ge=1, le=100),
+    search: Optional[str] = Query(default=None),
+    plan: Optional[str] = Query(default=None),
+    user_status: Optional[str] = Query(default=None, alias="status"),
+) -> Dict[str, Any]:
+    """
+    List all users with pagination, search, and filters.
+    Returns profile + active plan + today's usage for each user.
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Build query: join profiles with user_subscriptions and subscription_plans
+        query = supabase.table("profiles").select(
+            "id, email, full_name, status, is_admin, created_at, suspended_at, suspended_reason,"
+            "user_subscriptions!left(id, status, current_period_end, "
+            "subscription_plans!inner(name, display_name, price_monthly))"
+        ).order("created_at", desc=True)
+
+        if search:
+            query = query.ilike("email", f"%{search}%")
+        if user_status:
+            query = query.eq("status", user_status)
+
+        offset = (page - 1) * per_page
+        result = query.range(offset, offset + per_page - 1).execute()
+
+        # Count total
+        count_result = supabase.table("profiles").select("id", count="exact").execute()
+        total = count_result.count or 0
+
+        # Get today's usage for each user
+        today = datetime.now(timezone.utc).date().isoformat()
+        user_ids = [u["id"] for u in result.data]
+        usage_result = supabase.table("usage_quotas").select(
+            "user_id, cv_analyses_used, coach_seconds_used, job_searches_used"
+        ).eq("quota_date", today).in_("user_id", user_ids).execute()
+
+        usage_map = {u["user_id"]: u for u in (usage_result.data or [])}
+
+        # Merge usage into users
+        users = []
+        for user in result.data:
+            active_sub = next(
+                (s for s in (user.get("user_subscriptions") or []) if s.get("status") == "active"),
+                None
+            )
+            plan_filter_name = (active_sub or {}).get("subscription_plans", {}).get("name", "free")
+            if plan and plan_filter_name != plan:
+                continue
+
+            users.append({
+                **user,
+                "plan": active_sub,
+                "usage_today": usage_map.get(user["id"], {}),
+            })
+
+        return {
+            "users": users,
+            "total": total,
+            "page": page,
+            "per_page": per_page,
+            "pages": (total + per_page - 1) // per_page,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to list users: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch users")
+
+
+@router.get("/users/{user_id}")
+async def get_user_detail(
+    user_id: str,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """
+    Full user detail: profile, subscription history, usage last 30 days, last 50 security events.
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Profile
+        profile = supabase.table("profiles").select("*").eq("id", user_id).single().execute()
+        if not profile.data:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        # Active subscription
+        sub = supabase.table("user_subscriptions").select(
+            "*, subscription_plans(name, display_name, price_monthly, limits)"
+        ).eq("user_id", user_id).eq("status", "active").limit(1).execute()
+
+        # Subscription history (last 10)
+        history = supabase.table("subscription_history").select("*").eq(
+            "user_id", user_id
+        ).order("created_at", desc=True).limit(10).execute()
+
+        # Usage last 30 days
+        thirty_days_ago = (datetime.now(timezone.utc) - timedelta(days=30)).date().isoformat()
+        usage = supabase.table("usage_quotas").select("*").eq(
+            "user_id", user_id
+        ).gte("quota_date", thirty_days_ago).order("quota_date", desc=True).execute()
+
+        # Security events last 50
+        events = supabase.table("security_events").select(
+            "id, event_type, severity, created_at, ip_address, event_data"
+        ).eq("user_id", user_id).order("created_at", desc=True).limit(50).execute()
+
+        return {
+            "profile": profile.data,
+            "subscription": sub.data[0] if sub.data else None,
+            "subscription_history": history.data or [],
+            "usage_30d": usage.data or [],
+            "security_events": events.data or [],
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get user detail {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch user detail")
+
+
+@router.patch("/users/{user_id}/suspend")
+async def suspend_user(
+    user_id: str,
+    body: SuspendUserRequest,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Suspend a user account. They will be blocked from accessing the app."""
+    supabase = get_supabase_client()
+
+    try:
+        result = supabase.table("profiles").update({
+            "status": "suspended",
+            "suspended_at": datetime.now(timezone.utc).isoformat(),
+            "suspended_reason": body.reason,
+        }).eq("id", user_id).execute()
+
+        if not result.data:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        _log_admin_action(supabase, admin["id"], "admin.user_suspended", user_id, {
+            "reason": body.reason
+        })
+
+        logger.info(f"Admin {admin['email']} suspended user {user_id}: {body.reason}")
+        return {"success": True, "message": "User suspended"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to suspend user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to suspend user")
+
+
+@router.patch("/users/{user_id}/reactivate")
+async def reactivate_user(
+    user_id: str,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Reactivate a suspended user."""
+    supabase = get_supabase_client()
+
+    try:
+        result = supabase.table("profiles").update({
+            "status": "active",
+            "suspended_at": None,
+            "suspended_reason": None,
+        }).eq("id", user_id).execute()
+
+        if not result.data:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        _log_admin_action(supabase, admin["id"], "admin.user_reactivated", user_id)
+
+        logger.info(f"Admin {admin['email']} reactivated user {user_id}")
+        return {"success": True, "message": "User reactivated"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to reactivate user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to reactivate user")
+
+
+@router.post("/users/{user_id}/reset-password")
+async def reset_user_password(
+    user_id: str,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """
+    Send a password recovery email to the user via Supabase auth.admin.
+    Returns the magic link (for admin copy-paste if needed).
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Get user email first
+        profile = supabase.table("profiles").select("email").eq("id", user_id).single().execute()
+        if not profile.data:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        email = profile.data["email"]
+        settings = get_settings()
+
+        # Generate recovery link via Supabase admin API
+        response = supabase.auth.admin.generate_link({
+            "type": "recovery",
+            "email": email,
+            "options": {
+                "redirect_to": f"{settings.get_primary_frontend_url()}/reset-password"
+            }
+        })
+
+        _log_admin_action(supabase, admin["id"], "admin.password_reset", user_id, {
+            "email": email
+        })
+
+        logger.info(f"Admin {admin['email']} triggered password reset for {email}")
+
+        return {
+            "success": True,
+            "message": f"Password reset email sent to {email}",
+            "action_link": response.properties.action_link if hasattr(response, "properties") else None,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to reset password for user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to send reset email: {str(e)}")
+
+
+@router.delete("/users/{user_id}")
+async def delete_user(
+    user_id: str,
+    body: DeleteUserRequest,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """
+    Delete a user account. Requires body: {"confirm": true}.
+    Soft-deletes the profile then hard-deletes the auth user.
+    """
+    if not body.confirm:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail='Send {"confirm": true} to confirm deletion'
+        )
+
+    supabase = get_supabase_client()
+
+    try:
+        # Soft-delete profile first
+        supabase.table("profiles").update({
+            "status": "deleted",
+        }).eq("id", user_id).execute()
+
+        # Hard delete from Supabase auth
+        supabase.auth.admin.delete_user(user_id)
+
+        _log_admin_action(supabase, admin["id"], "admin.user_deleted", user_id)
+
+        logger.info(f"Admin {admin['email']} deleted user {user_id}")
+        return {"success": True, "message": "User deleted"}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to delete user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to delete user: {str(e)}")
+
+
+@router.post("/users/{user_id}/force-plan")
+async def force_plan_change(
+    user_id: str,
+    body: ForcePlanRequest,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """
+    Force a user onto a specific plan. Updates DB only — does NOT touch Stripe.
+    The next Stripe webhook will reconcile if needed.
+    """
+    supabase = get_supabase_client()
+
+    try:
+        # Verify plan exists
+        plan = supabase.table("subscription_plans").select(
+            "id, name, display_name"
+        ).eq("id", body.plan_id).single().execute()
+
+        if not plan.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        # Cancel any existing active subscriptions in DB
+        supabase.table("user_subscriptions").update({
+            "status": "canceled",
+            "canceled_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("user_id", user_id).eq("status", "active").execute()
+
+        # Create new subscription entry
+        now = datetime.now(timezone.utc)
+        result = supabase.table("user_subscriptions").insert({
+            "user_id": user_id,
+            "plan_id": body.plan_id,
+            "status": "active",
+            "current_period_start": now.isoformat(),
+            "current_period_end": (now + timedelta(days=30)).isoformat(),
+        }).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.subscription_force_changed", user_id, {
+            "new_plan_id": body.plan_id,
+            "new_plan_name": plan.data["name"],
+        })
+
+        logger.info(
+            f"Admin {admin['email']} force-changed {user_id} to plan {plan.data['name']}"
+        )
+        return {
+            "success": True,
+            "message": f"User plan changed to {plan.data['display_name']}",
+            "subscription": result.data[0] if result.data else None,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to force plan change for user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to change plan: {str(e)}")
+
+
+# ============================================================
+# PLANS / PACKAGE EDITOR
+# ============================================================
+
+@router.get("/plans")
+async def list_plans(admin: AdminUserDep) -> List[Dict[str, Any]]:
+    """List all subscription plans with their Stripe price IDs."""
+    supabase = get_supabase_client()
+
+    plans = supabase.table("subscription_plans").select(
+        "*, stripe_prices(billing_period, stripe_price_id, is_active)"
+    ).order("sort_order").execute()
+
+    return plans.data or []
+
+
+@router.patch("/plans/{plan_id}/limits")
+async def update_plan_limits(
+    plan_id: str,
+    body: Dict[str, Any],
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Update numeric limits for a plan (cv_analyses, coach_seconds, job_searches)."""
+    supabase = get_supabase_client()
+
+    allowed_keys = {"cv_analyses", "coach_seconds", "job_searches"}
+    limits = {k: v for k, v in body.items() if k in allowed_keys}
+
+    if not limits:
+        raise HTTPException(status_code=400, detail="No valid limit keys provided")
+
+    try:
+        # Get current limits and merge
+        current = supabase.table("subscription_plans").select(
+            "name, limits"
+        ).eq("id", plan_id).single().execute()
+
+        if not current.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        merged_limits = {**(current.data.get("limits") or {}), **limits}
+
+        result = supabase.table("subscription_plans").update({
+            "limits": merged_limits,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("id", plan_id).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.plan_limits_updated", None, {
+            "plan_id": plan_id,
+            "plan_name": current.data["name"],
+            "changes": limits,
+        })
+
+        return {"success": True, "limits": merged_limits}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to update plan limits {plan_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update limits")
+
+
+@router.patch("/plans/{plan_id}/features")
+async def update_plan_features(
+    plan_id: str,
+    body: Dict[str, Any],
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Update feature flags array for a plan."""
+    supabase = get_supabase_client()
+
+    features = body.get("features")
+    if not isinstance(features, list):
+        raise HTTPException(status_code=400, detail="features must be a list")
+
+    try:
+        current = supabase.table("subscription_plans").select(
+            "name"
+        ).eq("id", plan_id).single().execute()
+
+        if not current.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        result = supabase.table("subscription_plans").update({
+            "features": features,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("id", plan_id).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.plan_features_updated", None, {
+            "plan_id": plan_id,
+            "plan_name": current.data["name"],
+            "features": features,
+        })
+
+        return {"success": True, "features": features}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to update features")
+
+
+@router.patch("/plans/{plan_id}/price")
+async def update_plan_display_price(
+    plan_id: str,
+    body: Dict[str, Any],
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Update displayed price for a plan (DB only, does NOT touch Stripe)."""
+    supabase = get_supabase_client()
+
+    update_data: Dict[str, Any] = {}
+    if "price_monthly" in body:
+        update_data["price_monthly"] = float(body["price_monthly"])
+    if "price_yearly" in body:
+        update_data["price_yearly"] = float(body["price_yearly"])
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="No price fields provided")
+
+    update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    try:
+        current = supabase.table("subscription_plans").select("name").eq("id", plan_id).single().execute()
+        if not current.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        result = supabase.table("subscription_plans").update(update_data).eq("id", plan_id).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.plan_price_display_updated", None, {
+            "plan_id": plan_id, "plan_name": current.data["name"], "changes": update_data
+        })
+
+        return {"success": True, "plan": result.data[0] if result.data else None}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to update price")
+
+
+@router.post("/plans/{plan_id}/stripe-price")
+async def update_stripe_price(
+    plan_id: str,
+    body: Dict[str, Any],
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """
+    Create a new Stripe price and archive the old one.
+    Stripe does NOT allow editing existing prices — we must create new + archive old.
+    Then updates the stripe_prices DB table via the existing update_stripe_price() RPC.
+    """
+    billing_period = body.get("billing_period")
+    unit_amount = body.get("unit_amount")  # in cents (e.g. 890 for €8.90)
+    currency = body.get("currency", "eur")
+
+    if billing_period not in ("monthly", "yearly"):
+        raise HTTPException(status_code=400, detail="billing_period must be 'monthly' or 'yearly'")
+    if not unit_amount or int(unit_amount) < 50:
+        raise HTTPException(status_code=400, detail="unit_amount must be >= 50 cents")
+
+    supabase = get_supabase_client()
+    settings = get_settings()
+
+    try:
+        stripe_lib.api_key = settings.get_stripe_secret_key()
+
+        # Get plan info + current price ID
+        plan = supabase.table("subscription_plans").select("name, display_name").eq(
+            "id", plan_id
+        ).single().execute()
+        if not plan.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        old_price = supabase.table("stripe_prices").select("stripe_price_id, stripe_product_id").eq(
+            "plan_id", plan_id
+        ).eq("billing_period", billing_period).eq("is_active", True).limit(1).execute()
+
+        old_price_id = old_price.data[0]["stripe_price_id"] if old_price.data else None
+        product_id = old_price.data[0].get("stripe_product_id") if old_price.data else None
+
+        # Create new Stripe price
+        interval = "month" if billing_period == "monthly" else "year"
+        new_price = stripe_lib.Price.create(
+            unit_amount=int(unit_amount),
+            currency=currency,
+            recurring={"interval": interval},
+            product=product_id,
+            nickname=f"{plan.data['display_name']} {billing_period}",
+        )
+
+        # Archive old Stripe price
+        if old_price_id:
+            stripe_lib.Price.modify(old_price_id, active=False)
+
+        # Update DB via existing RPC
+        supabase.rpc("update_stripe_price", {
+            "p_plan_name": plan.data["name"],
+            "p_billing_period": billing_period,
+            "p_new_price_id": new_price.id,
+            "p_new_product_id": product_id,
+        }).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.stripe_price_updated", None, {
+            "plan_id": plan_id,
+            "plan_name": plan.data["name"],
+            "billing_period": billing_period,
+            "old_price_id": old_price_id,
+            "new_price_id": new_price.id,
+            "unit_amount": unit_amount,
+            "currency": currency,
+        })
+
+        return {
+            "success": True,
+            "new_price_id": new_price.id,
+            "archived_price_id": old_price_id,
+        }
+
+    except HTTPException:
+        raise
+    except stripe_lib.StripeError as e:
+        logger.error(f"Stripe error updating price: {e}")
+        raise HTTPException(status_code=500, detail=f"Stripe error: {str(e)}")
+    except Exception as e:
+        logger.error(f"Failed to update Stripe price: {e}")
+        raise HTTPException(status_code=500, detail="Failed to update Stripe price")
+
+
+# ============================================================
+# ANALYTICS
+# ============================================================
+
+@router.get("/analytics/revenue")
+async def get_revenue_analytics(
+    admin: AdminUserDep,
+    period: str = Query(default="30d", pattern="^(30d|90d|12m)$"),
+) -> Dict[str, Any]:
+    """MRR, ARR, revenue breakdown by plan."""
+    supabase = get_supabase_client()
+
+    try:
+        # Active paid subscriptions
+        subs = supabase.table("user_subscriptions").select(
+            "plan_id, subscription_plans!inner(name, display_name, price_monthly, price_yearly)"
+        ).eq("status", "active").execute()
+
+        mrr = 0.0
+        by_plan: Dict[str, Dict] = {}
+
+        for sub in (subs.data or []):
+            plan_info = sub.get("subscription_plans", {})
+            plan_name = plan_info.get("name", "free")
+            if plan_name == "free":
+                continue
+            monthly = float(plan_info.get("price_monthly") or 0)
+            mrr += monthly
+            if plan_name not in by_plan:
+                by_plan[plan_name] = {
+                    "name": plan_name,
+                    "display_name": plan_info.get("display_name"),
+                    "count": 0,
+                    "mrr": 0.0,
+                }
+            by_plan[plan_name]["count"] += 1
+            by_plan[plan_name]["mrr"] += monthly
+
+        # Total users per plan (including free)
+        all_subs = supabase.table("user_subscriptions").select(
+            "subscription_plans!inner(name)", count="exact"
+        ).eq("status", "active").execute()
+
+        total_users = supabase.table("profiles").select("id", count="exact").neq(
+            "status", "deleted"
+        ).execute()
+
+        return {
+            "mrr": round(mrr, 2),
+            "arr": round(mrr * 12, 2),
+            "by_plan": list(by_plan.values()),
+            "total_paying_users": sum(v["count"] for v in by_plan.values()),
+            "total_users": total_users.count or 0,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to fetch revenue analytics: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch revenue analytics")
+
+
+@router.get("/analytics/subscriptions")
+async def get_subscriptions_breakdown(
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Count of users per plan (active subscriptions)."""
+    supabase = get_supabase_client()
+
+    try:
+        result = supabase.table("user_subscriptions").select(
+            "status, subscription_plans!inner(name, display_name)"
+        ).in_("status", ["active", "past_due", "trialing"]).execute()
+
+        breakdown: Dict[str, int] = {}
+        for sub in (result.data or []):
+            plan_name = sub.get("subscription_plans", {}).get("name", "free")
+            breakdown[plan_name] = breakdown.get(plan_name, 0) + 1
+
+        return {"breakdown": breakdown}
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to fetch subscriptions breakdown")
+
+
+# ============================================================
+# LOGS
+# ============================================================
+
+@router.get("/logs/security")
+async def get_security_logs(
+    admin: AdminUserDep,
+    user_id: Optional[str] = Query(default=None),
+    event_type: Optional[str] = Query(default=None),
+    severity: Optional[str] = Query(default=None),
+    from_date: Optional[str] = Query(default=None),
+    to_date: Optional[str] = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=50, ge=1, le=200),
+) -> Dict[str, Any]:
+    """Query security events with filters."""
+    supabase = get_supabase_client()
+
+    try:
+        query = supabase.table("security_events").select(
+            "id, event_type, severity, user_id, ip_address, created_at, event_data, "
+            "profiles!left(email, full_name)"
+        ).order("created_at", desc=True)
+
+        if user_id:
+            query = query.eq("user_id", user_id)
+        if event_type:
+            query = query.eq("event_type", event_type)
+        if severity:
+            query = query.eq("severity", severity)
+        if from_date:
+            query = query.gte("created_at", from_date)
+        if to_date:
+            query = query.lte("created_at", to_date)
+
+        offset = (page - 1) * per_page
+        result = query.range(offset, offset + per_page - 1).execute()
+
+        count_q = supabase.table("security_events").select("id", count="exact")
+        if user_id:
+            count_q = count_q.eq("user_id", user_id)
+        count_result = count_q.execute()
+
+        return {
+            "events": result.data or [],
+            "total": count_result.count or 0,
+            "page": page,
+            "per_page": per_page,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to fetch security logs: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch security logs")
+
+
+@router.get("/logs/users/{user_id}")
+async def get_user_logs(
+    user_id: str,
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """All security events for a specific user."""
+    supabase = get_supabase_client()
+
+    result = supabase.table("security_events").select(
+        "id, event_type, severity, created_at, ip_address, event_data"
+    ).eq("user_id", user_id).order("created_at", desc=True).limit(100).execute()
+
+    return {"events": result.data or []}
+
+
+@router.get("/logs/webhooks")
+async def get_webhook_logs(
+    admin: AdminUserDep,
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=50, ge=1, le=100),
+) -> Dict[str, Any]:
+    """List Stripe webhook failures."""
+    supabase = get_supabase_client()
+
+    try:
+        offset = (page - 1) * per_page
+        result = supabase.table("webhook_failures").select("*").order(
+            "created_at", desc=True
+        ).range(offset, offset + per_page - 1).execute()
+
+        count_result = supabase.table("webhook_failures").select("id", count="exact").execute()
+
+        return {
+            "failures": result.data or [],
+            "total": count_result.count or 0,
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to fetch webhook logs")

--- a/backend/src/api/routes/admin_cleanup.py
+++ b/backend/src/api/routes/admin_cleanup.py
@@ -14,7 +14,7 @@ router = APIRouter()
 
 # Import dependencies
 try:
-    from src.api.deps import get_current_user
+    from src.api.deps import get_current_admin
     from src.services.stripe import supabase_client, stripe
 except ImportError as e:
     logger.error(f"Failed to import dependencies: {e}")
@@ -24,7 +24,7 @@ except ImportError as e:
 @router.post("/sync-subscriptions/{user_id}")
 async def sync_user_subscriptions(
     user_id: str,
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(get_current_admin)
 ) -> Dict[str, Any]:
     """
     Cleanup orphaned subscriptions by synchronizing with Stripe.

--- a/backend/src/api/routes/recruiter.py
+++ b/backend/src/api/routes/recruiter.py
@@ -17,6 +17,7 @@ import stripe
 from supabase import create_client, Client
 
 from src.config.settings import get_settings
+from src.api.deps import get_user_id_from_token
 from src.services.email import (
     send_recruiter_request_confirmation,
     send_recruiter_request_notification,
@@ -85,14 +86,10 @@ class RecruiterRequestStatus(BaseModel):
 
 def get_user_id_from_header(authorization: Optional[str] = Header(None)) -> Optional[str]:
     """
-    Extract user ID from Authorization header.
-
-    For now, returns None as we need to implement proper auth.
-    TODO: Implement proper JWT token validation with Supabase auth.
+    Extract user ID from Authorization Bearer token via Supabase JWT validation.
+    Returns None for anonymous/unauthenticated requests (allowed for recruiter contact).
     """
-    # Placeholder - In production, decode JWT and extract user_id
-    # For testing, we can accept requests without auth
-    return None
+    return get_user_id_from_token(authorization)
 
 
 # ============================================================================

--- a/backend/src/api/routes/stripe.py
+++ b/backend/src/api/routes/stripe.py
@@ -9,7 +9,7 @@ from typing import Optional
 from structlog import get_logger
 
 from src.api.deps import get_current_user
-from src.services.stripe import create_checkout_session, handle_stripe_webhook
+from src.services.stripe import create_checkout_session, handle_stripe_webhook, supabase_client
 from src.config.settings import settings
 
 logger = get_logger(__name__)
@@ -112,3 +112,66 @@ async def stripe_webhook(
     except Exception as e:
         logger.error(f"[STRIPE] Webhook processing failed: {e}")
         raise HTTPException(status_code=500, detail=f"Webhook processing failed: {str(e)}")
+
+
+@router.post("/cancel-subscription")
+async def cancel_subscription(
+    current_user: dict = Depends(get_current_user)
+):
+    """
+    Cancel the current user's subscription at end of billing period.
+    Uses cancel_at_period_end=True — user keeps access until period ends.
+    The webhook customer.subscription.updated will update DB automatically.
+    """
+    try:
+        user_id = current_user.get("id")
+        if not user_id:
+            raise HTTPException(status_code=401, detail="Invalid user")
+
+        if not supabase_client:
+            raise HTTPException(status_code=500, detail="Database not configured")
+
+        result = (
+            supabase_client
+            .table("user_subscriptions")
+            .select("stripe_subscription_id, status, plan_name")
+            .eq("user_id", user_id)
+            .eq("status", "active")
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+        )
+
+        if not result.data:
+            raise HTTPException(status_code=404, detail="No active subscription found")
+
+        subscription = result.data[0]
+        stripe_subscription_id = subscription.get("stripe_subscription_id")
+
+        if not stripe_subscription_id or not stripe_subscription_id.startswith("sub_"):
+            raise HTTPException(status_code=400, detail="Invalid subscription ID")
+
+        # GARDE-FOU: cancel_at_period_end=True UNIQUEMENT — jamais stripe.Subscription.delete()
+        import stripe as stripe_lib
+        updated = stripe_lib.Subscription.modify(
+            stripe_subscription_id,
+            cancel_at_period_end=True
+        )
+
+        logger.info(
+            f"[STRIPE] Subscription {stripe_subscription_id} marked for cancellation "
+            f"at period end for user {user_id}"
+        )
+
+        return {
+            "success": True,
+            "cancel_at_period_end": True,
+            "current_period_end": updated.get("current_period_end"),
+            "message": "Subscription will be cancelled at end of billing period"
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[STRIPE] Cancel subscription failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to cancel subscription: {str(e)}")

--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -807,7 +807,15 @@
     "multilingualComingSoon": "Multilingual support will be available soon",
     "thankSubscription": "Thanks for purchasing a membership!",
     "deleteAccountComingSoon": "Account deletion will be available soon (GDPR compliance)",
-    "cancelSubscriptionComingSoon": "Subscription cancellation will be available soon"
+    "cancelSubscriptionComingSoon": "Subscription cancellation will be available soon",
+    "cancelSubscription": "Cancel subscription",
+    "cancelling": "Cancelling...",
+    "cancelDialog": {
+      "title": "Cancel your subscription?",
+      "description": "You will keep access to all features until the end of your current billing period. No refund will be issued.",
+      "keep": "Keep my subscription",
+      "confirm": "Confirm cancellation"
+    }
   },
   "cv": {
     "inProgress": "In progress",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -807,7 +807,15 @@
     "multilingualComingSoon": "El soporte multilingüe estará disponible próximamente",
     "thankSubscription": "🎉 ¡Gracias por su suscripción!",
     "deleteAccountComingSoon": "La eliminación de la cuenta estará disponible en breve (RGPD compliance)",
-    "cancelSubscriptionComingSoon": "La cancelación de la suscripción estará disponible próximamente"
+    "cancelSubscriptionComingSoon": "La cancelación de la suscripción estará disponible próximamente",
+    "cancelSubscription": "Cancelar suscripción",
+    "cancelling": "Cancelando...",
+    "cancelDialog": {
+      "title": "¿Cancelar tu suscripción?",
+      "description": "Conservarás acceso a todas las funcionalidades hasta el final del período de facturación actual. No se realizará ningún reembolso.",
+      "keep": "Mantener mi suscripción",
+      "confirm": "Confirmar cancelación"
+    }
   },
   "cv": {
     "inProgress": "En curso...",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -807,7 +807,15 @@
     "multilingualComingSoon": "Le support multilingue sera disponible prochainement",
     "thankSubscription": "🎉 Merci de votre abonnement !",
     "deleteAccountComingSoon": "La suppression de compte sera bientôt disponible (RGPD compliance)",
-    "cancelSubscriptionComingSoon": "L'annulation d'abonnement sera disponible prochainement"
+    "cancelSubscriptionComingSoon": "L'annulation d'abonnement sera disponible prochainement",
+    "cancelSubscription": "Annuler l'abonnement",
+    "cancelling": "Annulation...",
+    "cancelDialog": {
+      "title": "Annuler votre abonnement ?",
+      "description": "Vous conserverez l'accès à toutes vos fonctionnalités jusqu'à la fin de la période en cours. Aucun remboursement ne sera effectué.",
+      "keep": "Garder mon abonnement",
+      "confirm": "Confirmer l'annulation"
+    }
   },
   "cv": {
     "inProgress": "En cours...",

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -807,7 +807,15 @@
     "multilingualComingSoon": "O suporte multilíngue estará disponível em breve",
     "thankSubscription": "🎉 Obrigado por se inscrever!",
     "deleteAccountComingSoon": "A eliminação da conta estará disponível em breve (em conformidade com o RGPD)",
-    "cancelSubscriptionComingSoon": "O cancelamento da assinatura estará disponível em breve"
+    "cancelSubscriptionComingSoon": "O cancelamento da assinatura estará disponível em breve",
+    "cancelSubscription": "Cancelar assinatura",
+    "cancelling": "Cancelando...",
+    "cancelDialog": {
+      "title": "Cancelar sua assinatura?",
+      "description": "Você manterá acesso a todas as funcionalidades até o final do período de cobrança atual. Nenhum reembolso será realizado.",
+      "keep": "Manter minha assinatura",
+      "confirm": "Confirmar cancelamento"
+    }
   },
   "cv": {
     "inProgress": "Em progresso...",

--- a/frontend-next/src/app/(dashboard)/admin/layout.tsx
+++ b/frontend-next/src/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,45 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import AdminNav from "@/components/admin/admin-nav";
+
+export const metadata = {
+  title: "Admin — Huntzen",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Not authenticated → redirect to login
+  if (!user) {
+    redirect("/login?redirectTo=/admin");
+  }
+
+  // Check is_admin from DB (source of truth — see migration 20260227000001)
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  // Not admin → redirect to dashboard
+  if (!profile?.is_admin) {
+    redirect("/jobs");
+  }
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <AdminNav />
+      <main className="flex-1 overflow-auto">
+        <div className="container mx-auto p-6 max-w-7xl">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/frontend-next/src/app/(dashboard)/admin/page.tsx
+++ b/frontend-next/src/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AdminPage() {
+  redirect('/admin/users')
+}

--- a/frontend-next/src/app/(dashboard)/recruiter-contact/success/page.tsx
+++ b/frontend-next/src/app/(dashboard)/recruiter-contact/success/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import {
+  CheckCircle2,
+  Calendar,
+  ArrowRight,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Status = "verifying" | "success" | "error";
+
+export default function RecruiterContactSuccessPage() {
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<Status>("verifying");
+
+  useEffect(() => {
+    const sessionId = searchParams.get("session_id");
+    if (!sessionId) {
+      setStatus("error");
+      return;
+    }
+    // Stripe webhook processes asynchronously — show success after brief delay
+    const timer = setTimeout(() => setStatus("success"), 2000);
+    return () => clearTimeout(timer);
+  }, [searchParams]);
+
+  if (status === "verifying") {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
+        <Loader2 className="w-12 h-12 animate-spin text-[#00D9FF]" />
+        <p className="text-lg text-gray-600">
+          Confirmation de votre paiement...
+        </p>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
+        <XCircle className="w-16 h-16 text-red-500" />
+        <h1 className="text-2xl font-bold text-gray-900">Session invalide</h1>
+        <p className="text-gray-600 text-center max-w-md">
+          Nous ne pouvons pas confirmer votre paiement. Si vous avez été
+          débité, contactez-nous à{" "}
+          <a
+            href="mailto:contact@huntzenjobs.co"
+            className="text-[#00D9FF] underline"
+          >
+            contact@huntzenjobs.co
+          </a>
+        </p>
+        <Button asChild>
+          <Link href="/recruiter-contact">Retour</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-8 py-12">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <div className="w-20 h-20 rounded-full bg-green-100 flex items-center justify-center">
+          <CheckCircle2 className="w-12 h-12 text-green-600" />
+        </div>
+        <h1 className="text-3xl font-bold text-gray-900">
+          Paiement confirmé !
+        </h1>
+        <p className="text-lg text-gray-600 max-w-md">
+          Votre consultation avec un recruteur expert a bien été réservée. Vous
+          allez recevoir un email de confirmation avec les détails.
+        </p>
+      </div>
+
+      <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 max-w-md w-full">
+        <div className="flex items-start gap-3">
+          <Calendar className="w-6 h-6 text-blue-600 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-semibold text-blue-900">Prochaines étapes</p>
+            <ul className="mt-2 space-y-1 text-sm text-blue-800">
+              <li>📧 Vérifiez votre boîte email (et les spams)</li>
+              <li>📅 Notre équipe vous contactera sous 48h pour planifier</li>
+              <li>
+                💬 Préparez vos questions pour maximiser la session
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex gap-4">
+        <Button variant="outline" asChild>
+          <Link href="/jobs">Rechercher des offres</Link>
+        </Button>
+        <Button asChild>
+          <Link href="/assistant" className="flex items-center gap-2">
+            Parler au coach <ArrowRight className="w-4 h-4" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend-next/src/app/auth/recovery/page.tsx
+++ b/frontend-next/src/app/auth/recovery/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * Auth Recovery Page (Client Component)
+ *
+ * Dedicated page for password reset email links.
+ * Handles both Supabase auth flows for recovery:
+ *  - PKCE flow  : ?code=xxx in query string → exchangeCodeForSession
+ *  - Implicit   : #access_token=xxx in hash  → onAuthStateChange PASSWORD_RECOVERY
+ *
+ * Why client-side and not route.ts:
+ * Browsers never send URL hash fragments (#...) to the server.
+ * A server Route Handler cannot read #access_token — it always sees an empty
+ * hash. This page runs in the browser and can handle both cases.
+ */
+
+import { useEffect, useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Loader2 } from "lucide-react";
+
+function RecoveryInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState("Vérification du lien...");
+
+  useEffect(() => {
+    const supabase = createClient();
+    const code = searchParams.get("code");
+    const error = searchParams.get("error");
+    const errorDescription = searchParams.get("error_description");
+
+    // Error from Supabase (e.g. expired link)
+    if (error) {
+      router.replace(
+        `/forgot-password?error=${encodeURIComponent(errorDescription || error)}`,
+      );
+      return;
+    }
+
+    // --- PKCE flow: ?code=xxx ---
+    if (code) {
+      setStatus("Validation du lien de réinitialisation...");
+      supabase.auth.exchangeCodeForSession(code).then(({ error: exchangeError }) => {
+        if (exchangeError) {
+          router.replace("/forgot-password?error=expired");
+          return;
+        }
+        router.replace("/reset-password");
+      });
+      return;
+    }
+
+    // --- Implicit flow: #access_token=xxx in hash ---
+    // Supabase client auto-detects the hash via detectSessionInUrl: true
+    // and fires PASSWORD_RECOVERY when a recovery token is found.
+    setStatus("Vérification de la session...");
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "PASSWORD_RECOVERY") {
+        router.replace("/reset-password");
+      } else if (event === "SIGNED_IN") {
+        // Shouldn't happen on recovery page, but handle gracefully
+        router.replace("/jobs");
+      }
+    });
+
+    // Safety timeout: if nothing fires in 6s, the link is invalid/expired
+    const timeout = setTimeout(() => {
+      router.replace("/forgot-password?error=expired");
+    }, 6000);
+
+    return () => {
+      subscription.unsubscribe();
+      clearTimeout(timeout);
+    };
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="text-center space-y-4">
+        <div className="flex justify-center">
+          <div className="w-16 h-16 bg-[#00D9FF]/10 rounded-full flex items-center justify-center">
+            <Loader2 className="w-8 h-8 animate-spin text-[#00D9FF]" />
+          </div>
+        </div>
+        <p className="text-gray-600 text-sm">{status}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthRecoveryPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gray-50">
+          <Loader2 className="w-8 h-8 animate-spin text-[#00D9FF]" />
+        </div>
+      }
+    >
+      <RecoveryInner />
+    </Suspense>
+  );
+}

--- a/frontend-next/src/components/admin/admin-nav.tsx
+++ b/frontend-next/src/components/admin/admin-nav.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  Users,
+  Package,
+  BarChart3,
+  FileText,
+  Gift,
+  ShieldCheck,
+  LayoutDashboard,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const navItems = [
+  {
+    href: '/admin/users',
+    label: 'Utilisateurs',
+    icon: Users,
+  },
+  {
+    href: '/admin/plans',
+    label: 'Packages',
+    icon: Package,
+  },
+  {
+    href: '/admin/analytics',
+    label: 'Revenue',
+    icon: BarChart3,
+  },
+  {
+    href: '/admin/logs',
+    label: 'Logs',
+    icon: FileText,
+  },
+  {
+    href: '/admin/referrals',
+    label: 'Parrainage',
+    icon: Gift,
+  },
+]
+
+export default function AdminNav() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="w-56 min-h-screen border-r bg-card flex flex-col shrink-0">
+      <div className="p-4 border-b">
+        <Link href="/admin/users" className="flex items-center gap-2 font-semibold text-sm">
+          <ShieldCheck className="h-5 w-5 text-primary" />
+          <span>Admin Panel</span>
+        </Link>
+      </div>
+
+      <nav className="flex-1 p-3 space-y-1">
+        {navItems.map((item) => {
+          const Icon = item.icon
+          const isActive = pathname.startsWith(item.href)
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
+                isActive
+                  ? 'bg-primary text-primary-foreground font-medium'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent'
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className="p-3 border-t">
+        <Link
+          href="/jobs"
+          className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <LayoutDashboard className="h-4 w-4 shrink-0" />
+          Retour app
+        </Link>
+      </div>
+    </aside>
+  )
+}

--- a/frontend-next/src/components/profile/subscription-card.tsx
+++ b/frontend-next/src/components/profile/subscription-card.tsx
@@ -1,10 +1,22 @@
 "use client";
 
+import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useSubscription } from "@/contexts/subscription-context";
+import { useAuth } from "@/contexts/auth-context";
 import { PLAN_LIMITS } from "@/hooks/use-freemium-limits";
 import { UsageCounter } from "@/components/freemium/usage-counter";
 import { Check, X, Crown, Sparkles, Zap, TrendingUp } from "lucide-react";
@@ -63,7 +75,12 @@ const FEATURE_LABELS: Record<string, string> = {
 export function SubscriptionCard() {
   const { plan, planName, isFreePlan, isPaidPlan, openPricingModal, limits } =
     useSubscription();
+  const { session } = useAuth();
   const t = useTranslations("profile");
+
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
 
   const planConfig = PLAN_CONFIG[plan];
   const planLimits = PLAN_LIMITS[plan];
@@ -88,204 +105,264 @@ export function SubscriptionCard() {
   const nextPlan = getNextPlan();
   const canUpgrade = nextPlan !== null;
 
+  const handleCancelSubscription = async () => {
+    setIsCancelling(true);
+    setCancelError(null);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/stripe/cancel-subscription`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${session?.access_token}`,
+            "Content-Type": "application/json",
+          },
+        },
+      );
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.detail || "Erreur lors de l'annulation");
+      }
+      setShowCancelDialog(false);
+      window.location.reload();
+    } catch (err) {
+      setCancelError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setIsCancelling(false);
+    }
+  };
+
   return (
-    <Card
-      className={cn(
-        "p-6 space-y-6",
-        isPaidPlan &&
-          "border-2 border-gradient-to-r from-violet-500 to-purple-500",
-      )}
-    >
-      {/* Plan Header */}
-      <div className="flex items-start justify-between">
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Badge className={cn("gap-1", planConfig.color)}>
-              {planConfig.icon}
-              {planConfig.name}
-            </Badge>
-            {isPaidPlan && (
-              <Badge
-                variant="outline"
-                className="gap-1 text-green-600 border-green-600"
-              >
-                <Check className="w-3 h-3" />
-                Actif
-              </Badge>
-            )}
-          </div>
-          <div>
-            <p className="text-2xl font-bold">
-              {planConfig.price}
-              <span className="text-sm font-normal text-gray-500">
-                {planConfig.period}
-              </span>
-            </p>
-            <p className="text-sm text-gray-600">{planConfig.description}</p>
-          </div>
-        </div>
-
-        {canUpgrade && (
-          <Button
-            onClick={() => openPricingModal()}
-            size="sm"
-            className="gap-2 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700"
-            aria-label={`Passer au plan ${PLAN_CONFIG[nextPlan].name} pour ${PLAN_CONFIG[nextPlan].price}${PLAN_CONFIG[nextPlan].period}`}
-          >
-            <TrendingUp className="w-4 h-4" aria-hidden="true" />
-            Passer à {PLAN_CONFIG[nextPlan].name}
-          </Button>
+    <>
+      <Card
+        className={cn(
+          "p-6 space-y-6",
+          isPaidPlan &&
+            "border-2 border-gradient-to-r from-violet-500 to-purple-500",
         )}
-      </div>
-
-      <Separator />
-
-      {/* Features List */}
-      <div className="space-y-3">
-        <h3 className="font-semibold text-sm text-gray-700">
-          Fonctionnalités incluses
-        </h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-          {features.map(({ key, label, enabled }) => (
-            <div
-              key={key}
-              className={cn(
-                "flex items-center gap-2 text-sm",
-                enabled ? "text-gray-700" : "text-gray-400",
+      >
+        {/* Plan Header */}
+        <div className="flex items-start justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Badge className={cn("gap-1", planConfig.color)}>
+                {planConfig.icon}
+                {planConfig.name}
+              </Badge>
+              {isPaidPlan && (
+                <Badge
+                  variant="outline"
+                  className="gap-1 text-green-600 border-green-600"
+                >
+                  <Check className="w-3 h-3" />
+                  Actif
+                </Badge>
               )}
-            >
-              {enabled ? (
-                <Check
-                  className="w-4 h-4 text-green-600 shrink-0"
-                  aria-hidden="true"
-                />
-              ) : (
-                <X
-                  className="w-4 h-4 text-gray-400 shrink-0"
-                  aria-hidden="true"
-                />
-              )}
-              <span className={!enabled ? "line-through" : ""}>{label}</span>
             </div>
-          ))}
-        </div>
-
-        {/* Quota limits */}
-        <div className="pt-2 space-y-1 text-sm text-gray-600">
-          <div className="flex items-center gap-2">
-            <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
-            <span>
-              {planLimits.cv_analyses_per_day === Infinity
-                ? "Analyses CV illimitées"
-                : `${planLimits.cv_analyses_per_day} analyse(s) CV par jour`}
-            </span>
+            <div>
+              <p className="text-2xl font-bold">
+                {planConfig.price}
+                <span className="text-sm font-normal text-gray-500">
+                  {planConfig.period}
+                </span>
+              </p>
+              <p className="text-sm text-gray-600">{planConfig.description}</p>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
-            <span>
-              {planLimits.coach_minutes_per_day === Infinity
-                ? "Coach IA illimité"
-                : `${planLimits.coach_minutes_per_day} min de Coach IA par jour`}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
-            <span>
-              {planLimits.job_searches_per_day === Infinity
-                ? "Recherches d'emploi illimitées"
-                : `${planLimits.job_searches_per_day} recherches d'emploi par jour`}
-            </span>
-          </div>
-        </div>
-      </div>
 
-      <Separator />
-
-      {/* Usage Quotas */}
-      <div className="space-y-4">
-        <h3 className="font-semibold text-sm text-gray-700">
-          Utilisation du jour
-        </h3>
-
-        {/* CV Analysis */}
-        <div className="space-y-1">
-          <p className="text-xs text-gray-500 font-medium">Analyses CV</p>
-          <UsageCounter feature="cv_analysis" showIcon={false} />
+          {canUpgrade && (
+            <Button
+              onClick={() => openPricingModal()}
+              size="sm"
+              className="gap-2 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700"
+              aria-label={`Passer au plan ${PLAN_CONFIG[nextPlan].name} pour ${PLAN_CONFIG[nextPlan].price}${PLAN_CONFIG[nextPlan].period}`}
+            >
+              <TrendingUp className="w-4 h-4" aria-hidden="true" />
+              Passer à {PLAN_CONFIG[nextPlan].name}
+            </Button>
+          )}
         </div>
 
-        {/* Coach Time */}
-        <div className="space-y-1">
-          <p className="text-xs text-gray-500 font-medium">Temps Coach IA</p>
-          <UsageCounter feature="coach_time" showIcon={false} />
-        </div>
+        <Separator />
 
-        {/* Job Searches */}
-        <div className="space-y-1">
-          <p className="text-xs text-gray-500 font-medium">
-            Recherches d'emploi
-          </p>
-          <UsageCounter feature="job_search" showIcon={false} />
-        </div>
-      </div>
-
-      {/* Upgrade CTA for free plan */}
-      {isFreePlan && (
-        <>
-          <Separator />
-          <div className="bg-gradient-to-r from-violet-50 to-purple-50 border border-violet-200 rounded-lg p-4 space-y-3">
-            <div className="flex items-start gap-3">
-              <Crown
-                className="w-5 h-5 text-violet-600 shrink-0 mt-0.5"
-                aria-hidden="true"
-              />
-              <div className="space-y-1">
-                <p className="font-semibold text-violet-900">
-                  Débloquez tout le potentiel de HuntZen
-                </p>
-                <p className="text-sm text-violet-700">
-                  Passez à un plan payant pour des analyses illimitées, plus de
-                  temps de coaching, et des fonctionnalités exclusives.
-                </p>
+        {/* Features List */}
+        <div className="space-y-3">
+          <h3 className="font-semibold text-sm text-gray-700">
+            Fonctionnalités incluses
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {features.map(({ key, label, enabled }) => (
+              <div
+                key={key}
+                className={cn(
+                  "flex items-center gap-2 text-sm",
+                  enabled ? "text-gray-700" : "text-gray-400",
+                )}
+              >
+                {enabled ? (
+                  <Check
+                    className="w-4 h-4 text-green-600 shrink-0"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <X
+                    className="w-4 h-4 text-gray-400 shrink-0"
+                    aria-hidden="true"
+                  />
+                )}
+                <span className={!enabled ? "line-through" : ""}>{label}</span>
               </div>
-            </div>
-            <Button
-              onClick={() => openPricingModal()}
-              className="w-full bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700"
-              aria-label="Voir tous les plans d'abonnement disponibles"
-            >
-              Voir les plans
-            </Button>
+            ))}
           </div>
-        </>
-      )}
 
-      {/* Manage subscription for paid plans */}
-      {isPaidPlan && (
-        <>
-          <Separator />
-          <div className="flex flex-col sm:flex-row gap-2">
-            <Button
-              variant="outline"
-              className="sm:flex-1"
-              onClick={() => openPricingModal()}
-              aria-label="Changer de plan d'abonnement"
-            >
-              Changer de plan
-            </Button>
-            <Button
-              variant="ghost"
-              className="sm:flex-1 text-red-600 hover:text-red-700 hover:bg-red-50"
-              disabled
-              aria-label="Annuler l'abonnement (bientôt disponible)"
-            >
-              Annuler l'abonnement
-            </Button>
+          {/* Quota limits */}
+          <div className="pt-2 space-y-1 text-sm text-gray-600">
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
+              <span>
+                {planLimits.cv_analyses_per_day === Infinity
+                  ? "Analyses CV illimitées"
+                  : `${planLimits.cv_analyses_per_day} analyse(s) CV par jour`}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
+              <span>
+                {planLimits.coach_minutes_per_day === Infinity
+                  ? "Coach IA illimité"
+                  : `${planLimits.coach_minutes_per_day} min de Coach IA par jour`}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-green-600" aria-hidden="true" />
+              <span>
+                {planLimits.job_searches_per_day === Infinity
+                  ? "Recherches d'emploi illimitées"
+                  : `${planLimits.job_searches_per_day} recherches d'emploi par jour`}
+              </span>
+            </div>
           </div>
-          <p className="text-xs text-gray-500 text-center">
-            💡 {t("cancelSubscriptionComingSoon")}
-          </p>
-        </>
-      )}
-    </Card>
+        </div>
+
+        <Separator />
+
+        {/* Usage Quotas */}
+        <div className="space-y-4">
+          <h3 className="font-semibold text-sm text-gray-700">
+            Utilisation du jour
+          </h3>
+
+          {/* CV Analysis */}
+          <div className="space-y-1">
+            <p className="text-xs text-gray-500 font-medium">Analyses CV</p>
+            <UsageCounter feature="cv_analysis" showIcon={false} />
+          </div>
+
+          {/* Coach Time */}
+          <div className="space-y-1">
+            <p className="text-xs text-gray-500 font-medium">Temps Coach IA</p>
+            <UsageCounter feature="coach_time" showIcon={false} />
+          </div>
+
+          {/* Job Searches */}
+          <div className="space-y-1">
+            <p className="text-xs text-gray-500 font-medium">
+              Recherches d'emploi
+            </p>
+            <UsageCounter feature="job_search" showIcon={false} />
+          </div>
+        </div>
+
+        {/* Upgrade CTA for free plan */}
+        {isFreePlan && (
+          <>
+            <Separator />
+            <div className="bg-gradient-to-r from-violet-50 to-purple-50 border border-violet-200 rounded-lg p-4 space-y-3">
+              <div className="flex items-start gap-3">
+                <Crown
+                  className="w-5 h-5 text-violet-600 shrink-0 mt-0.5"
+                  aria-hidden="true"
+                />
+                <div className="space-y-1">
+                  <p className="font-semibold text-violet-900">
+                    Débloquez tout le potentiel de HuntZen
+                  </p>
+                  <p className="text-sm text-violet-700">
+                    Passez à un plan payant pour des analyses illimitées, plus
+                    de temps de coaching, et des fonctionnalités exclusives.
+                  </p>
+                </div>
+              </div>
+              <Button
+                onClick={() => openPricingModal()}
+                className="w-full bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700"
+                aria-label="Voir tous les plans d'abonnement disponibles"
+              >
+                Voir les plans
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* Manage subscription for paid plans */}
+        {isPaidPlan && (
+          <>
+            <Separator />
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Button
+                variant="outline"
+                className="sm:flex-1"
+                onClick={() => openPricingModal()}
+                aria-label="Changer de plan d'abonnement"
+              >
+                Changer de plan
+              </Button>
+              <Button
+                variant="ghost"
+                className="sm:flex-1 text-red-600 hover:text-red-700 hover:bg-red-50"
+                onClick={() => setShowCancelDialog(true)}
+                disabled={isCancelling}
+                aria-label={t("cancelSubscription")}
+              >
+                {isCancelling ? (
+                  <span className="flex items-center gap-2">
+                    <span className="animate-spin h-4 w-4 border-2 border-red-400 border-t-transparent rounded-full inline-block" />
+                    {t("cancelling")}
+                  </span>
+                ) : (
+                  t("cancelSubscription")
+                )}
+              </Button>
+            </div>
+          </>
+        )}
+      </Card>
+
+      <AlertDialog open={showCancelDialog} onOpenChange={setShowCancelDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("cancelDialog.title")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("cancelDialog.description")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {cancelError && (
+            <p className="text-sm text-red-600 px-1">{cancelError}</p>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isCancelling}>
+              {t("cancelDialog.keep")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleCancelSubscription}
+              disabled={isCancelling}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {isCancelling ? t("cancelling") : t("cancelDialog.confirm")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend-next/src/contexts/auth-context.tsx
+++ b/frontend-next/src/contexts/auth-context.tsx
@@ -343,7 +343,7 @@ export function AuthProvider({
   const resetPasswordForEmail = async (email: string) => {
     setError(null);
     const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
+      redirectTo: `${window.location.origin}/auth/recovery`,
     });
     // Log in dev only — never expose to user to prevent email enumeration
     if (error) {

--- a/frontend-next/src/middleware.ts
+++ b/frontend-next/src/middleware.ts
@@ -1,38 +1,76 @@
-import { createServerClient, type CookieOptions } from '@supabase/ssr'
-import { NextResponse, type NextRequest } from 'next/server'
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
 
 // Supported locales
-const SUPPORTED_LOCALES = ['fr', 'en', 'es', 'pt'] as const
-const DEFAULT_LOCALE = 'fr'
+const SUPPORTED_LOCALES = ["fr", "en", "es", "pt"] as const;
+const DEFAULT_LOCALE = "fr";
 
 // Country to language mapping (IP geolocation)
 const COUNTRY_TO_LANG: Record<string, string> = {
   // French-speaking
-  FR: 'fr', BE: 'fr', LU: 'fr', CH: 'fr', MC: 'fr',
-  SN: 'fr', CI: 'fr', ML: 'fr', BF: 'fr', NE: 'fr',
-  CD: 'fr', CG: 'fr', MG: 'fr', CM: 'fr', TG: 'fr',
+  FR: "fr",
+  BE: "fr",
+  LU: "fr",
+  CH: "fr",
+  MC: "fr",
+  SN: "fr",
+  CI: "fr",
+  ML: "fr",
+  BF: "fr",
+  NE: "fr",
+  CD: "fr",
+  CG: "fr",
+  MG: "fr",
+  CM: "fr",
+  TG: "fr",
   // English-speaking
-  GB: 'en', US: 'en', CA: 'en', AU: 'en', NZ: 'en',
-  IE: 'en', IN: 'en', ZA: 'en', NG: 'en', KE: 'en',
+  GB: "en",
+  US: "en",
+  CA: "en",
+  AU: "en",
+  NZ: "en",
+  IE: "en",
+  IN: "en",
+  ZA: "en",
+  NG: "en",
+  KE: "en",
   // Spanish-speaking
-  ES: 'es', MX: 'es', AR: 'es', CO: 'es', CL: 'es',
-  PE: 'es', VE: 'es', EC: 'es', GT: 'es', CU: 'es',
-  BO: 'es', DO: 'es', HN: 'es', PY: 'es', SV: 'es',
+  ES: "es",
+  MX: "es",
+  AR: "es",
+  CO: "es",
+  CL: "es",
+  PE: "es",
+  VE: "es",
+  EC: "es",
+  GT: "es",
+  CU: "es",
+  BO: "es",
+  DO: "es",
+  HN: "es",
+  PY: "es",
+  SV: "es",
   // Portuguese-speaking
-  BR: 'pt', PT: 'pt', AO: 'pt', MZ: 'pt', GW: 'pt',
+  BR: "pt",
+  PT: "pt",
+  AO: "pt",
+  MZ: "pt",
+  GW: "pt",
   // Morocco/MENA (French as default)
-  MA: 'fr', DZ: 'fr', TN: 'fr',
-}
+  MA: "fr",
+  DZ: "fr",
+  TN: "fr",
+};
 
 // Generate a client ID for freemium tracking
 function generateClientId(): string {
-  return 'hzn_' + crypto.randomUUID().replace(/-/g, '')
+  return "hzn_" + crypto.randomUUID().replace(/-/g, "");
 }
 
 export async function middleware(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
     request,
-  })
+  });
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -40,20 +78,28 @@ export async function middleware(request: NextRequest) {
     {
       cookies: {
         getAll() {
-          return request.cookies.getAll()
+          return request.cookies.getAll();
         },
-        setAll(cookiesToSet: { name: string; value: string; options: CookieOptions }[]) {
-          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+        setAll(
+          cookiesToSet: {
+            name: string;
+            value: string;
+            options: CookieOptions;
+          }[],
+        ) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
           supabaseResponse = NextResponse.next({
             request,
-          })
+          });
           cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options)
-          )
+            supabaseResponse.cookies.set(name, value, options),
+          );
         },
       },
-    }
-  )
+    },
+  );
 
   // IMPORTANT: Avoid writing any logic between createServerClient and
   // supabase.auth.getUser(). A simple mistake could make it very hard to debug
@@ -61,17 +107,17 @@ export async function middleware(request: NextRequest) {
 
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser();
 
   // Set client ID cookie if not present (for freemium tracking)
-  const clientIdCookie = request.cookies.get('huntzen_client_id')
+  const clientIdCookie = request.cookies.get("huntzen_client_id");
   if (!clientIdCookie) {
-    const newClientId = generateClientId()
-    supabaseResponse.cookies.set('huntzen_client_id', newClientId, {
-      path: '/',
+    const newClientId = generateClientId();
+    supabaseResponse.cookies.set("huntzen_client_id", newClientId, {
+      path: "/",
       maxAge: 365 * 24 * 60 * 60, // 1 year
-      sameSite: 'lax',
-    })
+      sameSite: "lax",
+    });
   }
 
   // ============================================================================
@@ -79,68 +125,82 @@ export async function middleware(request: NextRequest) {
   // ============================================================================
 
   // Check if locale already set (user preference takes priority)
-  const existingLocaleCookie = request.cookies.get('NEXT_LOCALE')
+  const existingLocaleCookie = request.cookies.get("NEXT_LOCALE");
 
   if (!existingLocaleCookie) {
-    let detectedLocale = DEFAULT_LOCALE
+    let detectedLocale = DEFAULT_LOCALE;
 
     // Priority 1: IP Geolocation (Vercel Edge provides request.geo automatically)
-    const geo = request.geo
-    const countryCode = geo?.country // ISO country code (e.g., "FR", "US", "BR")
+    const geo = request.geo;
+    const countryCode = geo?.country; // ISO country code (e.g., "FR", "US", "BR")
 
     if (countryCode && COUNTRY_TO_LANG[countryCode]) {
-      detectedLocale = COUNTRY_TO_LANG[countryCode]
+      detectedLocale = COUNTRY_TO_LANG[countryCode];
     } else {
       // Priority 2: Accept-Language header
-      const acceptLanguage = request.headers.get('accept-language')
+      const acceptLanguage = request.headers.get("accept-language");
       if (acceptLanguage) {
         // Parse "fr-FR,fr;q=0.9,en;q=0.8" → extract primary language
-        const primaryLang = acceptLanguage.split(',')[0].split('-')[0].toLowerCase()
+        const primaryLang = acceptLanguage
+          .split(",")[0]
+          .split("-")[0]
+          .toLowerCase();
         if (SUPPORTED_LOCALES.includes(primaryLang as any)) {
-          detectedLocale = primaryLang
+          detectedLocale = primaryLang;
         }
       }
     }
 
     // Set locale cookie (1 year expiry)
-    supabaseResponse.cookies.set('NEXT_LOCALE', detectedLocale, {
-      path: '/',
+    supabaseResponse.cookies.set("NEXT_LOCALE", detectedLocale, {
+      path: "/",
       maxAge: 365 * 24 * 60 * 60, // 1 year
-      sameSite: 'lax',
-    })
+      sameSite: "lax",
+    });
   }
 
-  // Routes protegees (premium only) - rediriger vers login si non authentifie
+  // Store referral code from ?ref=CODE in cookie (30 days)
+  const refCode = request.nextUrl.searchParams.get("ref");
+  if (refCode && /^HZN-[A-Z0-9]{6}$/.test(refCode)) {
+    supabaseResponse.cookies.set("huntzen_referral_code", refCode, {
+      path: "/",
+      maxAge: 30 * 24 * 60 * 60, // 30 days
+      sameSite: "lax",
+    });
+  }
+
+  // Routes protegees - rediriger vers login si non authentifie
   // Note: /jobs, /cv-analysis, /assistant sont maintenant accessibles sans compte (freemium)
-  const protectedRoutes = ['/dashboard', '/profile', '/saved-jobs']
-  const isProtectedRoute = protectedRoutes.some(route =>
-    request.nextUrl.pathname.startsWith(route)
-  )
+  // /admin is protected here (auth check), is_admin check is in the admin layout (Server Component)
+  const protectedRoutes = ["/dashboard", "/profile", "/saved-jobs", "/admin"];
+  const isProtectedRoute = protectedRoutes.some((route) =>
+    request.nextUrl.pathname.startsWith(route),
+  );
 
   if (isProtectedRoute && !user) {
-    const url = request.nextUrl.clone()
-    url.pathname = '/login'
-    url.searchParams.set('redirectTo', request.nextUrl.pathname)
-    return NextResponse.redirect(url)
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    url.searchParams.set("redirectTo", request.nextUrl.pathname);
+    return NextResponse.redirect(url);
   }
 
   // Routes auth - rediriger vers jobs si deja authentifie
-  const authRoutes = ['/login', '/signup']
-  const isAuthRoute = authRoutes.some(route =>
-    request.nextUrl.pathname === route
-  )
+  const authRoutes = ["/login", "/signup"];
+  const isAuthRoute = authRoutes.some(
+    (route) => request.nextUrl.pathname === route,
+  );
 
   if (isAuthRoute && user) {
-    const url = request.nextUrl.clone()
-    url.pathname = '/jobs'
-    return NextResponse.redirect(url)
+    const url = request.nextUrl.clone();
+    url.pathname = "/jobs";
+    return NextResponse.redirect(url);
   }
 
-  return supabaseResponse
+  return supabaseResponse;
 }
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
-}
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,11 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "https://www.huntzenjobs.com/**",
+  "https://huntzenjobs.com/**",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -222,10 +226,13 @@ otp_expiry = 3600
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+[auth.email.template.confirmation]
+subject = "Confirmez votre adresse email – Huntzen"
+content_path = "./templates/confirmation.html"
+
+[auth.email.template.recovery]
+subject = "Réinitialisez votre mot de passe – Huntzen"
+content_path = "./templates/recovery.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,11 +149,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = [
-  "https://127.0.0.1:3000",
-  "https://www.huntzenjobs.com/**",
-  "https://huntzenjobs.com/**",
-]
+additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -228,11 +224,11 @@ otp_expiry = 3600
 
 [auth.email.template.confirmation]
 subject = "Confirmez votre adresse email – Huntzen"
-content_path = "./templates/confirmation.html"
+content_path = "./supabase/templates/confirmation.html"
 
 [auth.email.template.recovery]
 subject = "Réinitialisez votre mot de passe – Huntzen"
-content_path = "./templates/recovery.html"
+content_path = "./supabase/templates/recovery.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]

--- a/supabase/migrations/20260227000001_admin_flag.sql
+++ b/supabase/migrations/20260227000001_admin_flag.sql
@@ -1,0 +1,160 @@
+-- ============================================
+-- ADMIN FLAG & USER STATUS
+-- Sprint 1 - Security Hardening
+-- ============================================
+
+-- Add is_admin boolean to profiles table
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Add user status for suspension/deletion
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active'
+  CHECK (status IN ('active', 'suspended', 'deleted'));
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS suspended_reason TEXT;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_profiles_is_admin ON profiles(is_admin) WHERE is_admin = TRUE;
+CREATE INDEX IF NOT EXISTS idx_profiles_status ON profiles(status) WHERE status != 'active';
+
+-- ============================================
+-- RLS POLICIES: Admin reads all profiles
+-- ============================================
+
+-- Admin can read all profiles
+DROP POLICY IF EXISTS "admins_read_all_profiles" ON profiles;
+CREATE POLICY "admins_read_all_profiles" ON profiles
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- Admin can update all profiles (suspend, reactivate, etc.)
+DROP POLICY IF EXISTS "admins_update_all_profiles" ON profiles;
+CREATE POLICY "admins_update_all_profiles" ON profiles
+  FOR UPDATE
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads all subscriptions
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_all_subscriptions" ON user_subscriptions;
+CREATE POLICY "admins_read_all_subscriptions" ON user_subscriptions
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+DROP POLICY IF EXISTS "admins_update_all_subscriptions" ON user_subscriptions;
+CREATE POLICY "admins_update_all_subscriptions" ON user_subscriptions
+  FOR ALL
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads all usage quotas
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_all_quotas" ON usage_quotas;
+CREATE POLICY "admins_read_all_quotas" ON usage_quotas
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads all security events
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_all_security_events" ON security_events;
+CREATE POLICY "admins_read_all_security_events" ON security_events
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin manages subscription plans
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_update_subscription_plans" ON subscription_plans;
+CREATE POLICY "admins_update_subscription_plans" ON subscription_plans
+  FOR UPDATE
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin manages stripe prices
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_manage_stripe_prices" ON stripe_prices;
+CREATE POLICY "admins_manage_stripe_prices" ON stripe_prices
+  FOR ALL
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads recruiter requests
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_all_recruiter_requests" ON recruiter_requests;
+CREATE POLICY "admins_read_all_recruiter_requests" ON recruiter_requests
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+DROP POLICY IF EXISTS "admins_update_recruiter_requests" ON recruiter_requests;
+CREATE POLICY "admins_update_recruiter_requests" ON recruiter_requests
+  FOR UPDATE
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads subscription history
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_subscription_history" ON subscription_history;
+CREATE POLICY "admins_read_subscription_history" ON subscription_history
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- RLS POLICIES: Admin reads webhook failures
+-- ============================================
+
+DROP POLICY IF EXISTS "admins_read_webhook_failures" ON webhook_failures;
+CREATE POLICY "admins_read_webhook_failures" ON webhook_failures
+  FOR SELECT
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+DROP POLICY IF EXISTS "admins_update_webhook_failures" ON webhook_failures;
+CREATE POLICY "admins_update_webhook_failures" ON webhook_failures
+  FOR UPDATE
+  USING (
+    auth.uid() IN (SELECT id FROM profiles WHERE is_admin = TRUE)
+  );
+
+-- ============================================
+-- COMMENTS
+-- ============================================
+
+COMMENT ON COLUMN profiles.is_admin IS 'Super admin flag. Set ONLY via Supabase Dashboard or SQL migration — no API endpoint.';
+COMMENT ON COLUMN profiles.status IS 'User account status: active (default), suspended (admin action), deleted (soft-delete).';
+COMMENT ON COLUMN profiles.suspended_reason IS 'Admin-provided reason for suspension, visible in admin panel.';
+
+-- =============================================
+-- NOTE: To grant admin access to the first user:
+-- UPDATE profiles SET is_admin = TRUE WHERE email = 'your-email@huntzen.io';
+-- =============================================

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Confirmez votre email – Huntzen</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#f4f6f9;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:560px;">
+
+          <!-- Header avec logo -->
+          <tr>
+            <td align="center" style="padding-bottom:24px;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="background-color:#0a0a1a;border-radius:12px;padding:16px 28px;">
+                    <!-- Logo texte Huntzen -->
+                    <span style="font-size:22px;font-weight:800;letter-spacing:-0.5px;color:#ffffff;">Hunt</span><span style="font-size:22px;font-weight:800;letter-spacing:-0.5px;color:#00D9FF;">zen</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Carte principale -->
+          <tr>
+            <td style="background-color:#ffffff;border-radius:16px;box-shadow:0 4px 24px rgba(0,0,0,0.08);overflow:hidden;">
+
+              <!-- Bande colorée en haut -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="background:linear-gradient(135deg,#00D9FF 0%,#0099cc 100%);height:6px;font-size:0;line-height:0;">&nbsp;</td>
+                </tr>
+              </table>
+
+              <!-- Icône succès -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td align="center" style="padding:40px 40px 24px;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#e8fafe;border-radius:50%;width:72px;height:72px;text-align:center;vertical-align:middle;">
+                          <!-- Enveloppe SVG -->
+                          <img src="https://cdn.jsdelivr.net/npm/twemoji@14/assets/svg/1f4e7.svg" width="36" height="36" alt="📧" style="display:block;margin:18px auto;" />
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Contenu -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="padding:0 40px 16px;">
+                    <h1 style="margin:0 0 12px;font-size:24px;font-weight:700;color:#0a0a1a;text-align:center;line-height:1.3;">
+                      Confirmez votre adresse email
+                    </h1>
+                    <p style="margin:0;font-size:16px;color:#4b5563;text-align:center;line-height:1.6;">
+                      Bienvenue sur <strong style="color:#0a0a1a;">Huntzen</strong> ! Plus qu'une étape pour accéder à toutes les offres d'emploi personnalisées pour vous.
+                    </p>
+                  </td>
+                </tr>
+
+                <!-- Email affiché -->
+                <tr>
+                  <td style="padding:16px 40px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#f0fbfe;border:1px solid #bae6fd;border-radius:8px;padding:12px 16px;text-align:center;">
+                          <span style="font-size:14px;color:#0369a1;font-weight:600;">{{ .Email }}</span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Bouton CTA -->
+                <tr>
+                  <td align="center" style="padding:8px 40px 32px;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="border-radius:12px;background-color:#00D9FF;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block;padding:16px 40px;font-size:16px;font-weight:700;color:#0a0a1a;text-decoration:none;border-radius:12px;letter-spacing:-0.2px;">
+                            ✓ &nbsp;Confirmer mon email
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Divider -->
+                <tr>
+                  <td style="padding:0 40px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="border-top:1px solid #e5e7eb;font-size:0;line-height:0;">&nbsp;</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Avertissement expiry -->
+                <tr>
+                  <td style="padding:20px 40px 16px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#fffbeb;border-left:4px solid #f59e0b;border-radius:0 8px 8px 0;padding:12px 16px;">
+                          <p style="margin:0;font-size:13px;color:#78350f;line-height:1.5;">
+                            <strong>⏱ Ce lien expire dans 24 heures.</strong><br/>
+                            Si vous n'avez pas créé de compte Huntzen, vous pouvez ignorer cet email.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Lien alternatif -->
+                <tr>
+                  <td style="padding:8px 40px 32px;">
+                    <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;line-height:1.6;">
+                      Le bouton ne fonctionne pas ? Copiez ce lien dans votre navigateur :<br/>
+                      <a href="{{ .ConfirmationURL }}" style="color:#00b8d9;word-break:break-all;font-size:11px;">{{ .ConfirmationURL }}</a>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Ce que vous obtenez -->
+          <tr>
+            <td style="padding:24px 0 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="background-color:#ffffff;border-radius:12px;padding:24px 32px;">
+                    <p style="margin:0 0 16px;font-size:13px;font-weight:700;color:#6b7280;text-transform:uppercase;letter-spacing:0.5px;">
+                      Ce qui vous attend
+                    </p>
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="padding:6px 0;">
+                          <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                            <tr>
+                              <td style="width:28px;vertical-align:top;padding-top:1px;">
+                                <span style="display:inline-block;width:20px;height:20px;background-color:#00D9FF;border-radius:50%;text-align:center;font-size:11px;line-height:20px;font-weight:700;color:#0a0a1a;">✓</span>
+                              </td>
+                              <td style="font-size:14px;color:#374151;padding-left:8px;">
+                                <strong>Milliers d'offres</strong> agrégées en temps réel
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding:6px 0;">
+                          <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                            <tr>
+                              <td style="width:28px;vertical-align:top;padding-top:1px;">
+                                <span style="display:inline-block;width:20px;height:20px;background-color:#00D9FF;border-radius:50%;text-align:center;font-size:11px;line-height:20px;font-weight:700;color:#0a0a1a;">✓</span>
+                              </td>
+                              <td style="font-size:14px;color:#374151;padding-left:8px;">
+                                <strong>CV adapté</strong> automatiquement à chaque offre
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="padding:6px 0;">
+                          <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                            <tr>
+                              <td style="width:28px;vertical-align:top;padding-top:1px;">
+                                <span style="display:inline-block;width:20px;height:20px;background-color:#00D9FF;border-radius:50%;text-align:center;font-size:11px;line-height:20px;font-weight:700;color:#0a0a1a;">✓</span>
+                              </td>
+                              <td style="font-size:14px;color:#374151;padding-left:8px;">
+                                <strong>Assistant IA</strong> disponible 24h/24
+                              </td>
+                            </tr>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding:24px 0 0;">
+              <p style="margin:0 0 8px;font-size:12px;color:#9ca3af;">
+                Huntzen — La plateforme intelligente de recherche d'emploi
+              </p>
+              <p style="margin:0;font-size:11px;color:#d1d5db;">
+                Vous recevez cet email car vous venez de créer un compte sur
+                <a href="https://www.huntzenjobs.com" style="color:#00b8d9;text-decoration:none;">huntzenjobs.com</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Réinitialisez votre mot de passe – Huntzen</title>
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f9;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#f4f6f9;">
+    <tr>
+      <td align="center" style="padding:40px 16px;">
+
+        <!-- Container -->
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:560px;">
+
+          <!-- Header avec logo -->
+          <tr>
+            <td align="center" style="padding-bottom:24px;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="background-color:#0a0a1a;border-radius:12px;padding:16px 28px;">
+                    <span style="font-size:22px;font-weight:800;letter-spacing:-0.5px;color:#ffffff;">Hunt</span><span style="font-size:22px;font-weight:800;letter-spacing:-0.5px;color:#00D9FF;">zen</span>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Carte principale -->
+          <tr>
+            <td style="background-color:#ffffff;border-radius:16px;box-shadow:0 4px 24px rgba(0,0,0,0.08);overflow:hidden;">
+
+              <!-- Bande colorée en haut -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="background:linear-gradient(135deg,#00D9FF 0%,#0099cc 100%);height:6px;font-size:0;line-height:0;">&nbsp;</td>
+                </tr>
+              </table>
+
+              <!-- Icône cadenas -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td align="center" style="padding:40px 40px 24px;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#e8fafe;border-radius:50%;width:72px;height:72px;text-align:center;vertical-align:middle;">
+                          <img src="https://cdn.jsdelivr.net/npm/twemoji@14/assets/svg/1f512.svg" width="36" height="36" alt="🔒" style="display:block;margin:18px auto;" />
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Contenu -->
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                <tr>
+                  <td style="padding:0 40px 16px;">
+                    <h1 style="margin:0 0 12px;font-size:24px;font-weight:700;color:#0a0a1a;text-align:center;line-height:1.3;">
+                      Réinitialisez votre mot de passe
+                    </h1>
+                    <p style="margin:0;font-size:16px;color:#4b5563;text-align:center;line-height:1.6;">
+                      Vous avez demandé la réinitialisation du mot de passe associé au compte :
+                    </p>
+                  </td>
+                </tr>
+
+                <!-- Email affiché -->
+                <tr>
+                  <td style="padding:16px 40px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#f0fbfe;border:1px solid #bae6fd;border-radius:8px;padding:12px 16px;text-align:center;">
+                          <span style="font-size:14px;color:#0369a1;font-weight:600;">{{ .Email }}</span>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Bouton CTA -->
+                <tr>
+                  <td align="center" style="padding:8px 40px 24px;">
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="border-radius:12px;background-color:#00D9FF;">
+                          <a href="{{ .ConfirmationURL }}"
+                             target="_blank"
+                             style="display:inline-block;padding:16px 40px;font-size:16px;font-weight:700;color:#0a0a1a;text-decoration:none;border-radius:12px;letter-spacing:-0.2px;">
+                            🔑 &nbsp;Choisir un nouveau mot de passe
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Divider -->
+                <tr>
+                  <td style="padding:0 40px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="border-top:1px solid #e5e7eb;font-size:0;line-height:0;">&nbsp;</td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Avertissement sécurité -->
+                <tr>
+                  <td style="padding:20px 40px 16px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#fffbeb;border-left:4px solid #f59e0b;border-radius:0 8px 8px 0;padding:12px 16px;">
+                          <p style="margin:0;font-size:13px;color:#78350f;line-height:1.5;">
+                            <strong>⏱ Ce lien expire dans 1 heure.</strong><br/>
+                            Si vous n'avez pas demandé cette réinitialisation, ignorez cet email. Votre mot de passe restera inchangé.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Conseil sécurité -->
+                <tr>
+                  <td style="padding:8px 40px 24px;">
+                    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                      <tr>
+                        <td style="background-color:#f9fafb;border-radius:8px;padding:12px 16px;">
+                          <p style="margin:0;font-size:13px;color:#6b7280;line-height:1.6;">
+                            <strong style="color:#374151;">Conseils pour un mot de passe sécurisé :</strong><br/>
+                            Utilisez au minimum 8 caractères, mélangez majuscules, chiffres et symboles.
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+
+                <!-- Lien alternatif -->
+                <tr>
+                  <td style="padding:0 40px 32px;">
+                    <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;line-height:1.6;">
+                      Le bouton ne fonctionne pas ? Copiez ce lien dans votre navigateur :<br/>
+                      <a href="{{ .ConfirmationURL }}" style="color:#00b8d9;word-break:break-all;font-size:11px;">{{ .ConfirmationURL }}</a>
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td align="center" style="padding:24px 0 0;">
+              <p style="margin:0 0 8px;font-size:12px;color:#9ca3af;">
+                Huntzen — La plateforme intelligente de recherche d'emploi
+              </p>
+              <p style="margin:0;font-size:11px;color:#d1d5db;">
+                Vous recevez cet email car une demande de réinitialisation a été effectuée sur
+                <a href="https://www.huntzenjobs.com" style="color:#00b8d9;text-decoration:none;">huntzenjobs.com</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
Closes #90

## Problème
Le lien de reset password redirige vers `/login` au lieu de `/reset-password`.

**Cause racine :** `route.ts` est un server-side handler. Les navigateurs n'envoient jamais le fragment `#...` au serveur. Si Supabase envoie un token recovery via `#access_token=xxx`, le `route.ts` reçoit une requête sans `code` → redirige vers `/login`.

## Solution
Nouvelle page client `/auth/recovery` dédiée aux emails de réinitialisation :
- **PKCE** (`?code=xxx`) → `exchangeCodeForSession` → `/reset-password`
- **Implicit** (`#access_token=xxx`) → `onAuthStateChange PASSWORD_RECOVERY` → `/reset-password`
- Timeout 6s → `/forgot-password?error=expired` si aucun event

`/auth/callback/route.ts` **inchangé** — Google OAuth continue de fonctionner.

## Fichiers
- `frontend-next/src/app/auth/recovery/page.tsx` — nouvelle page client
- `frontend-next/src/contexts/auth-context.tsx` — `redirectTo` → `/auth/recovery`

## Test
- [ ] Clic sur lien de reset password → `/reset-password` (plus `/login`)
- [ ] Lien expiré/invalide → `/forgot-password` avec message d'erreur
- [ ] Google OAuth → toujours fonctionnel via `/auth/callback`