### PR TITLE
fix: CV generation 422 — wrong agent used for PDF text extraction

### DIFF
--- a/backend/src/api/routes/cv_adapter.py
+++ b/backend/src/api/routes/cv_adapter.py
@@ -179,8 +179,8 @@ async def adapt_cv_from_file(
     
     Supports PDF and DOCX formats.
     """
-    from src.api.deps import get_cv_agent
-    
+    from src.api.deps import get_cv_analyzer_main
+
     # Validate file
     if not file.filename:
         raise HTTPException(
@@ -214,10 +214,10 @@ async def adapt_cv_from_file(
                     logger.warning(
                         f"[cv_adapter] Modal extraction failed, falling back to local: {modal_exc}"
                     )
-                    cv_analyzer = get_cv_agent()
+                    cv_analyzer = get_cv_analyzer_main()
                     cv_text = await cv_analyzer.extract_text_from_pdf(content)
             else:
-                cv_analyzer = get_cv_agent()
+                cv_analyzer = get_cv_analyzer_main()
                 cv_text = await cv_analyzer.extract_text_from_pdf(content)
         else:
             from docx import Document


### PR DESCRIPTION
## Summary

- **Root cause:** `adapt_cv_from_file` was calling `get_cv_agent()` which returns `CVAnalyzerConversationalAgent`. This class inherits from `BaseAgent` and has **no `extract_text_from_pdf` method** — only `CVAnalyzerAgent` (the main agent) has it.
- **Symptom:** `POST /api/cv-adapter/adapt/upload` raised `AttributeError` caught as `HTTP 422 Unprocessable Content: "Could not extract text from file: ..."`.
- **Fix:** Replace `get_cv_agent()` with `get_cv_analyzer_main()` (returns `CVAnalyzerAgent`) in both the Modal fallback path and the direct local extraction path.

## Changes

- `backend/src/api/routes/cv_adapter.py` — 3-line change: import `get_cv_analyzer_main` instead of `get_cv_agent`, use it in both PDF extraction paths.

## Test plan

- [ ] Upload a PDF CV → should return 200 with adapted CV JSON instead of 422
- [ ] Upload a DOCX CV → still works (unaffected path)
- [ ] Confirm Railway logs show no more `AttributeError` on `/adapt/upload`