### PR TITLE
fix: docling 422 — torchvision CPU index mismatch + Modal libGL

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y \
 # Copy pyproject.toml for dependencies
 COPY pyproject.toml .
 
-# Install PyTorch CPU and dependencies from pyproject.toml
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu \
+# Install PyTorch CPU and torchvision from the same index (ensures operator compatibility)
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu \
     && pip install --no-cache-dir -e .
 
 # Stage 2: Production
@@ -45,8 +45,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Install PyTorch CPU first
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+# Install PyTorch CPU + torchvision from the same index (ensures operator compatibility)
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
 # Copy pyproject.toml and install dependencies
 COPY pyproject.toml .

--- a/backend/modal_pdf_extractor_app.py
+++ b/backend/modal_pdf_extractor_app.py
@@ -20,7 +20,7 @@ app = modal.App("huntzen-pdf-extractor")
 # Image with docling installed (loads heavy ML models once per container)
 docling_image = (
     modal.Image.debian_slim(python_version="3.11")
-    .apt_install(["libgomp1"])  # Required by some docling dependencies
+    .apt_install(["libgomp1", "libgl1-mesa-glx", "libglib2.0-0"])  # OpenGL + OpenMP required by docling/torchvision
     .pip_install([
         "docling>=2.0.0",
         "docling-core>=2.0.0",


### PR DESCRIPTION
## Problem

`POST /api/cv-adapter/adapt/upload` returned 422 in two stages:

1. **Railway**: `RuntimeError: operator torchvision::nms does not exist`
   - `torch` was pre-installed from the PyTorch CPU wheel index
   - `torchvision` was then pulled from PyPI by docling's dependency resolver
   - The two came from different sources → version/operator mismatch

2. **Modal**: `libGL.so.1: cannot open shared object file`
   - Modal image only had `libgomp1`; docling/torchvision needs OpenGL

## Fix

- **Dockerfile** (stages 1 & 2): install `torch torchvision` together from the same PyTorch CPU index _before_ `pip install -e .`, so docling picks up the already-installed CPU-compatible wheel instead of a generic PyPI wheel.
- **modal_pdf_extractor_app.py**: add `libgl1-mesa-glx` + `libglib2.0-0` to `apt_install` for the Mesa headless OpenGL implementation.

## Changes

- `backend/Dockerfile` — 2 lines changed
- `backend/modal_pdf_extractor_app.py` — 1 line changed

## Test plan

- [ ] Upload PDF CV via UI → 200 OK instead of 422
- [ ] Railway logs: no more `torchvision::nms does not exist`
- [ ] Modal: no more `libGL.so.1` error (after `modal deploy`)