### PR TITLE
fix: rapidocr Permission denied — chmod site-packages for non-root user

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -57,6 +57,10 @@ RUN pip install --no-cache-dir -e .
 RUN mkdir -p /usr/local/lib/python3.11/site-packages/static && \
     chmod -R 777 /usr/local/lib/python3.11/site-packages/static
 
+# Make all installed package files readable by non-root user (huntzen)
+# Docling uses rapidocr whose .pth model files default to root-only permissions
+RUN chmod -R a+rX /usr/local/lib/python3.11/site-packages/
+
 # Copy NEW application structure
 COPY --chown=huntzen:huntzen src/ ./src/
 COPY --chown=huntzen:huntzen app/ ./app/


### PR DESCRIPTION
## Problem

After the torchvision fix, docling now reaches rapidocr for OCR but fails with:
```
[Errno 13] Permission denied: '/usr/local/lib/python3.11/site-packages/rapidocr/models/ch_PP-OCRv4_det_infer.pth'
```

Rapidocr model files (`.pth`) are installed with root-only permissions. The app runs as the non-root `huntzen` user → can't read the models.

## Fix

Add `chmod -R a+rX /usr/local/lib/python3.11/site-packages/` in the Dockerfile after all pip installs and before `USER huntzen`. This makes all installed library files readable by any user.

`a+rX` = read for all + execute only for directories (safe, doesn't make files executable).

## Changes

- `backend/Dockerfile` — 3 lines added