### PR TITLE
fix: disable Docling OCR to prevent RapidOCR permission denied

### DIFF
--- a/backend/modal_pdf_extractor_app.py
+++ b/backend/modal_pdf_extractor_app.py
@@ -51,6 +51,8 @@ async def extract_pdf_text(body: dict) -> dict:
     import os
     import tempfile
     from docling.document_converter import DocumentConverter
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
+    from docling.datamodel.base_models import InputFormat
 
     pdf_bytes_b64 = body.get("pdf_bytes")
     if not pdf_bytes_b64:
@@ -68,7 +70,8 @@ async def extract_pdf_text(body: dict) -> dict:
             tmp.write(pdf_bytes)
             tmp_path = tmp.name
 
-        converter = DocumentConverter()
+        pdf_options = PdfPipelineOptions(do_ocr=False)
+        converter = DocumentConverter(format_options={InputFormat.PDF: pdf_options})
         result = converter.convert(tmp_path)
         text = result.document.export_to_markdown()
 

--- a/backend/src/agents/cv_analyzer/main_agent.py
+++ b/backend/src/agents/cv_analyzer/main_agent.py
@@ -101,9 +101,17 @@ class CVAnalyzerAgent(BaseAgent):
         """Lazy load Docling converter."""
         if self._docling_converter is None:
             from docling.document_converter import DocumentConverter
+            from docling.datamodel.pipeline_options import PdfPipelineOptions
+            from docling.datamodel.base_models import InputFormat
+
             logger.info(f"[{self.name}] Initializing Docling converter...")
-            self._docling_converter = DocumentConverter()
-            logger.info(f"[{self.name}] Docling ready")
+            # CVs are text-based PDFs — OCR is unnecessary and triggers
+            # RapidOCR model downloads that fail in non-root containers
+            pdf_options = PdfPipelineOptions(do_ocr=False)
+            self._docling_converter = DocumentConverter(
+                format_options={InputFormat.PDF: pdf_options}
+            )
+            logger.info(f"[{self.name}] Docling ready (OCR disabled for text-based PDFs)")
         return self._docling_converter
     
     async def run(


### PR DESCRIPTION
## Problem

After the torchvision fix, docling now initializes but triggers RapidOCR:
```
[RapidOCR] Initiating download: ch_PP-OCRv4_det_infer.pth (13.83MB)
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.11/site-packages/rapidocr/models/...'
```

Docling's default `do_ocr=True` causes RapidOCR to download ~14MB model files at runtime into `site-packages/rapidocr/models/`. The non-root `huntzen` user has no write permissions there.

## Root cause

CVs are **text-based PDFs** (created in Word/Google Docs). They already have an embedded text layer. OCR is only needed for scanned/image PDFs — completely unnecessary for standard CVs.

## Fix

Pass `PdfPipelineOptions(do_ocr=False)` when initializing `DocumentConverter` in:
- `backend/src/agents/cv_analyzer/main_agent.py` — local fallback extractor
- `backend/modal_pdf_extractor_app.py` — Modal PDF extraction handler

**Not modified**: `scripts/deployment/modal_app.py` (ATS analysis Modal — works fine, separate deployment).

## Changes

- `backend/src/agents/cv_analyzer/main_agent.py` — 9 lines changed
- `backend/modal_pdf_extractor_app.py` — 4 lines changed

## Test plan

- [ ] Upload PDF CV → 200 OK, no more RapidOCR download in Railway logs
- [ ] ATS analysis still works (unaffected — different Modal deployment)
- [ ] CV + cover letter generation works end-to-end in the UI