### PR TITLE
feat: Manual CV Builder + Profile Management

### DIFF
--- a/frontend-next/src/app/(dashboard)/documents/page.tsx
+++ b/frontend-next/src/app/(dashboard)/documents/page.tsx
@@ -7,23 +7,41 @@ import {
   ExternalLink,
   Trash2,
   Search,
+  User,
+  Plus,
+  Pencil,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDocuments, type UserDocument } from "@/hooks/use-documents";
+import { useCvProfiles, type CvProfile } from "@/hooks/use-cv-profiles";
+import { CvBuilderWizard } from "@/components/cv-builder/cv-builder-wizard";
+import type { CvData } from "@/components/cv-builder/types";
 import { format } from "date-fns";
 import { fr } from "date-fns/locale";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 type Filter = "all" | "cv-only" | "cv-lm";
 
 export default function DocumentsPage() {
   const t = useTranslations("dashboard.documents");
   const { documents, loading, fetchDocuments, deleteDocument } = useDocuments();
+  const {
+    profiles,
+    loading: profilesLoading,
+    fetchProfiles,
+    saveProfile,
+    updateProfile,
+    deleteProfile,
+  } = useCvProfiles();
+
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("all");
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [editingProfile, setEditingProfile] = useState<CvProfile | null>(null);
 
   const FILTER_LABELS: Record<Filter, string> = {
     all: t("filterAll"),
@@ -33,7 +51,8 @@ export default function DocumentsPage() {
 
   useEffect(() => {
     fetchDocuments();
-  }, [fetchDocuments]);
+    fetchProfiles();
+  }, [fetchDocuments, fetchProfiles]);
 
   const filtered = documents.filter((doc) => {
     const matchSearch =
@@ -46,67 +65,250 @@ export default function DocumentsPage() {
     return matchSearch && matchFilter;
   });
 
+  const handleWizardSave = async (name: string, data: CvData) => {
+    if (editingProfile) {
+      const ok = await updateProfile(
+        editingProfile.id,
+        name,
+        data as unknown as Record<string, unknown>
+      );
+      if (ok) {
+        toast.success("Profil mis à jour !");
+      } else {
+        toast.error("Erreur lors de la mise à jour du profil.");
+      }
+    } else {
+      const saved = await saveProfile(name, data as unknown as Record<string, unknown>);
+      if (saved) {
+        toast.success("Profil sauvegardé !");
+      } else {
+        toast.error("Erreur lors de la sauvegarde du profil.");
+      }
+    }
+    setEditingProfile(null);
+  };
+
+  const handleDeleteProfile = async (id: string) => {
+    await deleteProfile(id);
+    toast.success("Profil supprimé.");
+  };
+
+  const openEditWizard = (profile: CvProfile) => {
+    setEditingProfile(profile);
+    setWizardOpen(true);
+  };
+
+  const openNewWizard = () => {
+    setEditingProfile(null);
+    setWizardOpen(true);
+  };
+
   return (
-    <div className="p-6 max-w-3xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{t("title")}</h1>
-        <p className="text-gray-500 text-sm mt-1">
-          {t("subtitle")}
-          {documents.length > 0 && (
-            <span className="ml-1 text-gray-400">({documents.length})</span>
-          )}
-        </p>
-      </div>
+    <>
+      <div className="p-6 max-w-3xl mx-auto space-y-8">
 
-      {/* Filters */}
-      <div className="flex items-center gap-3 mb-6 flex-wrap">
-        <div className="relative flex-1 min-w-48">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-          <Input
-            placeholder={t("searchPlaceholder")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-9"
-          />
-        </div>
-        <div className="flex gap-2">
-          {(["all", "cv-only", "cv-lm"] as Filter[]).map((f) => (
+        {/* ── Section Profils CV ── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 flex items-center gap-2">
+                <User className="h-5 w-5 text-[#00D9FF]" />
+                Mes profils CV
+              </h2>
+              <p className="text-gray-500 text-xs mt-0.5">
+                Réutilisez votre profil pour générer des documents adaptés à chaque offre
+              </p>
+            </div>
             <Button
-              key={f}
-              variant={filter === f ? "default" : "outline"}
               size="sm"
-              onClick={() => setFilter(f)}
+              onClick={openNewWizard}
+              className="bg-[#00D9FF] text-gray-900 hover:bg-[#00b8d9]"
             >
-              {FILTER_LABELS[f]}
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Créer un profil
             </Button>
-          ))}
-        </div>
+          </div>
+
+          {profilesLoading ? (
+            <div className="space-y-2">
+              {[1, 2].map((i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : profiles.length === 0 ? (
+            <div className="rounded-xl border-2 border-dashed border-gray-200 p-8 text-center">
+              <User className="h-10 w-10 mx-auto mb-3 text-gray-300" />
+              <p className="text-sm font-medium text-gray-500 mb-1">
+                Aucun profil CV créé
+              </p>
+              <p className="text-xs text-gray-400 mb-4">
+                Créez votre profil une fois et utilisez-le pour toutes vos candidatures sans re-uploader votre CV
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={openNewWizard}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Créer mon premier profil
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {profiles.map((profile) => (
+                <ProfileCard
+                  key={profile.id}
+                  profile={profile}
+                  onEdit={() => openEditWizard(profile)}
+                  onDelete={() => handleDeleteProfile(profile.id)}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* ── Divider ── */}
+        <div className="border-t border-gray-100" />
+
+        {/* ── Section Documents générés ── */}
+        <section>
+          <div className="mb-4">
+            <h2 className="text-lg font-bold text-gray-900">
+              {t("title")}
+            </h2>
+            <p className="text-gray-500 text-sm mt-1">
+              {t("subtitle")}
+              {documents.length > 0 && (
+                <span className="ml-1 text-gray-400">({documents.length})</span>
+              )}
+            </p>
+          </div>
+
+          {/* Filters */}
+          <div className="flex items-center gap-3 mb-4 flex-wrap">
+            <div className="relative flex-1 min-w-48">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <Input
+                placeholder={t("searchPlaceholder")}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+            <div className="flex gap-2">
+              {(["all", "cv-only", "cv-lm"] as Filter[]).map((f) => (
+                <Button
+                  key={f}
+                  variant={filter === f ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setFilter(f)}
+                >
+                  {FILTER_LABELS[f]}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {/* Content */}
+          {loading ? (
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-24 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <EmptyState hasDocuments={documents.length > 0} t={t} />
+          ) : (
+            <div className="space-y-3">
+              {filtered.map((doc) => (
+                <DocumentCard
+                  key={doc.id}
+                  doc={doc}
+                  onDelete={() => deleteDocument(doc.id)}
+                  t={t}
+                />
+              ))}
+            </div>
+          )}
+        </section>
       </div>
 
-      {/* Content */}
-      {loading ? (
-        <div className="space-y-3">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-lg" />
-          ))}
+      {/* CV Builder Wizard */}
+      <CvBuilderWizard
+        open={wizardOpen}
+        onOpenChange={(v) => {
+          setWizardOpen(v);
+          if (!v) setEditingProfile(null);
+        }}
+        initialData={
+          editingProfile
+            ? (editingProfile.cv_data as unknown as Partial<CvData>)
+            : undefined
+        }
+        initialName={editingProfile?.name}
+        onSave={handleWizardSave}
+      />
+    </>
+  );
+}
+
+// ── ProfileCard ──────────────────────────────────────────────────────────────
+
+function ProfileCard({
+  profile,
+  onEdit,
+  onDelete,
+}: {
+  profile: CvProfile;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const cvData = profile.cv_data as Record<string, Record<string, string>>;
+  const name = cvData?.personal_info?.name;
+  const title = cvData?.personal_info?.title;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 flex items-center justify-between gap-4 hover:border-gray-300 transition-colors">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="h-9 w-9 rounded-full bg-[#00D9FF]/10 flex items-center justify-center shrink-0">
+          <User className="h-4 w-4 text-[#00D9FF]" />
         </div>
-      ) : filtered.length === 0 ? (
-        <EmptyState hasDocuments={documents.length > 0} t={t} />
-      ) : (
-        <div className="space-y-3">
-          {filtered.map((doc) => (
-            <DocumentCard
-              key={doc.id}
-              doc={doc}
-              onDelete={() => deleteDocument(doc.id)}
-              t={t}
-            />
-          ))}
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900 text-sm truncate">
+            {profile.name}
+          </p>
+          <p className="text-xs text-gray-500 truncate">
+            {name && title ? `${name} · ${title}` : name || title || "Profil CV"}
+            {" · "}
+            Modifié le{" "}
+            {format(new Date(profile.updated_at), "d MMM yyyy", { locale: fr })}
+          </p>
         </div>
-      )}
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-gray-500 hover:text-gray-900"
+          onClick={onEdit}
+        >
+          <Pencil className="h-3.5 w-3.5 mr-1.5" />
+          Modifier
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-gray-300 hover:text-red-500 hover:bg-red-50"
+          onClick={onDelete}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
     </div>
   );
 }
+
+// ── EmptyState ───────────────────────────────────────────────────────────────
 
 function EmptyState({
   hasDocuments,
@@ -119,11 +321,9 @@ function EmptyState({
     <div className="text-center py-16 text-gray-400">
       <FolderOpen className="h-12 w-12 mx-auto mb-3 opacity-30" />
       <p className="text-sm font-medium text-gray-500 mb-1">
-        {hasDocuments ? t("emptyStateTitle") : t("emptyStateTitle")}
+        {t("emptyStateTitle")}
       </p>
-      <p className="text-xs text-gray-400 mb-4">
-        {hasDocuments ? t("emptyStateSubtitle") : t("emptyStateSubtitle")}
-      </p>
+      <p className="text-xs text-gray-400 mb-4">{t("emptyStateSubtitle")}</p>
       {!hasDocuments && (
         <Button variant="outline" size="sm" asChild>
           <a href="/jobs">Parcourir les offres</a>
@@ -132,6 +332,8 @@ function EmptyState({
     </div>
   );
 }
+
+// ── DocumentCard ─────────────────────────────────────────────────────────────
 
 function DocumentCard({
   doc,

--- a/frontend-next/src/components/cv-builder/cv-builder-wizard.tsx
+++ b/frontend-next/src/components/cv-builder/cv-builder-wizard.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { Loader2, Check } from "lucide-react";
+
+import type { CvData, PersonalInfo, Experience, Education, Skills } from "./types";
+import { StepPersonalInfo } from "./steps/step-personal-info";
+import { StepSummary } from "./steps/step-summary";
+import { StepExperiences } from "./steps/step-experiences";
+import { StepEducation } from "./steps/step-education";
+import { StepSkills } from "./steps/step-skills";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface CvBuilderWizardProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Pre-fill with existing profile data for edit mode */
+  initialData?: Partial<CvData>;
+  initialName?: string;
+  onSave: (name: string, data: CvData) => Promise<void>;
+}
+
+// ── Step config ───────────────────────────────────────────────────────────────
+
+const STEPS = [
+  { label: "Infos perso.", short: "1" },
+  { label: "Résumé",      short: "2" },
+  { label: "Expériences", short: "3" },
+  { label: "Formation",   short: "4" },
+  { label: "Compétences", short: "5" },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildEmpty(): CvData {
+  return {
+    personal_info: { name: "", email: "", phone: "", location: "" },
+    summary: "",
+    experiences: [],
+    education: [],
+    skills: { technical: [], soft: [], languages: [] },
+  };
+}
+
+function mergeInitial(initial?: Partial<CvData>): CvData {
+  const base = buildEmpty();
+  if (!initial) return base;
+  return {
+    personal_info: { ...base.personal_info, ...(initial.personal_info ?? {}) },
+    summary: initial.summary ?? base.summary,
+    experiences: initial.experiences ?? base.experiences,
+    education: initial.education ?? base.education,
+    skills: {
+      technical: initial.skills?.technical ?? [],
+      soft: initial.skills?.soft ?? [],
+      languages: initial.skills?.languages ?? [],
+    },
+    certifications: initial.certifications,
+    projects: initial.projects,
+  };
+}
+
+function isStep0Valid(data: CvData): boolean {
+  return (
+    data.personal_info.name.trim().length > 0 &&
+    data.personal_info.email.trim().length > 0
+  );
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function CvBuilderWizard({
+  open,
+  onOpenChange,
+  initialData,
+  initialName = "Mon CV",
+  onSave,
+}: CvBuilderWizardProps) {
+  const [step, setStep] = useState(0);
+  const [profileName, setProfileName] = useState(initialName);
+  const [formData, setFormData] = useState<CvData>(() =>
+    mergeInitial(initialData)
+  );
+  const [saving, setSaving] = useState(false);
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) {
+      // Reset on close only if not saving
+      if (!saving) {
+        setStep(0);
+        setFormData(mergeInitial(initialData));
+        setProfileName(initialName);
+      }
+    }
+    onOpenChange(v);
+  };
+
+  const updatePersonalInfo = (updates: Partial<PersonalInfo>) =>
+    setFormData((d) => ({
+      ...d,
+      personal_info: { ...d.personal_info, ...updates },
+    }));
+
+  const updateSummary = (value: string) =>
+    setFormData((d) => ({ ...d, summary: value }));
+
+  const updateExperiences = (experiences: Experience[]) =>
+    setFormData((d) => ({ ...d, experiences }));
+
+  const updateEducation = (education: Education[]) =>
+    setFormData((d) => ({ ...d, education }));
+
+  const updateSkills = (skills: Skills) =>
+    setFormData((d) => ({ ...d, skills }));
+
+  const canNext =
+    step === 0 ? isStep0Valid(formData) : true;
+
+  const handleSave = async () => {
+    if (!isStep0Valid(formData)) return;
+    setSaving(true);
+    try {
+      await onSave(profileName.trim() || "Mon CV", formData);
+      onOpenChange(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-xl bg-white max-h-[90vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="text-slate-900">
+            {initialData ? "Modifier le profil CV" : "Créer un profil CV"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Profile name (always visible) */}
+        <div className="flex items-center gap-2 pb-2 border-b border-gray-100">
+          <Label htmlFor="profile-name" className="text-xs whitespace-nowrap text-gray-500">
+            Nom du profil :
+          </Label>
+          <Input
+            id="profile-name"
+            value={profileName}
+            onChange={(e) => setProfileName(e.target.value)}
+            placeholder="Mon CV principal"
+            className="h-7 text-sm border-0 border-b border-gray-200 rounded-none px-0 focus-visible:ring-0 focus-visible:border-[#00D9FF]"
+          />
+        </div>
+
+        {/* Step indicators */}
+        <div className="flex items-center gap-1.5 py-1">
+          {STEPS.map((s, i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <button
+                onClick={() => i < step && setStep(i)}
+                disabled={i >= step}
+                className={cn(
+                  "flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold transition-colors",
+                  i < step
+                    ? "bg-[#00D9FF] text-gray-900 cursor-pointer"
+                    : i === step
+                    ? "bg-gray-900 text-white"
+                    : "bg-gray-100 text-gray-400"
+                )}
+              >
+                {i < step ? <Check className="h-3 w-3" /> : s.short}
+              </button>
+              <span
+                className={cn(
+                  "text-xs hidden sm:block",
+                  i === step ? "text-gray-800 font-medium" : "text-gray-400"
+                )}
+              >
+                {s.label}
+              </span>
+              {i < STEPS.length - 1 && (
+                <div
+                  className={cn(
+                    "flex-1 h-px w-4 mx-1",
+                    i < step ? "bg-[#00D9FF]" : "bg-gray-200"
+                  )}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Step content — scrollable */}
+        <div className="flex-1 overflow-y-auto min-h-0 py-2">
+          {step === 0 && (
+            <StepPersonalInfo
+              data={formData.personal_info}
+              onChange={updatePersonalInfo}
+            />
+          )}
+          {step === 1 && (
+            <StepSummary
+              value={formData.summary ?? ""}
+              onChange={updateSummary}
+            />
+          )}
+          {step === 2 && (
+            <StepExperiences
+              data={formData.experiences}
+              onChange={updateExperiences}
+            />
+          )}
+          {step === 3 && (
+            <StepEducation
+              data={formData.education}
+              onChange={updateEducation}
+            />
+          )}
+          {step === 4 && (
+            <StepSkills data={formData.skills} onChange={updateSkills} />
+          )}
+        </div>
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between pt-3 border-t border-gray-100">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setStep((s) => s - 1)}
+            disabled={step === 0}
+          >
+            Précédent
+          </Button>
+
+          {step < STEPS.length - 1 ? (
+            <Button
+              size="sm"
+              onClick={() => setStep((s) => s + 1)}
+              disabled={!canNext}
+              className="bg-gray-900 hover:bg-gray-700 text-white"
+            >
+              Suivant
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={saving || !isStep0Valid(formData)}
+              className="bg-[#00D9FF] text-gray-900 hover:bg-[#00b8d9]"
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Sauvegarde...
+                </>
+              ) : (
+                "Sauvegarder le profil"
+              )}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend-next/src/components/cv-builder/steps/step-education.tsx
+++ b/frontend-next/src/components/cv-builder/steps/step-education.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Trash2, GraduationCap } from "lucide-react";
+import type { Education } from "../types";
+
+interface Props {
+  data: Education[];
+  onChange: (data: Education[]) => void;
+}
+
+const EMPTY_EDU: Education = {
+  degree: "",
+  institution: "",
+  year: "",
+  field: "",
+};
+
+export function StepEducation({ data, onChange }: Props) {
+  const [showForm, setShowForm] = useState(data.length === 0);
+  const [draft, setDraft] = useState<Education>({ ...EMPTY_EDU });
+
+  const addEducation = () => {
+    if (!draft.degree || !draft.institution) return;
+    onChange([...data, { ...draft }]);
+    setDraft({ ...EMPTY_EDU });
+    setShowForm(false);
+  };
+
+  const removeEducation = (idx: number) =>
+    onChange(data.filter((_, i) => i !== idx));
+
+  const updateField = (key: keyof Education, value: string) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  return (
+    <div className="space-y-3">
+      {data.length > 0 && (
+        <div className="space-y-2">
+          {data.map((edu, idx) => (
+            <div
+              key={idx}
+              className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3"
+            >
+              <GraduationCap className="h-4 w-4 text-gray-400 mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm text-gray-900">{edu.degree}</p>
+                <p className="text-xs text-gray-500">
+                  {edu.institution}
+                  {edu.field ? ` · ${edu.field}` : ""}
+                  {edu.year ? ` · ${edu.year}` : ""}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-gray-400 hover:text-red-500 shrink-0"
+                onClick={() => removeEducation(idx)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showForm ? (
+        <div className="rounded-lg border border-[#00D9FF]/30 bg-[#00D9FF]/5 p-4 space-y-3">
+          <p className="font-medium text-sm text-gray-800">Nouvelle formation</p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">
+                Diplôme <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                placeholder="Master Informatique"
+                value={draft.degree}
+                onChange={(e) => updateField("degree", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">
+                Établissement <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                placeholder="Université Paris-Saclay"
+                value={draft.institution}
+                onChange={(e) => updateField("institution", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Spécialité</Label>
+              <Input
+                placeholder="Intelligence Artificielle"
+                value={draft.field ?? ""}
+                onChange={(e) => updateField("field", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Année d&apos;obtention</Label>
+              <Input
+                placeholder="2022"
+                value={draft.year}
+                onChange={(e) => updateField("year", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={addEducation}
+              disabled={!draft.degree || !draft.institution}
+              className="bg-[#00D9FF] text-gray-900 hover:bg-[#00b8d9]"
+            >
+              Ajouter
+            </Button>
+            {data.length > 0 && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setShowForm(false);
+                  setDraft({ ...EMPTY_EDU });
+                }}
+              >
+                Annuler
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full border-dashed"
+          onClick={() => setShowForm(true)}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Ajouter une formation
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend-next/src/components/cv-builder/steps/step-experiences.tsx
+++ b/frontend-next/src/components/cv-builder/steps/step-experiences.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Plus, Trash2, Briefcase, ChevronDown, ChevronUp } from "lucide-react";
+import type { Experience } from "../types";
+
+interface Props {
+  data: Experience[];
+  onChange: (data: Experience[]) => void;
+}
+
+const EMPTY_EXP: Experience = {
+  title: "",
+  company: "",
+  start_date: "",
+  end_date: "",
+  current: false,
+  location: "",
+  description: "",
+};
+
+export function StepExperiences({ data, onChange }: Props) {
+  const [expandedIdx, setExpandedIdx] = useState<number | null>(
+    data.length === 0 ? null : 0
+  );
+  const [showForm, setShowForm] = useState(data.length === 0);
+  const [draft, setDraft] = useState<Experience>({ ...EMPTY_EXP });
+
+  const addExperience = () => {
+    if (!draft.title || !draft.company) return;
+    onChange([...data, { ...draft }]);
+    setDraft({ ...EMPTY_EXP });
+    setShowForm(false);
+  };
+
+  const removeExperience = (idx: number) => {
+    onChange(data.filter((_, i) => i !== idx));
+    if (expandedIdx === idx) setExpandedIdx(null);
+  };
+
+  const updateField = (key: keyof Experience, value: string | boolean) => {
+    setDraft((d) => ({ ...d, [key]: value }));
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Existing experiences */}
+      {data.length > 0 && (
+        <div className="space-y-2">
+          {data.map((exp, idx) => (
+            <div
+              key={idx}
+              className="rounded-lg border border-gray-200 bg-gray-50"
+            >
+              <div
+                className="flex items-center justify-between p-3 cursor-pointer"
+                onClick={() =>
+                  setExpandedIdx(expandedIdx === idx ? null : idx)
+                }
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <Briefcase className="h-4 w-4 text-gray-400 shrink-0" />
+                  <div className="min-w-0">
+                    <p className="font-medium text-sm text-gray-900 truncate">
+                      {exp.title}
+                    </p>
+                    <p className="text-xs text-gray-500 truncate">
+                      {exp.company}
+                      {exp.start_date ? ` · ${exp.start_date}` : ""}
+                      {exp.current ? " — présent" : exp.end_date ? ` — ${exp.end_date}` : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-gray-400 hover:text-red-500"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeExperience(idx);
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                  {expandedIdx === idx ? (
+                    <ChevronUp className="h-4 w-4 text-gray-400" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4 text-gray-400" />
+                  )}
+                </div>
+              </div>
+              {expandedIdx === idx && (
+                <div className="px-3 pb-3 text-sm text-gray-600 border-t border-gray-200 pt-2">
+                  {exp.description || "Aucune description"}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add form */}
+      {showForm ? (
+        <div className="rounded-lg border border-[#00D9FF]/30 bg-[#00D9FF]/5 p-4 space-y-3">
+          <p className="font-medium text-sm text-gray-800">
+            Nouvelle expérience
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">
+                Intitulé du poste <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                placeholder="Développeur Full-Stack"
+                value={draft.title}
+                onChange={(e) => updateField("title", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">
+                Entreprise <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                placeholder="Google"
+                value={draft.company}
+                onChange={(e) => updateField("company", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Date début</Label>
+              <Input
+                placeholder="janv. 2022"
+                value={draft.start_date}
+                onChange={(e) => updateField("start_date", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Date fin</Label>
+              <Input
+                placeholder="déc. 2023"
+                value={draft.end_date}
+                onChange={(e) => updateField("end_date", e.target.value)}
+                disabled={!!draft.current}
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="current"
+              checked={!!draft.current}
+              onCheckedChange={(v) => updateField("current", !!v)}
+            />
+            <Label htmlFor="current" className="text-xs cursor-pointer">
+              Poste actuel
+            </Label>
+            <div className="ml-4 flex-1 space-y-1">
+              <Label className="text-xs">Localisation</Label>
+              <Input
+                placeholder="Paris, France"
+                value={draft.location ?? ""}
+                onChange={(e) => updateField("location", e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs">Description</Label>
+            <Textarea
+              placeholder="Développement et maintenance d'une application SaaS B2B utilisée par 500+ clients..."
+              value={draft.description}
+              onChange={(e) => updateField("description", e.target.value)}
+              rows={3}
+              className="text-sm resize-none"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={addExperience}
+              disabled={!draft.title || !draft.company}
+              className="bg-[#00D9FF] text-gray-900 hover:bg-[#00b8d9]"
+            >
+              Ajouter
+            </Button>
+            {data.length > 0 && (
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setShowForm(false);
+                  setDraft({ ...EMPTY_EXP });
+                }}
+              >
+                Annuler
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full border-dashed"
+          onClick={() => setShowForm(true)}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          Ajouter une expérience
+        </Button>
+      )}
+
+      {data.length === 0 && !showForm && (
+        <p className="text-center text-sm text-gray-400 py-2">
+          Aucune expérience ajoutée
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend-next/src/components/cv-builder/steps/step-personal-info.tsx
+++ b/frontend-next/src/components/cv-builder/steps/step-personal-info.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { PersonalInfo } from "../types";
+
+interface Props {
+  data: Partial<PersonalInfo>;
+  onChange: (updates: Partial<PersonalInfo>) => void;
+}
+
+export function StepPersonalInfo({ data, onChange }: Props) {
+  const field = (key: keyof PersonalInfo) => ({
+    value: data[key] ?? "",
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+      onChange({ [key]: e.target.value }),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="name">
+            Nom complet <span className="text-red-500">*</span>
+          </Label>
+          <Input id="name" placeholder="Marie Dupont" {...field("name")} />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="title">Titre / Poste visé</Label>
+          <Input
+            id="title"
+            placeholder="Développeur Full-Stack"
+            {...field("title")}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="email">
+            Email <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="marie@exemple.com"
+            {...field("email")}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="phone">Téléphone</Label>
+          <Input
+            id="phone"
+            type="tel"
+            placeholder="+33 6 12 34 56 78"
+            {...field("phone")}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="location">Localisation</Label>
+          <Input id="location" placeholder="Paris, France" {...field("location")} />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="linkedin">LinkedIn</Label>
+          <Input
+            id="linkedin"
+            placeholder="linkedin.com/in/marie-dupont"
+            {...field("linkedin")}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-next/src/components/cv-builder/steps/step-skills.tsx
+++ b/frontend-next/src/components/cv-builder/steps/step-skills.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, X } from "lucide-react";
+import type { Skills, Language } from "../types";
+
+interface Props {
+  data: Skills;
+  onChange: (data: Skills) => void;
+}
+
+const LANGUAGE_LEVELS = ["Notions", "Intermédiaire", "Avancé", "Courant", "Natif"];
+
+export function StepSkills({ data, onChange }: Props) {
+  const [techInput, setTechInput] = useState("");
+  const [softInput, setSoftInput] = useState("");
+  const [langName, setLangName] = useState("");
+  const [langLevel, setLangLevel] = useState("");
+
+  const technical = data.technical ?? [];
+  const soft = data.soft ?? [];
+  const languages = data.languages ?? [];
+
+  const addTag = (
+    key: "technical" | "soft",
+    value: string,
+    setter: (v: string) => void
+  ) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const current = data[key] ?? [];
+    if (!current.includes(trimmed)) {
+      onChange({ ...data, [key]: [...current, trimmed] });
+    }
+    setter("");
+  };
+
+  const removeTag = (key: "technical" | "soft", value: string) => {
+    onChange({ ...data, [key]: (data[key] ?? []).filter((t) => t !== value) });
+  };
+
+  const addLanguage = () => {
+    if (!langName || !langLevel) return;
+    const existing = languages.find(
+      (l) => l.language.toLowerCase() === langName.trim().toLowerCase()
+    );
+    if (!existing) {
+      onChange({
+        ...data,
+        languages: [...languages, { language: langName.trim(), level: langLevel }],
+      });
+    }
+    setLangName("");
+    setLangLevel("");
+  };
+
+  const removeLanguage = (lang: string) => {
+    onChange({
+      ...data,
+      languages: languages.filter((l) => l.language !== lang),
+    });
+  };
+
+  const handleTagKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    key: "technical" | "soft",
+    value: string,
+    setter: (v: string) => void
+  ) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(key, value, setter);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      {/* Technical skills */}
+      <div className="space-y-2">
+        <Label>Compétences techniques</Label>
+        <div className="flex gap-2">
+          <Input
+            placeholder="React, Python, SQL... (Entrée pour ajouter)"
+            value={techInput}
+            onChange={(e) => setTechInput(e.target.value)}
+            onKeyDown={(e) => handleTagKeyDown(e, "technical", techInput, setTechInput)}
+            className="text-sm"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => addTag("technical", techInput, setTechInput)}
+            className="shrink-0"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+        {technical.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-1">
+            {technical.map((skill) => (
+              <Badge
+                key={skill}
+                variant="secondary"
+                className="pr-1 gap-1 text-xs"
+              >
+                {skill}
+                <button
+                  onClick={() => removeTag("technical", skill)}
+                  className="ml-0.5 rounded-full hover:bg-gray-300"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Soft skills */}
+      <div className="space-y-2">
+        <Label>Compétences comportementales</Label>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Leadership, Travail en équipe... (Entrée pour ajouter)"
+            value={softInput}
+            onChange={(e) => setSoftInput(e.target.value)}
+            onKeyDown={(e) => handleTagKeyDown(e, "soft", softInput, setSoftInput)}
+            className="text-sm"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => addTag("soft", softInput, setSoftInput)}
+            className="shrink-0"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+        {soft.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-1">
+            {soft.map((skill) => (
+              <Badge
+                key={skill}
+                variant="outline"
+                className="pr-1 gap-1 text-xs"
+              >
+                {skill}
+                <button
+                  onClick={() => removeTag("soft", skill)}
+                  className="ml-0.5 rounded-full hover:bg-gray-200"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Languages */}
+      <div className="space-y-2">
+        <Label>Langues</Label>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Français, Anglais..."
+            value={langName}
+            onChange={(e) => setLangName(e.target.value)}
+            className="text-sm flex-1"
+          />
+          <Select value={langLevel} onValueChange={setLangLevel}>
+            <SelectTrigger className="w-36 text-sm">
+              <SelectValue placeholder="Niveau" />
+            </SelectTrigger>
+            <SelectContent>
+              {LANGUAGE_LEVELS.map((level) => (
+                <SelectItem key={level} value={level}>
+                  {level}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={addLanguage}
+            disabled={!langName || !langLevel}
+            className="shrink-0"
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+        {languages.length > 0 && (
+          <div className="space-y-1 mt-1">
+            {languages.map((l: Language) => (
+              <div
+                key={l.language}
+                className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-1.5 text-sm"
+              >
+                <span className="text-gray-800">{l.language}</span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-gray-500">{l.level}</span>
+                  <button
+                    onClick={() => removeLanguage(l.language)}
+                    className="text-gray-400 hover:text-red-500"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend-next/src/components/cv-builder/steps/step-summary.tsx
+++ b/frontend-next/src/components/cv-builder/steps/step-summary.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function StepSummary({ value, onChange }: Props) {
+  return (
+    <div className="space-y-3">
+      <Label htmlFor="summary">
+        Résumé professionnel
+        <span className="ml-2 text-xs font-normal text-gray-400">optionnel</span>
+      </Label>
+      <Textarea
+        id="summary"
+        placeholder="Développeur passionné avec 5 ans d'expérience en React et Node.js, spécialisé dans la création d'applications web performantes..."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={5}
+        className="resize-none"
+      />
+      <p className="text-xs text-gray-400">
+        Un bon résumé fait 3-5 phrases. Il sera adapté automatiquement par l&apos;IA lors de la candidature.
+      </p>
+    </div>
+  );
+}

--- a/frontend-next/src/components/cv-builder/types.ts
+++ b/frontend-next/src/components/cv-builder/types.ts
@@ -1,0 +1,58 @@
+export interface PersonalInfo {
+  name: string;
+  email: string;
+  phone: string;
+  location: string;
+  linkedin?: string;
+  title?: string;
+}
+
+export interface Experience {
+  title: string;
+  company: string;
+  start_date: string;
+  end_date?: string;
+  current?: boolean;
+  location?: string;
+  description: string;
+}
+
+export interface Education {
+  degree: string;
+  institution: string;
+  year: string;
+  field?: string;
+}
+
+export interface Language {
+  language: string;
+  level: string;
+}
+
+export interface Skills {
+  technical?: string[];
+  soft?: string[];
+  languages?: Language[];
+}
+
+export interface Certification {
+  name: string;
+  issuer?: string;
+  year?: string;
+}
+
+export interface Project {
+  name: string;
+  description: string;
+  url?: string;
+}
+
+export interface CvData {
+  personal_info: PersonalInfo;
+  summary?: string;
+  experiences: Experience[];
+  education: Education[];
+  skills: Skills;
+  certifications?: Certification[];
+  projects?: Project[];
+}

--- a/frontend-next/src/components/jobs/apply-modal.tsx
+++ b/frontend-next/src/components/jobs/apply-modal.tsx
@@ -2,15 +2,20 @@
  * ApplyModal - Génère automatiquement un CV adapté + Lettre de motivation
  * pour une offre d'emploi spécifique.
  *
- * Flow :
+ * Flow A (upload) :
  *   Step 1 → Upload CV + confirmation offre
  *   Step 2 → Génération en cours (appels API backend)
+ *   Step 3 → Résultats + téléchargement PDF
+ *
+ * Flow B (profil sauvegardé) :
+ *   Step 1 → Sélection profil sauvegardé (ou création via wizard)
+ *   Step 2 → Génération en cours (cv_data sérialisé → /adapt → PDFs)
  *   Step 3 → Résultats + téléchargement PDF
  */
 
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import {
   Dialog,
@@ -33,11 +38,17 @@ import {
   Building,
   MapPin,
   AlertCircle,
+  User,
+  Plus,
+  Check,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import type { Job } from "@/lib/api/huntzen-client";
 import { useDocuments } from "@/hooks/use-documents";
+import { useCvProfiles, type CvProfile } from "@/hooks/use-cv-profiles";
+import { CvBuilderWizard } from "@/components/cv-builder/cv-builder-wizard";
+import type { CvData } from "@/components/cv-builder/types";
 
 // ============================================================================
 // TYPES
@@ -50,6 +61,7 @@ interface ApplyModalProps {
 }
 
 type Step = "upload" | "generating" | "results";
+type CvSource = "upload" | "profile";
 
 interface GenerationResult {
   cvPdfBlob: Blob;
@@ -82,13 +94,79 @@ function downloadBlob(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
+/**
+ * Serialize cv_data profile to readable text for the /adapt endpoint.
+ * The LLM can process this structured text format as a CV.
+ */
+function cvDataToText(cv: CvData): string {
+  const lines: string[] = [];
+  const p = cv.personal_info;
+
+  lines.push(`Nom : ${p.name}`);
+  if (p.title) lines.push(`Titre : ${p.title}`);
+  if (p.email) lines.push(`Email : ${p.email}`);
+  if (p.phone) lines.push(`Téléphone : ${p.phone}`);
+  if (p.location) lines.push(`Localisation : ${p.location}`);
+  if (p.linkedin) lines.push(`LinkedIn : ${p.linkedin}`);
+
+  if (cv.summary) {
+    lines.push(`\nRésumé professionnel :\n${cv.summary}`);
+  }
+
+  if (cv.experiences.length > 0) {
+    lines.push("\nExpériences professionnelles :");
+    for (const exp of cv.experiences) {
+      const dates = exp.current
+        ? `${exp.start_date} — présent`
+        : `${exp.start_date}${exp.end_date ? ` — ${exp.end_date}` : ""}`;
+      lines.push(`\n${exp.title} chez ${exp.company} (${dates})`);
+      if (exp.location) lines.push(`Lieu : ${exp.location}`);
+      if (exp.description) lines.push(exp.description);
+    }
+  }
+
+  if (cv.education.length > 0) {
+    lines.push("\nFormation :");
+    for (const edu of cv.education) {
+      lines.push(
+        `${edu.degree}${edu.field ? ` en ${edu.field}` : ""} — ${edu.institution}${edu.year ? ` (${edu.year})` : ""}`
+      );
+    }
+  }
+
+  if (cv.skills) {
+    if (cv.skills.technical?.length) {
+      lines.push(`\nCompétences techniques : ${cv.skills.technical.join(", ")}`);
+    }
+    if (cv.skills.soft?.length) {
+      lines.push(`Soft skills : ${cv.skills.soft.join(", ")}`);
+    }
+    if (cv.skills.languages?.length) {
+      lines.push(
+        `Langues : ${cv.skills.languages.map((l) => `${l.language} (${l.level})`).join(", ")}`
+      );
+    }
+  }
+
+  if (cv.certifications?.length) {
+    lines.push(
+      `\nCertifications : ${cv.certifications.map((c) => c.name).join(", ")}`
+    );
+  }
+
+  return lines.join("\n");
+}
+
 // ============================================================================
 // COMPONENT
 // ============================================================================
 
 export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
   const [step, setStep] = useState<Step>("upload");
+  const [cvSource, setCvSource] = useState<CvSource>("upload");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState<CvProfile | null>(null);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const [language, setLanguage] = useState<"fr" | "en">("fr");
   const [isDragging, setIsDragging] = useState(false);
   const [result, setResult] = useState<GenerationResult | null>(null);
@@ -98,12 +176,27 @@ export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
 
   const t = useTranslations("applyModal");
   const { saveDocument } = useDocuments();
+  const {
+    profiles,
+    loading: profilesLoading,
+    fetchProfiles,
+    saveProfile,
+  } = useCvProfiles();
+
+  // Load profiles when switching to profile tab
+  useEffect(() => {
+    if (cvSource === "profile" && profiles.length === 0) {
+      fetchProfiles();
+    }
+  }, [cvSource, profiles.length, fetchProfiles]);
 
   // Reset state when modal closes
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       setStep("upload");
       setSelectedFile(null);
+      setSelectedProfile(null);
+      setCvSource("upload");
       setResult(null);
       setGeneratingLabel("");
       setMarkedApplied(false);
@@ -155,18 +248,14 @@ export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
 
   const handleDragLeave = () => setIsDragging(false);
 
-  // ── Generation ─────────────────────────────────────────────────────────────
+  // ── Generation from uploaded file ───────────────────────────────────────────
 
-  const handleGenerate = async () => {
-    if (!selectedFile) {
-      toast.error("Veuillez sélectionner votre CV avant de continuer.");
-      return;
-    }
+  const generateFromFile = async () => {
+    if (!selectedFile) return;
 
     setStep("generating");
 
     try {
-      // Step 1 — Adapter le CV au poste (retourne cv_data JSON)
       setGeneratingLabel(t("processingStep1"));
 
       const formData = new FormData();
@@ -189,77 +278,135 @@ export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
       const cvData = adaptData.cv_data;
       const matchScore = adaptData.match_score;
 
-      if (!cvData) {
-        throw new Error("Impossible d'extraire les données du CV");
-      }
+      if (!cvData) throw new Error("Impossible d'extraire les données du CV");
 
-      // Step 2 — Générer CV PDF + LM PDF en parallèle
-      setGeneratingLabel(t("processingStep2"));
-
-      const [cvPdfResponse, lmPdfResponse] = await Promise.all([
-        // CV adapté en PDF
-        fetch(`${BACKEND_URL}/api/cv-adapter/generate-pdf`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            cv_data: cvData,
-            template: "ats",
-            language,
-          }),
-        }),
-        // Lettre de motivation en PDF
-        fetch(`${BACKEND_URL}/api/cv-adapter/generate-cover-letter`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            cv_data: cvData,
-            job_description: job.description || job.title,
-            language,
-            company_name: job.company || "",
-          }),
-        }),
-      ]);
-
-      if (!cvPdfResponse.ok) {
-        const err = await cvPdfResponse.json().catch(() => ({}));
-        throw new Error(err.detail || "Erreur lors de la génération du CV PDF");
-      }
-      if (!lmPdfResponse.ok) {
-        const err = await lmPdfResponse.json().catch(() => ({}));
-        throw new Error(
-          err.detail ||
-            "Erreur lors de la génération de la lettre de motivation",
-        );
-      }
-
-      const [cvPdfBlob, lmPdfBlob] = await Promise.all([
-        cvPdfResponse.blob(),
-        lmPdfResponse.blob(),
-      ]);
-
-      setResult({ cvPdfBlob, lmPdfBlob, matchScore });
-      setStep("results");
-
-      // Persist PDFs to Supabase Storage in background (non-blocking)
-      saveDocument({
-        jobTitle: job.title,
-        company: job.company ?? "",
-        matchScore:
-          matchScore != null ? Math.round(matchScore * 100) : undefined,
-        cvData: cvData as Record<string, unknown>,
-        cvPdfBlob,
-        lmPdfBlob,
-        language,
-        jobUrl: job.url ?? undefined,
-      }).catch(() => {
-        // Silent fail — PDFs are still downloadable locally
-      });
+      await generatePdfsAndSave(cvData, matchScore);
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Une erreur est survenue";
       toast.error(message);
       setStep("upload");
       setGeneratingLabel("");
+    }
+  };
+
+  // ── Generation from saved profile ───────────────────────────────────────────
+
+  const generateFromProfile = async () => {
+    if (!selectedProfile) return;
+
+    setStep("generating");
+
+    try {
+      setGeneratingLabel("Adaptation de votre profil au poste...");
+
+      // Serialize cv_data to text for the /adapt endpoint
+      const cvText = cvDataToText(selectedProfile.cv_data as unknown as CvData);
+
+      const adaptFormData = new FormData();
+      adaptFormData.append("cv_text", cvText);
+      adaptFormData.append("job_description", job.description || job.title);
+      adaptFormData.append("language", language);
+      adaptFormData.append("template", "ats");
+
+      const adaptResponse = await fetch(`${BACKEND_URL}/api/cv-adapter/adapt`, {
+        method: "POST",
+        body: adaptFormData,
+      });
+
+      if (!adaptResponse.ok) {
+        const err = await adaptResponse.json().catch(() => ({}));
+        throw new Error(err.detail || "Erreur lors de l'adaptation du CV");
+      }
+
+      const adaptData = await adaptResponse.json();
+      const cvData = adaptData.cv_data;
+      const matchScore = adaptData.match_score;
+
+      if (!cvData) throw new Error("Impossible d'adapter le profil");
+
+      await generatePdfsAndSave(cvData, matchScore);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Une erreur est survenue";
+      toast.error(message);
+      setStep("upload");
+      setGeneratingLabel("");
+    }
+  };
+
+  // ── Shared PDF generation + save ────────────────────────────────────────────
+
+  const generatePdfsAndSave = async (
+    cvData: Record<string, unknown>,
+    matchScore?: number
+  ) => {
+    setGeneratingLabel(t("processingStep2"));
+
+    const [cvPdfResponse, lmPdfResponse] = await Promise.all([
+      fetch(`${BACKEND_URL}/api/cv-adapter/generate-pdf`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cv_data: cvData, template: "ats", language }),
+      }),
+      fetch(`${BACKEND_URL}/api/cv-adapter/generate-cover-letter`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cv_data: cvData,
+          job_description: job.description || job.title,
+          language,
+          company_name: job.company || "",
+        }),
+      }),
+    ]);
+
+    if (!cvPdfResponse.ok) {
+      const err = await cvPdfResponse.json().catch(() => ({}));
+      throw new Error(err.detail || "Erreur lors de la génération du CV PDF");
+    }
+    if (!lmPdfResponse.ok) {
+      const err = await lmPdfResponse.json().catch(() => ({}));
+      throw new Error(
+        err.detail || "Erreur lors de la génération de la lettre de motivation",
+      );
+    }
+
+    const [cvPdfBlob, lmPdfBlob] = await Promise.all([
+      cvPdfResponse.blob(),
+      lmPdfResponse.blob(),
+    ]);
+
+    setResult({ cvPdfBlob, lmPdfBlob, matchScore });
+    setStep("results");
+
+    saveDocument({
+      jobTitle: job.title,
+      company: job.company ?? "",
+      matchScore: matchScore != null ? Math.round(matchScore * 100) : undefined,
+      cvData: cvData as Record<string, unknown>,
+      cvPdfBlob,
+      lmPdfBlob,
+      language,
+      jobUrl: job.url ?? undefined,
+    }).catch(() => {});
+  };
+
+  // ── Main generate handler ────────────────────────────────────────────────────
+
+  const handleGenerate = async () => {
+    if (cvSource === "upload") {
+      if (!selectedFile) {
+        toast.error("Veuillez sélectionner votre CV avant de continuer.");
+        return;
+      }
+      await generateFromFile();
+    } else {
+      if (!selectedProfile) {
+        toast.error("Veuillez sélectionner un profil sauvegardé.");
+        return;
+      }
+      await generateFromProfile();
     }
   };
 
@@ -277,286 +424,417 @@ export function ApplyModal({ open, onOpenChange, job }: ApplyModalProps) {
     downloadBlob(result.lmPdfBlob, `Lettre_Motivation_${companySlug}.pdf`);
   };
 
+  // ── CV Builder wizard save ─────────────────────────────────────────────────
+
+  const handleWizardSave = async (name: string, data: CvData) => {
+    const saved = await saveProfile(name, data as unknown as Record<string, unknown>);
+    if (saved) {
+      setSelectedProfile(saved);
+      toast.success("Profil sauvegardé !");
+    } else {
+      toast.error("Erreur lors de la sauvegarde du profil.");
+    }
+  };
+
   // ── Render ─────────────────────────────────────────────────────────────────
 
+  const canGenerate =
+    cvSource === "upload" ? !!selectedFile : !!selectedProfile;
+
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-lg bg-white">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-slate-900">
-            <Sparkles className="h-5 w-5 text-[#00D9FF]" />
-            {t("title")}
-          </DialogTitle>
-          <DialogDescription className="text-slate-500">
-            Génération automatique de votre CV adapté + lettre de motivation
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-lg bg-white">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-slate-900">
+              <Sparkles className="h-5 w-5 text-[#00D9FF]" />
+              {t("title")}
+            </DialogTitle>
+            <DialogDescription className="text-slate-500">
+              Génération automatique de votre CV adapté + lettre de motivation
+            </DialogDescription>
+          </DialogHeader>
 
-        {/* Job summary */}
-        <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
-          <p className="font-semibold text-slate-900 text-sm line-clamp-1">
-            {job.title}
-          </p>
-          <div className="flex items-center gap-3 mt-1 text-xs text-slate-500">
-            {job.company && (
-              <span className="flex items-center gap-1">
-                <Building className="h-3 w-3" />
-                {job.company}
-              </span>
-            )}
-            {job.location && (
-              <span className="flex items-center gap-1">
-                <MapPin className="h-3 w-3" />
-                {job.location}
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* ── STEP 1 : Upload ── */}
-        {step === "upload" && (
-          <div className="space-y-4">
-            {/* Upload zone */}
-            <div
-              className={cn(
-                "relative rounded-xl border-2 border-dashed p-6 text-center cursor-pointer transition-colors",
-                isDragging
-                  ? "border-[#00D9FF] bg-[#00D9FF]/5"
-                  : selectedFile
-                    ? "border-green-400 bg-green-50"
-                    : "border-slate-200 hover:border-[#00D9FF]/50 hover:bg-slate-50",
+          {/* Job summary */}
+          <div className="rounded-lg border border-slate-100 bg-slate-50 p-3">
+            <p className="font-semibold text-slate-900 text-sm line-clamp-1">
+              {job.title}
+            </p>
+            <div className="flex items-center gap-3 mt-1 text-xs text-slate-500">
+              {job.company && (
+                <span className="flex items-center gap-1">
+                  <Building className="h-3 w-3" />
+                  {job.company}
+                </span>
               )}
-              onDrop={handleDrop}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".pdf,.docx"
-                className="hidden"
-                onChange={handleInputChange}
-              />
+              {job.location && (
+                <span className="flex items-center gap-1">
+                  <MapPin className="h-3 w-3" />
+                  {job.location}
+                </span>
+              )}
+            </div>
+          </div>
 
-              {selectedFile ? (
-                <div className="flex items-center justify-center gap-3">
-                  <FileText className="h-8 w-8 text-green-500 flex-shrink-0" />
-                  <div className="text-left">
-                    <p className="font-medium text-slate-900 text-sm">
-                      {selectedFile.name}
+          {/* ── STEP 1 : Source selection ── */}
+          {step === "upload" && (
+            <div className="space-y-4">
+              {/* Source tabs */}
+              <div className="flex rounded-lg border border-slate-200 p-1 gap-1">
+                <button
+                  onClick={() => setCvSource("upload")}
+                  className={cn(
+                    "flex-1 flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    cvSource === "upload"
+                      ? "bg-slate-900 text-white"
+                      : "text-slate-600 hover:bg-slate-100",
+                  )}
+                >
+                  <Upload className="h-3.5 w-3.5" />
+                  Importer un fichier
+                </button>
+                <button
+                  onClick={() => setCvSource("profile")}
+                  className={cn(
+                    "flex-1 flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    cvSource === "profile"
+                      ? "bg-slate-900 text-white"
+                      : "text-slate-600 hover:bg-slate-100",
+                  )}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  Profil sauvegardé
+                </button>
+              </div>
+
+              {/* Upload zone */}
+              {cvSource === "upload" && (
+                <div
+                  className={cn(
+                    "relative rounded-xl border-2 border-dashed p-6 text-center cursor-pointer transition-colors",
+                    isDragging
+                      ? "border-[#00D9FF] bg-[#00D9FF]/5"
+                      : selectedFile
+                        ? "border-green-400 bg-green-50"
+                        : "border-slate-200 hover:border-[#00D9FF]/50 hover:bg-slate-50",
+                  )}
+                  onDrop={handleDrop}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".pdf,.docx"
+                    className="hidden"
+                    onChange={handleInputChange}
+                  />
+
+                  {selectedFile ? (
+                    <div className="flex items-center justify-center gap-3">
+                      <FileText className="h-8 w-8 text-green-500 flex-shrink-0" />
+                      <div className="text-left">
+                        <p className="font-medium text-slate-900 text-sm">
+                          {selectedFile.name}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          {(selectedFile.size / 1024 / 1024).toFixed(1)} Mo
+                        </p>
+                      </div>
+                      <button
+                        className="ml-auto p-1 rounded-full hover:bg-slate-200 transition-colors"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedFile(null);
+                        }}
+                      >
+                        <X className="h-4 w-4 text-slate-500" />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      <Upload className="h-8 w-8 text-slate-300 mx-auto" />
+                      <p className="text-sm font-medium text-slate-700">
+                        {t("uploadInstruction")}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        PDF ou DOCX · Max {MAX_SIZE_MB} Mo
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Profile selection */}
+              {cvSource === "profile" && (
+                <div className="space-y-2">
+                  {profilesLoading ? (
+                    <div className="flex items-center justify-center py-6">
+                      <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+                    </div>
+                  ) : profiles.length === 0 ? (
+                    <div className="rounded-xl border-2 border-dashed border-slate-200 p-6 text-center">
+                      <User className="h-8 w-8 text-slate-300 mx-auto mb-2" />
+                      <p className="text-sm text-slate-600 font-medium mb-1">
+                        Aucun profil sauvegardé
+                      </p>
+                      <p className="text-xs text-slate-400 mb-4">
+                        Créez votre profil CV une fois, utilisez-le pour toutes vos candidatures
+                      </p>
+                      <Button
+                        size="sm"
+                        onClick={() => setWizardOpen(true)}
+                        className="bg-[#00D9FF] text-gray-900 hover:bg-[#00b8d9]"
+                      >
+                        <Plus className="h-3.5 w-3.5 mr-1.5" />
+                        Créer mon profil CV
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="max-h-48 overflow-y-auto space-y-1.5 pr-1">
+                        {profiles.map((profile) => (
+                          <button
+                            key={profile.id}
+                            onClick={() =>
+                              setSelectedProfile(
+                                selectedProfile?.id === profile.id
+                                  ? null
+                                  : profile,
+                              )
+                            }
+                            className={cn(
+                              "w-full text-left rounded-lg border p-3 transition-colors",
+                              selectedProfile?.id === profile.id
+                                ? "border-[#00D9FF] bg-[#00D9FF]/5"
+                                : "border-slate-200 hover:border-slate-300 bg-white",
+                            )}
+                          >
+                            <div className="flex items-center justify-between">
+                              <div className="min-w-0">
+                                <p className="font-medium text-sm text-slate-900 truncate">
+                                  {profile.name}
+                                </p>
+                                <p className="text-xs text-slate-500">
+                                  {(profile.cv_data as Record<string, {name?: string}>)?.personal_info?.name || ""}
+                                </p>
+                              </div>
+                              {selectedProfile?.id === profile.id && (
+                                <div className="shrink-0 ml-2 rounded-full bg-[#00D9FF] p-0.5">
+                                  <Check className="h-3 w-3 text-gray-900" />
+                                </div>
+                              )}
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-full border-dashed text-xs"
+                        onClick={() => setWizardOpen(true)}
+                      >
+                        <Plus className="h-3.5 w-3.5 mr-1.5" />
+                        Créer un nouveau profil
+                      </Button>
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* Language selector */}
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-slate-500 font-medium">
+                  {t("selectLanguage")}
+                </span>
+                <button
+                  className={cn(
+                    "px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                    language === "fr"
+                      ? "bg-[#0D1F3C] text-white"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200",
+                  )}
+                  onClick={() => setLanguage("fr")}
+                >
+                  {t("languageFr")}
+                </button>
+                <button
+                  className={cn(
+                    "px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                    language === "en"
+                      ? "bg-[#0D1F3C] text-white"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200",
+                  )}
+                  onClick={() => setLanguage("en")}
+                >
+                  {t("languageEn")}
+                </button>
+              </div>
+
+              <Button
+                className="w-full bg-gradient-to-r from-[#00D9FF] to-blue-600 hover:from-[#00D9FF]/90 hover:to-blue-700 text-white font-semibold"
+                size="lg"
+                onClick={handleGenerate}
+                disabled={!canGenerate}
+              >
+                <Sparkles className="mr-2 h-4 w-4" />
+                {t("generateButton")}
+              </Button>
+
+              <p className="text-center text-xs text-slate-400">
+                L'IA adapte votre CV aux mots-clés du poste et rédige une lettre
+                personnalisée
+              </p>
+            </div>
+          )}
+
+          {/* ── STEP 2 : Generating ── */}
+          {step === "generating" && (
+            <div className="flex flex-col items-center gap-6 py-8">
+              <div className="relative">
+                <div className="h-16 w-16 rounded-full border-4 border-slate-100 border-t-[#00D9FF] animate-spin" />
+                <Sparkles className="absolute inset-0 m-auto h-6 w-6 text-[#00D9FF]" />
+              </div>
+              <div className="text-center space-y-1">
+                <p className="font-semibold text-slate-900">
+                  Génération en cours...
+                </p>
+                <p className="text-sm text-slate-500">{generatingLabel}</p>
+              </div>
+              <div className="w-full space-y-2">
+                {[
+                  t("processingStep1"),
+                  t("processingStep2"),
+                  t("processingStep3"),
+                  t("processingStep4"),
+                ].map((label, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 text-xs text-slate-500"
+                  >
+                    <Loader2 className="h-3 w-3 animate-spin text-[#00D9FF]" />
+                    {label}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* ── STEP 3 : Results ── */}
+          {step === "results" && result && (
+            <div className="space-y-4">
+              {/* Match score */}
+              {result.matchScore !== undefined && (
+                <div className="flex items-center gap-3 rounded-lg bg-green-50 border border-green-200 p-3">
+                  <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />
+                  <div>
+                    <p className="text-sm font-semibold text-green-800">
+                      Score de matching : {Math.round(result.matchScore * 100)}%
                     </p>
-                    <p className="text-xs text-slate-500">
-                      {(selectedFile.size / 1024 / 1024).toFixed(1)} Mo
+                    <p className="text-xs text-green-600">
+                      Votre CV a été optimisé pour cette offre
                     </p>
                   </div>
-                  <button
-                    className="ml-auto p-1 rounded-full hover:bg-slate-200 transition-colors"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSelectedFile(null);
-                    }}
-                  >
-                    <X className="h-4 w-4 text-slate-500" />
-                  </button>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <Upload className="h-8 w-8 text-slate-300 mx-auto" />
-                  <p className="text-sm font-medium text-slate-700">
-                    {t("uploadInstruction")}
-                  </p>
-                  <p className="text-xs text-slate-400">
-                    PDF ou DOCX · Max {MAX_SIZE_MB} Mo
-                  </p>
                 </div>
               )}
-            </div>
 
-            {/* Language selector */}
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-slate-500 font-medium">
-                {t("selectLanguage")}
-              </span>
-              <button
-                className={cn(
-                  "px-3 py-1 rounded-full text-xs font-medium transition-colors",
-                  language === "fr"
-                    ? "bg-[#0D1F3C] text-white"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200",
-                )}
-                onClick={() => setLanguage("fr")}
-              >
-                {t("languageFr")}
-              </button>
-              <button
-                className={cn(
-                  "px-3 py-1 rounded-full text-xs font-medium transition-colors",
-                  language === "en"
-                    ? "bg-[#0D1F3C] text-white"
-                    : "bg-slate-100 text-slate-600 hover:bg-slate-200",
-                )}
-                onClick={() => setLanguage("en")}
-              >
-                {t("languageEn")}
-              </button>
-            </div>
-
-            <Button
-              className="w-full bg-gradient-to-r from-[#00D9FF] to-blue-600 hover:from-[#00D9FF]/90 hover:to-blue-700 text-white font-semibold"
-              size="lg"
-              onClick={handleGenerate}
-              disabled={!selectedFile}
-            >
-              <Sparkles className="mr-2 h-4 w-4" />
-              {t("generateButton")}
-            </Button>
-
-            <p className="text-center text-xs text-slate-400">
-              L'IA adapte votre CV aux mots-clés du poste et rédige une lettre
-              personnalisée
-            </p>
-          </div>
-        )}
-
-        {/* ── STEP 2 : Generating ── */}
-        {step === "generating" && (
-          <div className="flex flex-col items-center gap-6 py-8">
-            <div className="relative">
-              <div className="h-16 w-16 rounded-full border-4 border-slate-100 border-t-[#00D9FF] animate-spin" />
-              <Sparkles className="absolute inset-0 m-auto h-6 w-6 text-[#00D9FF]" />
-            </div>
-            <div className="text-center space-y-1">
-              <p className="font-semibold text-slate-900">
-                Génération en cours...
-              </p>
-              <p className="text-sm text-slate-500">{generatingLabel}</p>
-            </div>
-            <div className="w-full space-y-2">
-              {[
-                t("processingStep1"),
-                t("processingStep2"),
-                t("processingStep3"),
-                t("processingStep4"),
-              ].map((label, i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-2 text-xs text-slate-500"
+              {/* Download buttons */}
+              <div className="space-y-2">
+                <Button
+                  variant="outline"
+                  className="w-full border-[#0D1F3C] text-[#0D1F3C] hover:bg-[#0D1F3C] hover:text-white transition-colors"
+                  size="lg"
+                  onClick={handleDownloadCV}
                 >
-                  <Loader2 className="h-3 w-3 animate-spin text-[#00D9FF]" />
-                  {label}
+                  <Download className="mr-2 h-4 w-4" />
+                  {t("downloadCv")}
+                  <Badge variant="secondary" className="ml-auto text-xs">
+                    PDF
+                  </Badge>
+                </Button>
+
+                <Button
+                  variant="outline"
+                  className="w-full border-[#0D1F3C] text-[#0D1F3C] hover:bg-[#0D1F3C] hover:text-white transition-colors"
+                  size="lg"
+                  onClick={handleDownloadLM}
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  {t("downloadCoverLetter")}
+                  <Badge variant="secondary" className="ml-auto text-xs">
+                    PDF
+                  </Badge>
+                </Button>
+              </div>
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t border-slate-100" />
                 </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* ── STEP 3 : Results ── */}
-        {step === "results" && result && (
-          <div className="space-y-4">
-            {/* Match score */}
-            {result.matchScore !== undefined && (
-              <div className="flex items-center gap-3 rounded-lg bg-green-50 border border-green-200 p-3">
-                <CheckCircle2 className="h-5 w-5 text-green-500 flex-shrink-0" />
-                <div>
-                  <p className="text-sm font-semibold text-green-800">
-                    Score de matching : {Math.round(result.matchScore * 100)}%
-                  </p>
-                  <p className="text-xs text-green-600">
-                    Votre CV a été optimisé pour cette offre
-                  </p>
+                <div className="relative flex justify-center">
+                  <span className="bg-white px-3 text-xs text-slate-400">
+                    puis
+                  </span>
                 </div>
               </div>
-            )}
 
-            {/* Download buttons */}
-            <div className="space-y-2">
-              <Button
-                variant="outline"
-                className="w-full border-[#0D1F3C] text-[#0D1F3C] hover:bg-[#0D1F3C] hover:text-white transition-colors"
-                size="lg"
-                onClick={handleDownloadCV}
-              >
-                <Download className="mr-2 h-4 w-4" />
-                {t("downloadCv")}
-                <Badge variant="secondary" className="ml-auto text-xs">
-                  PDF
-                </Badge>
-              </Button>
-
-              <Button
-                variant="outline"
-                className="w-full border-[#0D1F3C] text-[#0D1F3C] hover:bg-[#0D1F3C] hover:text-white transition-colors"
-                size="lg"
-                onClick={handleDownloadLM}
-              >
-                <Download className="mr-2 h-4 w-4" />
-                {t("downloadCoverLetter")}
-                <Badge variant="secondary" className="ml-auto text-xs">
-                  PDF
-                </Badge>
-              </Button>
-            </div>
-
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-slate-100" />
-              </div>
-              <div className="relative flex justify-center">
-                <span className="bg-white px-3 text-xs text-slate-400">
-                  puis
-                </span>
-              </div>
-            </div>
-
-            {/* External apply link */}
-            {job.url && (
-              <Button
-                asChild
-                className="w-full bg-gradient-to-r from-blue-600 to-violet-600 hover:from-blue-700 hover:to-violet-700"
-                size="lg"
-              >
-                <a href={job.url} target="_blank" rel="noopener noreferrer">
-                  Postuler sur le site de l'offre
-                  <ExternalLink className="ml-2 h-4 w-4" />
-                </a>
-              </Button>
-            )}
-
-            {/* Mark as applied */}
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full text-sm"
-              disabled={markedApplied}
-              onClick={() => {
-                setMarkedApplied(true);
-                toast.success("Candidature marquée comme envoyée !");
-              }}
-            >
-              {markedApplied ? (
-                <>
-                  <CheckCircle2 className="mr-2 h-3.5 w-3.5 text-green-500" />
-                  Candidature enregistrée
-                </>
-              ) : (
-                "Marquer comme postulé"
+              {/* External apply link */}
+              {job.url && (
+                <Button
+                  asChild
+                  className="w-full bg-gradient-to-r from-blue-600 to-violet-600 hover:from-blue-700 hover:to-violet-700"
+                  size="lg"
+                >
+                  <a href={job.url} target="_blank" rel="noopener noreferrer">
+                    Postuler sur le site de l'offre
+                    <ExternalLink className="ml-2 h-4 w-4" />
+                  </a>
+                </Button>
               )}
-            </Button>
 
-            {/* Retry */}
-            <button
-              className="w-full text-xs text-slate-400 hover:text-slate-600 text-center transition-colors"
-              onClick={() => {
-                setStep("upload");
-                setResult(null);
-              }}
-            >
-              {t("retryButton")}
-            </button>
-          </div>
-        )}
-      </DialogContent>
-    </Dialog>
+              {/* Mark as applied */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full text-sm"
+                disabled={markedApplied}
+                onClick={() => {
+                  setMarkedApplied(true);
+                  toast.success("Candidature marquée comme envoyée !");
+                }}
+              >
+                {markedApplied ? (
+                  <>
+                    <CheckCircle2 className="mr-2 h-3.5 w-3.5 text-green-500" />
+                    Candidature enregistrée
+                  </>
+                ) : (
+                  "Marquer comme postulé"
+                )}
+              </Button>
+
+              {/* Retry */}
+              <button
+                className="w-full text-xs text-slate-400 hover:text-slate-600 text-center transition-colors"
+                onClick={() => {
+                  setStep("upload");
+                  setResult(null);
+                }}
+              >
+                {t("retryButton")}
+              </button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* CV Builder Wizard (outside main dialog to avoid nesting) */}
+      <CvBuilderWizard
+        open={wizardOpen}
+        onOpenChange={setWizardOpen}
+        onSave={handleWizardSave}
+      />
+    </>
   );
 }

--- a/frontend-next/src/hooks/use-cv-profiles.ts
+++ b/frontend-next/src/hooks/use-cv-profiles.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export interface CvProfile {
+  id: string;
+  name: string;
+  cv_data: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export function useCvProfiles() {
+  const [profiles, setProfiles] = useState<CvProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchProfiles = useCallback(async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("cv_profiles")
+        .select("id, name, cv_data, created_at, updated_at")
+        .order("updated_at", { ascending: false });
+      setProfiles(data ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const saveProfile = useCallback(
+    async (
+      name: string,
+      cvData: Record<string, unknown>
+    ): Promise<CvProfile | null> => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return null;
+
+      const { data, error } = await supabase
+        .from("cv_profiles")
+        .insert({ user_id: user.id, name, cv_data: cvData })
+        .select()
+        .single();
+
+      if (error || !data) return null;
+      setProfiles((p) => [data as CvProfile, ...p]);
+      return data as CvProfile;
+    },
+    []
+  );
+
+  const updateProfile = useCallback(
+    async (
+      id: string,
+      name: string,
+      cvData: Record<string, unknown>
+    ): Promise<boolean> => {
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("cv_profiles")
+        .update({ name, cv_data: cvData })
+        .eq("id", id);
+
+      if (error) return false;
+      setProfiles((p) =>
+        p.map((x) => (x.id === id ? { ...x, name, cv_data: cvData } : x))
+      );
+      return true;
+    },
+    []
+  );
+
+  const deleteProfile = useCallback(async (id: string): Promise<void> => {
+    const supabase = createClient();
+    await supabase.from("cv_profiles").delete().eq("id", id);
+    setProfiles((p) => p.filter((x) => x.id !== id));
+  }, []);
+
+  return {
+    profiles,
+    loading,
+    fetchProfiles,
+    saveProfile,
+    updateProfile,
+    deleteProfile,
+  };
+}

--- a/supabase/migrations/20260227000005_create_cv_profiles.sql
+++ b/supabase/migrations/20260227000005_create_cv_profiles.sql
@@ -1,0 +1,45 @@
+-- CV Profiles: reusable structured CV data for manual CV creation flow
+-- Separate from user_documents (which stores job-specific generated PDFs)
+
+CREATE TABLE IF NOT EXISTS cv_profiles (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name       TEXT NOT NULL DEFAULT 'Mon CV',
+  cv_data    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE cv_profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own cv_profiles"
+  ON cv_profiles FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own cv_profiles"
+  ON cv_profiles FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own cv_profiles"
+  ON cv_profiles FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own cv_profiles"
+  ON cv_profiles FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE INDEX idx_cv_profiles_user_id ON cv_profiles(user_id);
+CREATE INDEX idx_cv_profiles_updated_at ON cv_profiles(updated_at DESC);
+
+-- Auto-update updated_at on row modification
+CREATE OR REPLACE FUNCTION update_cv_profiles_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_cv_profiles_updated_at
+  BEFORE UPDATE ON cv_profiles
+  FOR EACH ROW EXECUTE FUNCTION update_cv_profiles_updated_at();


### PR DESCRIPTION
## Summary

- **Nouvelle table Supabase** `cv_profiles` — stocke les profils CV structurés (séparé de `user_documents` qui contient les PDFs job-spécifiques)
- **Hook `use-cv-profiles`** — CRUD via Supabase client direct (RLS protège)
- **CV Builder Wizard** — formulaire 5 étapes : Infos perso → Résumé → Expériences → Formation → Compétences
- **`apply-modal.tsx`** — ajout d'un onglet "Profil sauvegardé" à côté de l'upload fichier ; le profil est sérialisé en texte → `/adapt` → PDFs
- **`documents/page.tsx`** — section "Mes profils CV" avec liste, création, modification et suppression

## Flow

```
apply-modal
  ├── Option A (existant) : Upload PDF/DOCX → /adapt/upload → génération
  └── Option B (nouveau) : Profil → cvDataToText() → /adapt → /generate-pdf + /generate-cover-letter
```

## Test plan

- [ ] Page Documents → bouton "Créer un profil" → wizard s'ouvre avec 5 étapes
- [ ] Remplir infos perso (nom + email minimum) → Suivant fonctionne
- [ ] Ajouter expériences / formation / compétences → Sauvegarder → profil apparaît dans la liste
- [ ] Modifier un profil → wizard pré-rempli → modification sauvegardée
- [ ] Supprimer un profil → confirmation toast
- [ ] apply-modal → onglet "Profil sauvegardé" → liste des profils → sélectionner → Générer → CV + LM créés