### PR TITLE
feat: Interview Sim coming-soon + Branding assistant + console.logs cleanup

### DIFF
--- a/frontend-next/next.config.js
+++ b/frontend-next/next.config.js
@@ -127,6 +127,11 @@ const nextConfig = {
   // Output standalone for Docker deployment
   output: 'standalone',
 
+  // Prevent webpack from bundling packages that use __dirname/fs.readFileSync
+  // isomorphic-dompurify uses jsdom which reads CSS files via readFileSync
+  // This keeps them as runtime require() so __dirname stays correct
+  serverExternalPackages: ['isomorphic-dompurify', 'jsdom'],
+
   // React Strict Mode pour détecter les problèmes
   reactStrictMode: true,
 

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -45,12 +45,22 @@ export default function AssistantPage() {
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [sessionId] = useState(() => uuidv4());
+  const [brandingState, setBrandingState] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
 
   // Assistant state
   const { selectedAssistant, setSelectedAssistant } = useAssistant();
   const assistantConfig = getAssistantConfig(selectedAssistant);
+
+  // Reset branding state when switching assistants so stale branding session
+  // data does not leak into a different assistant's conversation
+  useEffect(() => {
+    setBrandingState(null);
+  }, [selectedAssistant]);
 
   // Freemium state
   const {
@@ -173,12 +183,31 @@ export default function AssistantPage() {
 
     try {
       // Use the appropriate API method based on selected assistant
-      const response = await huntzenApi.sendAssistantMessage(
-        messageText,
-        sessionId,
-        selectedAssistant,
-        locale,
-      );
+      let response: {
+        success: boolean;
+        response: string;
+        agent?: string;
+        language?: string;
+        branding_state?: Record<string, unknown> | null;
+      };
+
+      if (selectedAssistant === "branding") {
+        const brandingResponse = await huntzenApi.sendBrandingMessage(
+          messageText,
+          sessionId,
+          locale,
+          brandingState,
+        );
+        setBrandingState(brandingResponse.branding_state ?? null);
+        response = { ...brandingResponse, agent: "branding" };
+      } else {
+        response = await huntzenApi.sendAssistantMessage(
+          messageText,
+          sessionId,
+          selectedAssistant,
+          locale,
+        );
+      }
 
       const assistantMessage: ChatMessageType = {
         id: uuidv4(),
@@ -237,6 +266,7 @@ export default function AssistantPage() {
     setMessages([]);
     setCurrentConversationId(null);
     setInput("");
+    setBrandingState(null);
   };
 
   // Check if we should show welcome screen (no messages)

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -49,7 +49,7 @@ export default function AssistantPage() {
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
 
   // Assistant state
-  const { selectedAssistant } = useAssistant();
+  const { selectedAssistant, setSelectedAssistant } = useAssistant();
   const assistantConfig = getAssistantConfig(selectedAssistant);
 
   // Freemium state
@@ -216,7 +216,7 @@ export default function AssistantPage() {
       openPricingModal("has_interview_sim");
       return;
     }
-    // TODO: Implement interview simulation
+    setSelectedAssistant("interview-sim");
   };
 
   // Load conversation from history

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -241,11 +241,7 @@ export default function AssistantPage() {
   };
 
   const handleSimulation = () => {
-    if (!hasFeature("has_interview_sim")) {
-      openPricingModal("has_interview_sim");
-      return;
-    }
-    setSelectedAssistant("interview-sim");
+    // Interview Simulator is coming soon — button is hidden but kept for future use
   };
 
   // Load conversation from history

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -281,7 +281,6 @@ export default function JobsPage() {
 
     if (Object.keys(filters).length > 0) {
       setAdvancedFilters(filters);
-      console.log("[ADVANCED_FILTERS] Loaded from URL:", filters);
     }
   }, [searchParams]);
 
@@ -399,16 +398,6 @@ export default function JobsPage() {
         throw new Error("Veuillez remplir le titre du poste et le pays");
       }
 
-      // Debug: Log search parameters
-      console.log("🔍 [SEARCH] Paramètres de recherche:", {
-        query: jobSearchParams.query,
-        location: jobSearchParams.location,
-        country: jobSearchParams.country,
-        // radiusKm: jobSearchParams.radiusKm, // Désactivé
-        includeRemote: jobSearchParams.includeRemote,
-        contractType,
-      });
-
       const data = await huntzenApi.searchJobs({
         job_title: jobSearchParams.query,
         country_code: jobSearchParams.country,
@@ -423,11 +412,6 @@ export default function JobsPage() {
         salaryMin: advancedFilters.salaryMin,
         salaryMax: advancedFilters.salaryMax,
         companySize: advancedFilters.companySize,
-      });
-
-      console.log("✅ [SEARCH] Résultats reçus:", {
-        totalJobs: data.jobs.length,
-        correctedQuery: data.corrected_query,
       });
 
       return data;
@@ -468,7 +452,6 @@ export default function JobsPage() {
       !searchQuery.isFetching && // Not currently fetching
       !hasIncrementedQuotaRef.current // Not already counted
     ) {
-      console.log("📊 [QUOTA] Incrementing usage for job_search");
       incrementUsage("job_search");
       hasIncrementedQuotaRef.current = true;
     }
@@ -582,9 +565,6 @@ export default function JobsPage() {
     setAdvancedFilters(filters);
     setAdvancedFiltersOpen(false);
 
-    // Log for debugging
-    console.log("[ADVANCED_FILTERS] Applied filters:", filters);
-
     // Persist in URL search params
     const params = new URLSearchParams(searchParams.toString());
 
@@ -621,7 +601,6 @@ export default function JobsPage() {
 
     // Re-run search with new filters if a search has already been performed
     if (jobTitle && selectedCountry && jobs.length > 0) {
-      console.log("[ADVANCED_FILTERS] Re-running search with filters...");
       handleSearch({
         query: jobTitle,
         country: selectedCountry,
@@ -1323,9 +1302,6 @@ export default function JobsPage() {
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    console.log(
-                      "🔄 [REFRESH] Forcing refetch (bypassing cache)",
-                    );
                     searchQuery.refetch();
                   }}
                   disabled={searchQuery.isFetching}

--- a/frontend-next/src/components/assistant/bot-selector.tsx
+++ b/frontend-next/src/components/assistant/bot-selector.tsx
@@ -8,7 +8,17 @@
  */
 
 import { useState, useEffect } from "react";
-import { Check, ChevronDown, Lock, Crown } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  Lock,
+  Crown,
+  Sparkles,
+  Mic,
+  Zap,
+  Brain,
+  Star,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAssistant } from "@/contexts/assistant-context";
 import { getAllAssistants, getAssistantConfig } from "@/config/assistants";
@@ -32,6 +42,7 @@ export function BotSelector({
   variant = "default",
 }: BotSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [showComingSoon, setShowComingSoon] = useState(false);
   const { selectedAssistant, setSelectedAssistant } = useAssistant();
   const subscription = useOptionalSubscription();
   const auth = useOptionalAuth();
@@ -61,6 +72,13 @@ export function BotSelector({
 
   const handleSelect = (type: AssistantType) => {
     const config = getAssistantConfig(type);
+
+    // Feature coming soon — show teaser instead of selecting
+    if (config.isComingSoon) {
+      setIsOpen(false);
+      setShowComingSoon(true);
+      return;
+    }
 
     // Vérifier si l'assistant est premium et si l'utilisateur a accès
     if (config.isPremium && (!user || isFreePlan)) {
@@ -172,6 +190,111 @@ export function BotSelector({
           user={user}
         />
       )}
+
+      {/* Coming Soon modal — Interview Simulator */}
+      {showComingSoon && (
+        <InterviewSimComingSoon onClose={() => setShowComingSoon(false)} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Modale "Coming Soon" pour l'Interview Simulator
+ */
+function InterviewSimComingSoon({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="relative w-full max-w-md bg-white rounded-2xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+        {/* Gradient header */}
+        <div className="relative bg-gradient-to-br from-orange-500 via-orange-600 to-amber-500 px-6 pt-8 pb-10 text-white overflow-hidden">
+          <div className="absolute inset-0 opacity-20">
+            <div className="absolute top-2 right-8 w-32 h-32 rounded-full bg-white blur-2xl" />
+            <div className="absolute -bottom-4 left-4 w-24 h-24 rounded-full bg-white blur-2xl" />
+          </div>
+          <div className="relative">
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-xs font-semibold px-2.5 py-1 rounded-full bg-white/20 backdrop-blur-sm uppercase tracking-wider">
+                Bientôt disponible
+              </span>
+            </div>
+            <div className="flex items-center gap-3 mb-2">
+              <div className="w-12 h-12 rounded-xl bg-white/20 backdrop-blur-sm flex items-center justify-center">
+                <Mic className="w-6 h-6 text-white" />
+              </div>
+              <h2 className="text-2xl font-bold">Interview Simulator</h2>
+            </div>
+            <p className="text-white/80 text-sm leading-relaxed">
+              Préparez vos entretiens comme jamais auparavant — avec une IA qui
+              joue le recruteur en temps réel.
+            </p>
+          </div>
+        </div>
+
+        {/* Features */}
+        <div className="px-6 py-5 space-y-3">
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">
+            Ce qui arrive
+          </p>
+          {[
+            {
+              icon: Zap,
+              label: "Entretiens en temps réel",
+              desc: "Simulation live face à un recruteur IA",
+            },
+            {
+              icon: Brain,
+              label: "Feedback instantané",
+              desc: "Analyse de vos réponses, posture, mots-clés",
+            },
+            {
+              icon: Star,
+              label: "Tous types d'entretiens",
+              desc: "Tech, RH, comportemental, cas pratiques",
+            },
+            {
+              icon: Sparkles,
+              label: "Coaching post-entretien",
+              desc: "Plan d'amélioration personnalisé",
+            },
+          ].map(({ icon: Icon, label, desc }) => (
+            <div key={label} className="flex items-start gap-3">
+              <div className="w-8 h-8 rounded-lg bg-orange-50 flex items-center justify-center shrink-0 mt-0.5">
+                <Icon className="w-4 h-4 text-orange-500" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-slate-900">{label}</p>
+                <p className="text-xs text-slate-500">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* CTA */}
+        <div className="px-6 pb-6">
+          <button
+            onClick={onClose}
+            className="w-full py-3 rounded-xl bg-gradient-to-r from-orange-500 to-amber-500 text-white font-semibold text-sm hover:from-orange-600 hover:to-amber-600 transition-all shadow-lg shadow-orange-200"
+          >
+            J&apos;ai hâte ! Fermer
+          </button>
+          <p className="text-center text-xs text-slate-400 mt-3">
+            Vous serez notifié dès le lancement 🚀
+          </p>
+        </div>
+
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 w-7 h-7 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center text-white transition-colors"
+          aria-label="Fermer"
+        >
+          ✕
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend-next/src/components/cv/cv-info-panel.tsx
+++ b/frontend-next/src/components/cv/cv-info-panel.tsx
@@ -3,14 +3,20 @@
  * Features: name, email, phone, skills with copy-to-clipboard
  */
 
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { User, Mail, Phone, Briefcase, Copy, Check } from 'lucide-react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { cn } from '@/lib/utils'
+import { useState } from "react";
+import { User, Mail, Phone, Briefcase, Copy, Check } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // TYPES
@@ -18,23 +24,23 @@ import { cn } from '@/lib/utils'
 
 interface CVInfo {
   // Legacy fields
-  name?: string
-  email?: string
-  phone?: string
-  skills?: string[]
+  name?: string;
+  email?: string;
+  phone?: string;
+  skills?: string[];
   // New fields from backend
-  nom_complet?: string
-  poste_actuel?: string
-  annees_experience?: number
-  telephone?: string
-  age?: number | null
-  competences_principales?: string[]
-  localisation?: string
+  nom_complet?: string;
+  poste_actuel?: string;
+  annees_experience?: number;
+  telephone?: string;
+  age?: number | null;
+  competences_principales?: string[];
+  localisation?: string;
 }
 
 interface CVInfoPanelProps {
-  cvInfo: CVInfo
-  className?: string
+  cvInfo: CVInfo;
+  className?: string;
 }
 
 // ============================================================================
@@ -42,38 +48,39 @@ interface CVInfoPanelProps {
 // ============================================================================
 
 export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
-  console.log('[CVInfoPanel] Received cvInfo:', cvInfo)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [copiedField, setCopiedField] = useState<string | null>(null);
 
   const handleCopy = (text: string, field: string) => {
-    navigator.clipboard.writeText(text)
-    setCopiedField(field)
-    setTimeout(() => setCopiedField(null), 2000)
-  }
+    navigator.clipboard.writeText(text);
+    setCopiedField(field);
+    setTimeout(() => setCopiedField(null), 2000);
+  };
 
   // Normalize field names (backend sends nom_complet, frontend expects name)
-  const displayName = cvInfo.nom_complet || cvInfo.name
-  const displayEmail = cvInfo.email
-  const displayPhone = cvInfo.telephone || cvInfo.phone
-  const displaySkills = cvInfo.competences_principales || cvInfo.skills
-
-  console.log('[CVInfoPanel] Display values:', {
-    displayName,
-    displayEmail,
-    displayPhone,
-    poste_actuel: cvInfo.poste_actuel,
-    annees_experience: cvInfo.annees_experience,
-    displaySkills
-  })
+  const displayName = cvInfo.nom_complet || cvInfo.name;
+  const displayEmail = cvInfo.email;
+  const displayPhone = cvInfo.telephone || cvInfo.phone;
+  const displaySkills = cvInfo.competences_principales || cvInfo.skills;
 
   // Don't render if no info
-  if (!displayName && !displayEmail && !displayPhone && !cvInfo.poste_actuel && !cvInfo.annees_experience && (!displaySkills || displaySkills.length === 0)) {
-    console.log('[CVInfoPanel] NOT RENDERING - No info to display')
-    return null
+  if (
+    !displayName &&
+    !displayEmail &&
+    !displayPhone &&
+    !cvInfo.poste_actuel &&
+    !cvInfo.annees_experience &&
+    (!displaySkills || displaySkills.length === 0)
+  ) {
+    return null;
   }
 
   return (
-    <Card className={cn('bg-gradient-to-br from-blue-50 to-violet-50 border-blue-200', className)}>
+    <Card
+      className={cn(
+        "bg-gradient-to-br from-blue-50 to-violet-50 border-blue-200",
+        className,
+      )}
+    >
       <CardHeader className="pb-4">
         <CardTitle className="flex items-center gap-2 text-gray-900">
           <div className="w-10 h-10 rounded-full bg-gradient-to-br from-huntzen-blue to-huntzen-turquoise flex items-center justify-center">
@@ -99,10 +106,10 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => handleCopy(displayName, 'name')}
+              onClick={() => handleCopy(displayName, "name")}
               className="h-8 w-8 p-0"
             >
-              {copiedField === 'name' ? (
+              {copiedField === "name" ? (
                 <Check className="h-4 w-4 text-green-600" />
               ) : (
                 <Copy className="h-4 w-4 text-gray-500" />
@@ -118,24 +125,29 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
               <Briefcase className="h-4 w-4 text-gray-500 flex-shrink-0" />
               <div>
                 <p className="text-xs text-gray-500">💼 Poste actuel</p>
-                <p className="text-sm font-bold text-gray-900">{cvInfo.poste_actuel}</p>
+                <p className="text-sm font-bold text-gray-900">
+                  {cvInfo.poste_actuel}
+                </p>
               </div>
             </div>
           </div>
         )}
 
         {/* Années d'expérience */}
-        {cvInfo.annees_experience !== undefined && cvInfo.annees_experience !== null && (
-          <div className="flex items-center justify-between p-3 bg-white rounded-lg">
-            <div className="flex items-center gap-3">
-              <Briefcase className="h-4 w-4 text-gray-500 flex-shrink-0" />
-              <div>
-                <p className="text-xs text-gray-500">⏱️ Expérience</p>
-                <p className="text-sm font-bold text-gray-900">{cvInfo.annees_experience} ans</p>
+        {cvInfo.annees_experience !== undefined &&
+          cvInfo.annees_experience !== null && (
+            <div className="flex items-center justify-between p-3 bg-white rounded-lg">
+              <div className="flex items-center gap-3">
+                <Briefcase className="h-4 w-4 text-gray-500 flex-shrink-0" />
+                <div>
+                  <p className="text-xs text-gray-500">⏱️ Expérience</p>
+                  <p className="text-sm font-bold text-gray-900">
+                    {cvInfo.annees_experience} ans
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
         {/* Localisation */}
         {cvInfo.localisation && (
@@ -144,7 +156,9 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
               <Briefcase className="h-4 w-4 text-gray-500 flex-shrink-0" />
               <div>
                 <p className="text-xs text-gray-500">📍 Localisation</p>
-                <p className="text-sm font-semibold text-gray-900">{cvInfo.localisation}</p>
+                <p className="text-sm font-semibold text-gray-900">
+                  {cvInfo.localisation}
+                </p>
               </div>
             </div>
           </div>
@@ -157,16 +171,18 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
               <Mail className="h-4 w-4 text-gray-500 flex-shrink-0" />
               <div>
                 <p className="text-xs text-gray-500">📧 Email</p>
-                <p className="text-sm font-semibold text-gray-900 truncate">{displayEmail}</p>
+                <p className="text-sm font-semibold text-gray-900 truncate">
+                  {displayEmail}
+                </p>
               </div>
             </div>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => handleCopy(displayEmail, 'email')}
+              onClick={() => handleCopy(displayEmail, "email")}
               className="h-8 w-8 p-0"
             >
-              {copiedField === 'email' ? (
+              {copiedField === "email" ? (
                 <Check className="h-4 w-4 text-green-600" />
               ) : (
                 <Copy className="h-4 w-4 text-gray-500" />
@@ -182,16 +198,18 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
               <Phone className="h-4 w-4 text-gray-500 flex-shrink-0" />
               <div>
                 <p className="text-xs text-gray-500">📱 Téléphone</p>
-                <p className="text-sm font-semibold text-gray-900">{displayPhone}</p>
+                <p className="text-sm font-semibold text-gray-900">
+                  {displayPhone}
+                </p>
               </div>
             </div>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => handleCopy(displayPhone, 'phone')}
+              onClick={() => handleCopy(displayPhone, "phone")}
               className="h-8 w-8 p-0"
             >
-              {copiedField === 'phone' ? (
+              {copiedField === "phone" ? (
                 <Check className="h-4 w-4 text-green-600" />
               ) : (
                 <Copy className="h-4 w-4 text-gray-500" />
@@ -205,7 +223,9 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
           <div className="p-3 bg-white rounded-lg col-span-2">
             <div className="flex items-center gap-2 mb-3">
               <Briefcase className="h-4 w-4 text-gray-500" />
-              <p className="text-xs text-gray-500 font-medium">🎯 Compétences principales</p>
+              <p className="text-xs text-gray-500 font-medium">
+                🎯 Compétences principales
+              </p>
             </div>
             <div className="flex flex-wrap gap-2">
               {displaySkills.slice(0, 5).map((skill, index) => (
@@ -222,5 +242,5 @@ export function CVInfoPanel({ cvInfo, className }: CVInfoPanelProps) {
         )}
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/frontend-next/src/components/jobs/search-form-inline.tsx
+++ b/frontend-next/src/components/jobs/search-form-inline.tsx
@@ -77,16 +77,12 @@ export function SearchFormInline({
 
   // Fetch cities for autocomplete - DYNAMIC SEARCH with OpenStreetMap
   const fetchCities = async (query: string): Promise<AutocompleteOption[]> => {
-    console.log("🏙️ fetchCities called:", { query, country, isCountryValid });
     if (!query || query.length < 1 || !country) {
-      console.log("❌ Missing query or country code");
       return [];
     }
     try {
-      console.log("🌐 Searching cities dynamically via Nominatim:", query);
       // Use dynamic search with OpenStreetMap Nominatim
       const cities = await huntzenApi.searchCities(query, country);
-      console.log("✅ Cities found:", cities.length);
       return cities.map((c) => ({ label: c, value: c }));
     } catch (error) {
       console.error("❌ Error searching cities:", error);
@@ -96,40 +92,30 @@ export function SearchFormInline({
 
   // Handle country selection
   const handleCountryChange = (value: string) => {
-    console.log("🔍 handleCountryChange received:", {
-      value,
-      length: value.length,
-      isUppercase: value === value.toUpperCase(),
-    });
     setCountry(value);
 
     // Clear country name when empty
     if (!value) {
       setSelectedCountryName("");
       setIsCountryValid(false);
-      console.log("❌ Country cleared");
       return;
     }
 
     // If it's a valid country code (2-3 chars), find the country name
     if (value.length >= 2 && value.length <= 3) {
-      console.log("✅ Valid code format, fetching country name...");
       huntzenApi.getCountries().then((countries) => {
         const found = countries.find(
           (c) => c.code.toLowerCase() === value.toLowerCase(),
         );
         if (found) {
-          console.log("✅ Country found:", found.name);
           setSelectedCountryName(found.name);
           setIsCountryValid(true);
         } else {
-          console.log("❌ Country code not found in list");
           setIsCountryValid(false);
         }
       });
     } else {
       // User is typing text, not a valid code yet
-      console.log("⏳ User typing, not a valid code yet");
       setIsCountryValid(false);
     }
   };

--- a/frontend-next/src/config/assistants.ts
+++ b/frontend-next/src/config/assistants.ts
@@ -11,6 +11,7 @@ import {
   UserCheck,
   FileEdit,
   Mic,
+  Linkedin,
 } from 'lucide-react'
 import { AssistantConfig, AssistantType } from '@/types/assistant'
 
@@ -142,6 +143,31 @@ export const ASSISTANTS_CONFIG: Record<AssistantType, AssistantConfig> = {
     apiEndpoint: '/api/interview/start', // À créer (Sprint 2)
     responseTime: 'Session live 30 min',
   },
+
+  'branding': {
+    id: 'branding',
+    name: 'Assistant Branding',
+    shortName: 'Assistant Branding',
+    description: "Créez votre présence LinkedIn et X avec l'IA",
+    icon: Linkedin,
+    color: '#0077b5',
+    bgColor: '#dbeafe',
+    isPremium: false,
+    certificationBadge: 'Expert Personal Branding',
+    specialties: [
+      'Posts LinkedIn viraux',
+      'Storytelling professionnel',
+      'Personal branding X/Twitter',
+      'Stratégie de contenu',
+    ],
+    exampleQuestions: [
+      'Aide-moi à rédiger un post LinkedIn sur ma reconversion',
+      'Comment développer ma marque personnelle ?',
+      'Crée un post engageant sur mon expertise',
+    ],
+    apiEndpoint: '/api/branding/chat',
+    responseTime: '< 2 min',
+  },
 }
 
 /**
@@ -153,6 +179,7 @@ export const ASSISTANTS_ORDER: AssistantType[] = [
   'cv-analyzer',
   'cv-adapter',
   'interview-sim',
+  'branding',
 ]
 
 /**

--- a/frontend-next/src/config/assistants.ts
+++ b/frontend-next/src/config/assistants.ts
@@ -12,205 +12,207 @@ import {
   FileEdit,
   Mic,
   Linkedin,
-} from 'lucide-react'
-import { AssistantConfig, AssistantType } from '@/types/assistant'
+} from "lucide-react";
+import { AssistantConfig, AssistantType } from "@/types/assistant";
 
 /**
  * Configuration complète de tous les assistants disponibles
  */
 export const ASSISTANTS_CONFIG: Record<AssistantType, AssistantConfig> = {
-  'career-coach': {
-    id: 'career-coach',
-    name: 'Assistant Coach Carrière',
-    shortName: 'Assistant Coach Carrière',
-    description: 'Discutez avec un expert en orientation professionnelle',
+  "career-coach": {
+    id: "career-coach",
+    name: "Assistant Coach Carrière",
+    shortName: "Assistant Coach Carrière",
+    description: "Discutez avec un expert en orientation professionnelle",
     icon: UserCheck,
-    color: '#2563eb', // blue-600
-    bgColor: '#dbeafe', // blue-100
+    color: "#2563eb", // blue-600
+    bgColor: "#dbeafe", // blue-100
     isPremium: false,
-    certificationBadge: 'Certifié RNCP',
+    certificationBadge: "Certifié RNCP",
     specialties: [
-      'Orientation professionnelle',
-      'Reconversion',
-      'Plan de carrière',
-      'Formation continue',
+      "Orientation professionnelle",
+      "Reconversion",
+      "Plan de carrière",
+      "Formation continue",
     ],
     exampleQuestions: [
-      'Comment me reconvertir dans la tech ?',
-      'Quel plan de carrière pour progresser ?',
-      'Quelles formations pour mes objectifs ?',
+      "Comment me reconvertir dans la tech ?",
+      "Quel plan de carrière pour progresser ?",
+      "Quelles formations pour mes objectifs ?",
     ],
-    apiEndpoint: '/api/coach/chat',
-    responseTime: '< 2 min',
+    apiEndpoint: "/api/coach/chat",
+    responseTime: "< 2 min",
   },
 
-  'job-scout': {
-    id: 'job-scout',
-    name: 'Assistant Recherche d\'Emploi',
-    shortName: 'Assistant Recherche d\'Emploi',
-    description: 'Aide personnalisée pour votre recherche d\'emploi',
+  "job-scout": {
+    id: "job-scout",
+    name: "Assistant Recherche d'Emploi",
+    shortName: "Assistant Recherche d'Emploi",
+    description: "Aide personnalisée pour votre recherche d'emploi",
     icon: Briefcase,
-    color: '#059669', // emerald-600
-    bgColor: '#d1fae5', // emerald-100
+    color: "#059669", // emerald-600
+    bgColor: "#d1fae5", // emerald-100
     isPremium: false,
-    certificationBadge: '10+ ans d\'expérience',
+    certificationBadge: "10+ ans d'expérience",
     specialties: [
-      'Stratégie de recherche',
-      'Ciblage d\'entreprises',
-      'Candidature spontanée',
-      'Réseau professionnel',
+      "Stratégie de recherche",
+      "Ciblage d'entreprises",
+      "Candidature spontanée",
+      "Réseau professionnel",
     ],
     exampleQuestions: [
-      'Comment trouver des offres cachées ?',
-      'Où postuler dans mon secteur ?',
-      'Comment approcher un recruteur ?',
+      "Comment trouver des offres cachées ?",
+      "Où postuler dans mon secteur ?",
+      "Comment approcher un recruteur ?",
     ],
-    apiEndpoint: '/api/jobs/search',
-    responseTime: '< 3 min',
+    apiEndpoint: "/api/jobs/search",
+    responseTime: "< 3 min",
   },
 
-  'cv-analyzer': {
-    id: 'cv-analyzer',
-    name: 'Assistant Expert CV',
-    shortName: 'Assistant Expert CV',
-    description: 'Optimisation professionnelle de votre CV',
+  "cv-analyzer": {
+    id: "cv-analyzer",
+    name: "Assistant Expert CV",
+    shortName: "Assistant Expert CV",
+    description: "Optimisation professionnelle de votre CV",
     icon: FileText,
-    color: '#7c3aed', // violet-600
-    bgColor: '#ede9fe', // violet-100
+    color: "#7c3aed", // violet-600
+    bgColor: "#ede9fe", // violet-100
     isPremium: false,
-    certificationBadge: 'Expert RH',
+    certificationBadge: "Expert RH",
     specialties: [
-      'Analyse ATS',
-      'Structure et mise en page',
-      'Mots-clés sectoriels',
-      'Impact des expériences',
+      "Analyse ATS",
+      "Structure et mise en page",
+      "Mots-clés sectoriels",
+      "Impact des expériences",
     ],
     exampleQuestions: [
-      'Mon CV passe-t-il les ATS ?',
-      'Comment améliorer mon CV ?',
-      'Quels mots-clés utiliser ?',
+      "Mon CV passe-t-il les ATS ?",
+      "Comment améliorer mon CV ?",
+      "Quels mots-clés utiliser ?",
     ],
-    apiEndpoint: '/api/cv/analyze',
-    responseTime: '< 5 min',
+    apiEndpoint: "/api/cv/analyze",
+    responseTime: "< 5 min",
   },
 
-  'cv-adapter': {
-    id: 'cv-adapter',
-    name: 'Assistant Adaptation CV',
-    shortName: 'Assistant Adaptation CV',
-    description: 'Personnalisation par un spécialiste pour chaque offre',
+  "cv-adapter": {
+    id: "cv-adapter",
+    name: "Assistant Adaptation CV",
+    shortName: "Assistant Adaptation CV",
+    description: "Personnalisation par un spécialiste pour chaque offre",
     icon: FileEdit,
-    color: '#dc2626', // red-600
-    bgColor: '#fee2e2', // red-100
+    color: "#dc2626", // red-600
+    bgColor: "#fee2e2", // red-100
     isPremium: false,
-    certificationBadge: 'Spécialiste Candidature',
+    certificationBadge: "Spécialiste Candidature",
     specialties: [
-      'Matching CV-offre',
-      'Reformulation ciblée',
-      'Alignement compétences',
-      'Optimisation mots-clés',
+      "Matching CV-offre",
+      "Reformulation ciblée",
+      "Alignement compétences",
+      "Optimisation mots-clés",
     ],
     exampleQuestions: [
-      'Comment adapter mon CV à cette offre ?',
-      'Quelles compétences mettre en avant ?',
-      'Comment reformuler mon expérience ?',
+      "Comment adapter mon CV à cette offre ?",
+      "Quelles compétences mettre en avant ?",
+      "Comment reformuler mon expérience ?",
     ],
-    apiEndpoint: '/api/cv-adapter/adapt',
-    responseTime: '< 5 min',
+    apiEndpoint: "/api/cv-adapter/adapt",
+    responseTime: "< 5 min",
   },
 
-  'interview-sim': {
-    id: 'interview-sim',
-    name: 'Assistant Simulation Entretien',
-    shortName: 'Assistant Simulation Entretien',
-    description: 'Entraînement avec un recruteur professionnel',
+  "interview-sim": {
+    id: "interview-sim",
+    name: "Interview Simulator",
+    shortName: "Interview Simulator",
+    description:
+      "Entretiens en temps réel avec feedback IA — bientôt disponible",
     icon: Mic,
-    color: '#ea580c', // orange-600
-    bgColor: '#ffedd5', // orange-100
-    isPremium: true, // Service premium
-    certificationBadge: 'Recruteur certifié',
+    color: "#ea580c", // orange-600
+    bgColor: "#ffedd5", // orange-100
+    isPremium: true,
+    certificationBadge: "Bientôt disponible",
     specialties: [
-      'Entretien technique',
-      'Entretien RH',
-      'Questions pièges',
-      'Communication verbale',
+      "Entretien technique en temps réel",
+      "Feedback IA instantané",
+      "Simulation RH & comportemental",
+      "Coaching post-entretien",
     ],
     exampleQuestions: [
-      'Comment me préparer à un entretien tech ?',
-      'Quelles questions pièges prévoir ?',
-      'Comment gérer le stress ?',
+      "Simule un entretien pour un poste de dev senior",
+      "Prépare-moi pour un entretien Amazon",
+      "Entraîne-moi sur les questions comportementales",
     ],
-    apiEndpoint: '/api/interview/start', // À créer (Sprint 2)
-    responseTime: 'Session live 30 min',
+    apiEndpoint: "/api/assistant/interview-sim",
+    responseTime: "Temps réel",
+    isComingSoon: true,
   },
 
-  'branding': {
-    id: 'branding',
-    name: 'Assistant Branding',
-    shortName: 'Assistant Branding',
+  branding: {
+    id: "branding",
+    name: "Assistant Branding",
+    shortName: "Assistant Branding",
     description: "Créez votre présence LinkedIn et X avec l'IA",
     icon: Linkedin,
-    color: '#0077b5',
-    bgColor: '#dbeafe',
+    color: "#0077b5",
+    bgColor: "#dbeafe",
     isPremium: false,
-    certificationBadge: 'Expert Personal Branding',
+    certificationBadge: "Expert Personal Branding",
     specialties: [
-      'Posts LinkedIn viraux',
-      'Storytelling professionnel',
-      'Personal branding X/Twitter',
-      'Stratégie de contenu',
+      "Posts LinkedIn viraux",
+      "Storytelling professionnel",
+      "Personal branding X/Twitter",
+      "Stratégie de contenu",
     ],
     exampleQuestions: [
-      'Aide-moi à rédiger un post LinkedIn sur ma reconversion',
-      'Comment développer ma marque personnelle ?',
-      'Crée un post engageant sur mon expertise',
+      "Aide-moi à rédiger un post LinkedIn sur ma reconversion",
+      "Comment développer ma marque personnelle ?",
+      "Crée un post engageant sur mon expertise",
     ],
-    apiEndpoint: '/api/branding/chat',
-    responseTime: '< 2 min',
+    apiEndpoint: "/api/branding/chat",
+    responseTime: "< 2 min",
   },
-}
+};
 
 /**
  * Ordre d'affichage des assistants dans l'UI
  */
 export const ASSISTANTS_ORDER: AssistantType[] = [
-  'career-coach',
-  'job-scout',
-  'cv-analyzer',
-  'cv-adapter',
-  'interview-sim',
-  'branding',
-]
+  "career-coach",
+  "job-scout",
+  "cv-analyzer",
+  "cv-adapter",
+  "interview-sim",
+  "branding",
+];
 
 /**
  * Assistant par défaut au premier chargement
  */
-export const DEFAULT_ASSISTANT: AssistantType = 'career-coach'
+export const DEFAULT_ASSISTANT: AssistantType = "career-coach";
 
 /**
  * Helper pour obtenir la config d'un assistant
  */
 export function getAssistantConfig(type: AssistantType): AssistantConfig {
-  return ASSISTANTS_CONFIG[type]
+  return ASSISTANTS_CONFIG[type];
 }
 
 /**
  * Helper pour obtenir tous les assistants (dans l'ordre)
  */
 export function getAllAssistants(): AssistantConfig[] {
-  return ASSISTANTS_ORDER.map((type) => ASSISTANTS_CONFIG[type])
+  return ASSISTANTS_ORDER.map((type) => ASSISTANTS_CONFIG[type]);
 }
 
 /**
  * Helper pour obtenir les assistants gratuits
  */
 export function getFreeAssistants(): AssistantConfig[] {
-  return getAllAssistants().filter((a) => !a.isPremium)
+  return getAllAssistants().filter((a) => !a.isPremium);
 }
 
 /**
  * Helper pour obtenir les assistants premium
  */
 export function getPremiumAssistants(): AssistantConfig[] {
-  return getAllAssistants().filter((a) => a.isPremium)
+  return getAllAssistants().filter((a) => a.isPremium);
 }

--- a/frontend-next/src/contexts/assistant-context.tsx
+++ b/frontend-next/src/contexts/assistant-context.tsx
@@ -105,6 +105,7 @@ function isValidAssistantType(value: string): boolean {
     'cv-analyzer',
     'cv-adapter',
     'interview-sim',
+    'branding',
   ]
   return validTypes.includes(value as AssistantType)
 }

--- a/frontend-next/src/contexts/subscription-context.tsx
+++ b/frontend-next/src/contexts/subscription-context.tsx
@@ -148,13 +148,10 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
 
   // Manual reconciliation function (for debugging or user-triggered sync)
   const reconcileSubscription = useCallback(async () => {
-    console.log("[SUBSCRIPTION] Manual reconciliation triggered");
-
     // Clear local cache
     try {
       localStorage.removeItem("huntzen_subscription_cache");
       localStorage.removeItem("huntzen_subscription_cache_expiry");
-      console.log("[SUBSCRIPTION] Local cache cleared");
     } catch (error) {
       console.error("[SUBSCRIPTION] Failed to clear cache:", error);
     }
@@ -243,7 +240,6 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       // Auto-refetch after 5 seconds if not an error
       if (!isApiError) {
         setTimeout(() => {
-          console.log("[SUBSCRIPTION] Auto-refetching subscription data...");
           apiRefetchRef.current?.();
         }, 5000);
       }
@@ -251,9 +247,6 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
 
     // Reset warning flag when subscription data is successfully loaded
     if (hasSubscriptionData && hasShownInconsistencyWarning) {
-      console.log(
-        "[SUBSCRIPTION] Subscription data loaded successfully, resetting warning flag",
-      );
       setHasShownInconsistencyWarning(false);
     }
   }, [
@@ -390,13 +383,16 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
   );
 
   // hasFeature: Check feature availability based on API plan (source of truth)
-  const hasFeature = useCallback((feature: keyof PlanLimits): boolean => {
-    // Use API plan as source of truth (not localStorage fallback)
-    // This ensures Premium users get Premium features even after cache expiry
-    const currentPlan = apiData.subscription?.plan_name || freemium.plan
-    const limits = PLAN_LIMITS[currentPlan]
-    return !!limits[feature]
-  }, [apiData.subscription?.plan_name, freemium.plan])
+  const hasFeature = useCallback(
+    (feature: keyof PlanLimits): boolean => {
+      // Use API plan as source of truth (not localStorage fallback)
+      // This ensures Premium users get Premium features even after cache expiry
+      const currentPlan = apiData.subscription?.plan_name || freemium.plan;
+      const limits = PLAN_LIMITS[currentPlan];
+      return !!limits[feature];
+    },
+    [apiData.subscription?.plan_name, freemium.plan],
+  );
 
   // useMemo with ONLY primitive dependencies that actually change
   const value: SubscriptionContextType = useMemo(

--- a/frontend-next/src/lib/api/huntzen-client.ts
+++ b/frontend-next/src/lib/api/huntzen-client.ts
@@ -400,6 +400,28 @@ class HuntzenApiClient {
     );
   }
 
+  async sendBrandingMessage(
+    message: string,
+    sessionId: string,
+    language: string = "fr",
+    brandingState?: Record<string, unknown> | null,
+  ): Promise<{
+    success: boolean;
+    response: string;
+    language: string;
+    branding_state: Record<string, unknown> | null;
+  }> {
+    return this.fetch("/api/branding/chat", {
+      method: "POST",
+      body: JSON.stringify({
+        message,
+        session_id: sessionId,
+        language,
+        branding_state: brandingState ?? null,
+      }),
+    });
+  }
+
   // Legacy method - kept for backwards compatibility
   async sendCoachMessage(
     message: string,

--- a/frontend-next/src/lib/utils/sanitize.ts
+++ b/frontend-next/src/lib/utils/sanitize.ts
@@ -3,7 +3,7 @@
  * Uses DOMPurify to strip HTML and prevent XSS attacks
  */
 
-import DOMPurify from 'isomorphic-dompurify'
+import DOMPurify from "isomorphic-dompurify";
 
 /**
  * Sanitize user input by stripping all HTML tags
@@ -11,12 +11,12 @@ import DOMPurify from 'isomorphic-dompurify'
  * @returns Sanitized string safe for display
  */
 export function sanitizeInput(input: string): string {
-  if (!input) return ''
+  if (!input) return "";
 
   return DOMPurify.sanitize(input, {
-    ALLOWED_TAGS: [],  // Strip all HTML tags
-    KEEP_CONTENT: true,  // Keep text content
-  })
+    ALLOWED_TAGS: [], // Strip all HTML tags
+    KEEP_CONTENT: true, // Keep text content
+  });
 }
 
 /**
@@ -25,13 +25,13 @@ export function sanitizeInput(input: string): string {
  * @returns Sanitized HTML safe for rendering
  */
 export function sanitizeHTML(html: string): string {
-  if (!html) return ''
+  if (!html) return "";
 
   return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a', 'p', 'br', 'ul', 'ol', 'li'],
-    ALLOWED_ATTR: ['href', 'target', 'rel'],
+    ALLOWED_TAGS: ["b", "i", "em", "strong", "a", "p", "br", "ul", "ol", "li"],
+    ALLOWED_ATTR: ["href", "target", "rel"],
     ALLOW_DATA_ATTR: false,
-  })
+  });
 }
 
 /**
@@ -40,10 +40,25 @@ export function sanitizeHTML(html: string): string {
  * @returns Sanitized email or null if invalid
  */
 export function sanitizeEmail(email: string): string | null {
-  const sanitized = sanitizeInput(email).toLowerCase().trim()
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  const sanitized = sanitizeInput(email).toLowerCase().trim();
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-  return emailRegex.test(sanitized) ? sanitized : null
+  return emailRegex.test(sanitized) ? sanitized : null;
+}
+
+/**
+ * Strip HTML tags from a job description for plain-text card preview.
+ * Uses regex only — no jsdom/DOMPurify, safe for server-side rendering.
+ * @param html - Raw description (may contain HTML)
+ * @returns Clean plain text
+ */
+export function stripHtmlForPreview(html: string): string {
+  if (!html) return "";
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&[a-z]+;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 /**
@@ -53,16 +68,16 @@ export function sanitizeEmail(email: string): string | null {
  */
 export function sanitizeURL(url: string): string | null {
   try {
-    const sanitized = sanitizeInput(url).trim()
-    const parsed = new URL(sanitized)
+    const sanitized = sanitizeInput(url).trim();
+    const parsed = new URL(sanitized);
 
     // Only allow safe protocols
-    if (['http:', 'https:'].includes(parsed.protocol)) {
-      return parsed.toString()
+    if (["http:", "https:"].includes(parsed.protocol)) {
+      return parsed.toString();
     }
 
-    return null
+    return null;
   } catch {
-    return null
+    return null;
   }
 }

--- a/frontend-next/src/types/assistant.ts
+++ b/frontend-next/src/types/assistant.ts
@@ -5,62 +5,64 @@
  * agents humains spécialisés (pas des IA autonomes)
  */
 
-import { LucideIcon } from 'lucide-react'
+import { LucideIcon } from "lucide-react";
 
 /**
  * Types d'assistants disponibles (interfaces pour experts humains)
  */
 export type AssistantType =
-  | 'career-coach'      // Coach Carrière humain
-  | 'job-scout'         // Expert Recherche d'Emploi
-  | 'cv-analyzer'       // Expert CV
-  | 'cv-adapter'        // Spécialiste Adaptation CV
-  | 'interview-sim'     // Recruteur pour simulation entretien
-  | 'branding'          // Expert Personal Branding
-  | 'branding'          // Expert Personal Branding
+  | "career-coach" // Coach Carrière humain
+  | "job-scout" // Expert Recherche d'Emploi
+  | "cv-analyzer" // Expert CV
+  | "cv-adapter" // Spécialiste Adaptation CV
+  | "interview-sim" // Recruteur pour simulation entretien
+  | "branding"; // Expert Personal Branding
 
 /**
  * Configuration d'un assistant (agent humain expert)
  */
 export interface AssistantConfig {
   /** Identifiant unique de l'assistant */
-  id: AssistantType
+  id: AssistantType;
 
   /** Nom de l'expert (ex: "Marie Dupont - Coach Carrière") */
-  name: string
+  name: string;
 
   /** Titre court (ex: "Coach Carrière") */
-  shortName: string
+  shortName: string;
 
   /** Description du service humain */
-  description: string
+  description: string;
 
   /** Icône pour l'UI */
-  icon: LucideIcon
+  icon: LucideIcon;
 
   /** Couleur de branding (hex ou tailwind class) */
-  color: string
+  color: string;
 
   /** Couleur de fond (plus claire) */
-  bgColor: string
+  bgColor: string;
 
   /** Est-ce un service premium ? */
-  isPremium: boolean
+  isPremium: boolean;
 
   /** Badge de certification (ex: "Certifié RNCP", "10 ans d'expérience") */
-  certificationBadge?: string
+  certificationBadge?: string;
 
   /** Spécialités de l'expert */
-  specialties: string[]
+  specialties: string[];
 
   /** Questions types posées par les utilisateurs */
-  exampleQuestions: string[]
+  exampleQuestions: string[];
 
   /** Endpoint API pour cet assistant */
-  apiEndpoint: string
+  apiEndpoint: string;
 
   /** Temps de réponse moyen (ex: "< 2 minutes") */
-  responseTime?: string
+  responseTime?: string;
+
+  /** Feature disponible prochainement — affiche un teaser au clic */
+  isComingSoon?: boolean;
 }
 
 /**
@@ -68,28 +70,28 @@ export interface AssistantConfig {
  */
 export interface AssistantMessage {
   /** ID unique du message */
-  id: string
+  id: string;
 
   /** Type d'assistant qui a géré ce message */
-  assistantType: AssistantType
+  assistantType: AssistantType;
 
   /** Rôle (user ou assistant) */
-  role: 'user' | 'assistant'
+  role: "user" | "assistant";
 
   /** Contenu du message */
-  content: string
+  content: string;
 
   /** Timestamp */
-  timestamp: Date
+  timestamp: Date;
 
   /** Le message a-t-il été traité par un humain expert ? */
-  handledByHuman?: boolean
+  handledByHuman?: boolean;
 
   /** Nom de l'expert qui a répondu (si applicable) */
-  expertName?: string
+  expertName?: string;
 
   /** Métadonnées additionnelles */
-  metadata?: Record<string, any>
+  metadata?: Record<string, any>;
 }
 
 /**
@@ -97,28 +99,28 @@ export interface AssistantMessage {
  */
 export interface AssistantSession {
   /** ID de la session */
-  id: string
+  id: string;
 
   /** Type d'assistant */
-  assistantType: AssistantType
+  assistantType: AssistantType;
 
   /** ID de l'utilisateur */
-  userId: string
+  userId: string;
 
   /** Titre de la conversation (généré par LLM ou manuel) */
-  title: string
+  title: string;
 
   /** Messages de la conversation */
-  messages: AssistantMessage[]
+  messages: AssistantMessage[];
 
   /** Date de création */
-  createdAt: Date
+  createdAt: Date;
 
   /** Dernière mise à jour */
-  updatedAt: Date
+  updatedAt: Date;
 
   /** Statut de la session */
-  status: 'active' | 'completed' | 'archived'
+  status: "active" | "completed" | "archived";
 }
 
 /**
@@ -126,17 +128,17 @@ export interface AssistantSession {
  */
 export interface AssistantLimits {
   /** Type d'assistant */
-  assistantType: AssistantType
+  assistantType: AssistantType;
 
   /** Nombre de sessions/mois (plan gratuit) */
-  freeSessions: number
+  freeSessions: number;
 
   /** Durée max par session (en minutes, plan gratuit) */
-  freeSessionDuration?: number
+  freeSessionDuration?: number;
 
   /** Fonctionnalités disponibles en gratuit */
-  freeFeatures: string[]
+  freeFeatures: string[];
 
   /** Fonctionnalités réservées aux plans premium */
-  premiumFeatures: string[]
+  premiumFeatures: string[];
 }

--- a/frontend-next/src/types/assistant.ts
+++ b/frontend-next/src/types/assistant.ts
@@ -17,6 +17,7 @@ export type AssistantType =
   | 'cv-adapter'        // Spécialiste Adaptation CV
   | 'interview-sim'     // Recruteur pour simulation entretien
   | 'branding'          // Expert Personal Branding
+  | 'branding'          // Expert Personal Branding
 
 /**
  * Configuration d'un assistant (agent humain expert)

--- a/frontend-next/src/types/assistant.ts
+++ b/frontend-next/src/types/assistant.ts
@@ -16,6 +16,7 @@ export type AssistantType =
   | 'cv-analyzer'       // Expert CV
   | 'cv-adapter'        // Spécialiste Adaptation CV
   | 'interview-sim'     // Recruteur pour simulation entretien
+  | 'branding'          // Expert Personal Branding
 
 /**
  * Configuration d'un assistant (agent humain expert)


### PR DESCRIPTION
## Summary

- **Vercel fix**: `serverExternalPackages` pour `isomorphic-dompurify`/`jsdom` — résout le crash ENOENT `default-stylesheet.css` (déjà cherry-pické sur Production)
- **Interview Simulator**: Bouton dans le BotSelector → modale \"Coming Soon\" attractive avec teaser temps réel, feedback IA, types d'entretiens
- **Branding**: 6e assistant dans `/assistant` avec gestion de `branding_state` (machine d'état 4 phases côté backend)
- **console.logs**: 25 logs debug supprimés en production (subscription-context, jobs/page, search-form-inline, cv-info-panel)
- **Fix doublon**: `'branding'` en double dans `AssistantType` supprimé
- **Fix qualité branding**: `isValidAssistantType` dans assistant-context mis à jour, `brandingState` reset au switch d'assistant

## Test plan

- [ ] Cliquer sur Interview Simulator dans le BotSelector → modale \"Coming Soon\" s'ouvre (orange gradient)
- [ ] Modale affiche 4 features : temps réel, feedback IA, types d'entretiens, coaching post-entretien
- [ ] 6e assistant Branding visible dans la liste, sélectionnable
- [ ] Envoyer un message avec Branding → réponse cohérente avec la phase onboarding
- [ ] Nouvelle conversation → brandingState reset (network: `branding_state: null`)
- [ ] Changer d'assistant → brandingState reset
- [ ] Console navigateur propre (plus de `[SUBSCRIPTION]`, `[SEARCH]`, `[QUOTA]`, `[CVInfoPanel]`)
- [ ] Vercel build `/jobs` passe sans ENOENT