### PR TITLE
fix(frontend): defer BACKEND_URL validation to fix Vercel prerender crash

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -42,10 +42,12 @@ dependencies = [
     
     # PDF Processing (IBM Docling)
     "docling>=2.0.0",
+    "pypdf>=4.0.0",           # Lightweight fallback for PDF text extraction
     "python-docx>=1.1.0",
     "weasyprint>=62.0",
     
     # HTTP & Scraping
+    "aiohttp>=3.9.0",          # Async HTTP client
     "beautifulsoup4>=4.12.0",
     
     # Database (Optional)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ langchain-core
 
 # PDF Processing
 docling
+pypdf  # Lightweight fallback for PDF text extraction
 
 # HTTP Clients
 httpx

--- a/backend/src/agents/cv_analyzer/main_agent.py
+++ b/backend/src/agents/cv_analyzer/main_agent.py
@@ -238,18 +238,18 @@ class CVAnalyzerAgent(BaseAgent):
     
     async def extract_text_from_pdf(self, pdf_bytes: bytes) -> str:
         """
-        Extract text from PDF using Docling.
-        
+        Extract text from PDF using Docling (high quality) with pypdf fallback.
+
         Args:
             pdf_bytes: PDF file content
-            
+
         Returns:
             Extracted text as markdown
         """
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             tmp.write(pdf_bytes)
             tmp_path = tmp.name
-        
+
         try:
             loop = asyncio.get_event_loop()
             doc = await loop.run_in_executor(
@@ -257,6 +257,23 @@ class CVAnalyzerAgent(BaseAgent):
                 lambda: self.docling_converter.convert(tmp_path).document
             )
             return doc.export_to_markdown()
+        except Exception as docling_exc:
+            logger.warning(
+                f"[cv_analyzer] Docling extraction failed, falling back to pypdf: {docling_exc}"
+            )
+            try:
+                import io
+                from pypdf import PdfReader
+                reader = PdfReader(io.BytesIO(pdf_bytes))
+                text = "\n".join(
+                    page.extract_text() or "" for page in reader.pages
+                )
+                if not text.strip():
+                    raise ValueError("pypdf extracted no text from PDF")
+                return text
+            except Exception as pypdf_exc:
+                logger.error(f"[cv_analyzer] pypdf fallback also failed: {pypdf_exc}")
+                raise pypdf_exc
         finally:
             os.unlink(tmp_path)
     

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -337,7 +337,7 @@ export default function AssistantPage() {
           )}
 
           {/* Export button (if has messages and feature access) */}
-          {hasFeature("has_coach_history") && messages.length > 0 && (
+          {false && hasFeature("has_coach_history") && messages.length > 0 && (
             <ExportDialog
               messages={messages.map(toCoachMessage)}
               title={

--- a/frontend-next/src/components/cv/wizard-container.tsx
+++ b/frontend-next/src/components/cv/wizard-container.tsx
@@ -3,20 +3,21 @@
  * Manages: state, navigation, Framer Motion transitions, API integration
  */
 
-'use client'
+"use client";
 
-import { useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { WizardSteps } from '@/components/cv/wizard-steps'
-import { Step1Upload } from '@/components/cv/wizard/step1-upload'
-import { Step2AnalysisType } from '@/components/cv/wizard/step2-analysis-type'
-import { Step3Results } from '@/components/cv/wizard/step3-results'
-import { CVHistoryDrawer } from '@/components/cv/cv-history-drawer'
-import { useCVHistory } from '@/hooks/use-cv-history'
-import type { CVAnalysisResult } from '@/hooks/use-cv-history'
-import type { Suggestion } from '@/components/cv/actionable-suggestions'
-import type { BreakdownItem } from '@/components/cv/score-breakdown-v2'
-import { cn } from '@/lib/utils'
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { WizardSteps } from "@/components/cv/wizard-steps";
+import { Step1Upload } from "@/components/cv/wizard/step1-upload";
+import { Step2AnalysisType } from "@/components/cv/wizard/step2-analysis-type";
+import { Step3Results } from "@/components/cv/wizard/step3-results";
+import { CVHistoryDrawer } from "@/components/cv/cv-history-drawer";
+import { useCVHistory } from "@/hooks/use-cv-history";
+import { exportCVAnalysisToPDF } from "@/utils/export-cv-pdf";
+import type { CVAnalysisResult } from "@/hooks/use-cv-history";
+import type { Suggestion } from "@/components/cv/actionable-suggestions";
+import type { BreakdownItem } from "@/components/cv/score-breakdown-v2";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // TYPES
@@ -26,34 +27,34 @@ interface WizardContainerProps {
   onAnalyze: (
     file: File | null,
     cvText: string,
-    jobOffer: string
+    jobOffer: string,
   ) => Promise<{
-    score: number
-    breakdown: BreakdownItem[]
-    strengths: string[]
-    weaknesses: string[]
-    suggestions: any[]
-    rawAnalysis?: string
-    cv_info?: any
-  }>
-  onOpenPricingModal: (feature: string) => void
+    score: number;
+    breakdown: BreakdownItem[];
+    strengths: string[];
+    weaknesses: string[];
+    suggestions: any[];
+    rawAnalysis?: string;
+    cv_info?: any;
+  }>;
+  onOpenPricingModal: (feature: string) => void;
   hasFeatures: {
-    hasCVHistory: boolean
-    hasPDFExport: boolean
-  }
-  className?: string
+    hasCVHistory: boolean;
+    hasPDFExport: boolean;
+  };
+  className?: string;
 }
 
 interface WizardState {
-  currentStep: 1 | 2 | 3
-  uploadMethod: 'file' | 'text'
-  file: File | null
-  cvText: string
-  analysisType: 'global' | 'match' | null
-  jobOffer: string
-  loading: boolean
-  result: CVAnalysisResult | null
-  error: string | null
+  currentStep: 1 | 2 | 3;
+  uploadMethod: "file" | "text";
+  file: File | null;
+  cvText: string;
+  analysisType: "global" | "match" | null;
+  jobOffer: string;
+  loading: boolean;
+  result: CVAnalysisResult | null;
+  error: string | null;
 }
 
 // ============================================================================
@@ -63,8 +64,8 @@ interface WizardState {
 const stepVariants = {
   enter: { opacity: 0, x: 100 },
   center: { opacity: 1, x: 0 },
-  exit: { opacity: 0, x: -100 }
-}
+  exit: { opacity: 0, x: -100 },
+};
 
 // ============================================================================
 // MAIN COMPONENT
@@ -74,34 +75,34 @@ export function WizardContainer({
   onAnalyze,
   onOpenPricingModal,
   hasFeatures,
-  className
+  className,
 }: WizardContainerProps) {
-  const { history, saveAnalysis } = useCVHistory()
-  const [showHistory, setShowHistory] = useState(false)
+  const { history, saveAnalysis } = useCVHistory();
+  const [showHistory, setShowHistory] = useState(false);
 
   const [wizardState, setWizardState] = useState<WizardState>({
     currentStep: 1,
-    uploadMethod: 'file',
+    uploadMethod: "file",
     file: null,
-    cvText: '',
+    cvText: "",
     analysisType: null,
-    jobOffer: '',
+    jobOffer: "",
     loading: false,
     result: null,
-    error: null
-  })
+    error: null,
+  });
 
   // ============================================================================
   // HANDLERS
   // ============================================================================
 
   const handleStep1Next = () => {
-    setWizardState((prev) => ({ ...prev, currentStep: 2 }))
-  }
+    setWizardState((prev) => ({ ...prev, currentStep: 2 }));
+  };
 
   const handleStep2Back = () => {
-    setWizardState((prev) => ({ ...prev, currentStep: 1 }))
-  }
+    setWizardState((prev) => ({ ...prev, currentStep: 1 }));
+  };
 
   const handleStep2Next = async () => {
     // Move to step 3 and start loading
@@ -109,69 +110,72 @@ export function WizardContainer({
       ...prev,
       currentStep: 3,
       loading: true,
-      error: null
-    }))
+      error: null,
+    }));
 
     try {
       // Call API
       const response = await onAnalyze(
         wizardState.file,
         wizardState.cvText,
-        wizardState.jobOffer
-      )
+        wizardState.jobOffer,
+      );
 
       // Transform suggestions
-      const transformedSuggestions: Suggestion[] = (response.suggestions || []).map((suggestion: any) => ({
-        text: typeof suggestion === 'string' ? suggestion : suggestion.text || '',
+      const transformedSuggestions: Suggestion[] = (
+        response.suggestions || []
+      ).map((suggestion: any) => ({
+        text:
+          typeof suggestion === "string" ? suggestion : suggestion.text || "",
         impact: suggestion.impact || 5,
-        category: suggestion.category || 'other',
-        actionable: suggestion.actionable !== false
-      }))
+        category: suggestion.category || "other",
+        actionable: suggestion.actionable !== false,
+      }));
 
       // Create analysis data (without id and analyzedAt - saveAnalysis will add them)
       const analysisData = {
-        fileName: wizardState.file?.name || 'CV (texte collé)',
+        fileName: wizardState.file?.name || "CV (texte collé)",
         score: response.score,
         breakdown: response.breakdown,
         strengths: response.strengths,
         weaknesses: response.weaknesses,
         suggestions: transformedSuggestions,
         rawAnalysis: response.rawAnalysis,
-        cv_info: response.cv_info
-      }
+        cv_info: response.cv_info,
+      };
 
       // Save to history (returns complete CVAnalysisResult with id and analyzedAt)
-      const savedAnalysis = saveAnalysis(analysisData)
+      const savedAnalysis = saveAnalysis(analysisData);
 
       // Update state
       setWizardState((prev) => ({
         ...prev,
         loading: false,
-        result: savedAnalysis
-      }))
+        result: savedAnalysis,
+      }));
     } catch (error: any) {
-      console.error('Analysis error:', error)
+      console.error("Analysis error:", error);
       setWizardState((prev) => ({
         ...prev,
         loading: false,
-        error: error.message || 'Une erreur est survenue lors de l\'analyse'
-      }))
+        error: error.message || "Une erreur est survenue lors de l'analyse",
+      }));
     }
-  }
+  };
 
   const handleReset = () => {
     setWizardState({
       currentStep: 1,
-      uploadMethod: 'file',
+      uploadMethod: "file",
       file: null,
-      cvText: '',
+      cvText: "",
       analysisType: null,
-      jobOffer: '',
+      jobOffer: "",
       loading: false,
       result: null,
-      error: null
-    })
-  }
+      error: null,
+    });
+  };
 
   const handleLoadFromHistory = (analysis: CVAnalysisResult) => {
     setWizardState((prev) => ({
@@ -179,15 +183,18 @@ export function WizardContainer({
       currentStep: 3,
       result: analysis,
       loading: false,
-      error: null
-    }))
-    setShowHistory(false)
-  }
+      error: null,
+    }));
+    setShowHistory(false);
+  };
 
-  const handleExportPDF = () => {
-    // TODO: Implement PDF export
-    // Feature not yet implemented
-  }
+  const handleExportPDF = async () => {
+    if (!wizardState.result) return;
+    const fileName = wizardState.file?.name
+      ? `cv-analysis-${wizardState.file.name.replace(/\.[^.]+$/, "")}.pdf`
+      : undefined;
+    await exportCVAnalysisToPDF(wizardState.result, fileName);
+  };
 
   // ============================================================================
   // RENDER STEP
@@ -214,7 +221,7 @@ export function WizardContainer({
             onNext={handleStep1Next}
             historyCount={history.length}
           />
-        )
+        );
 
       case 2:
         return (
@@ -230,7 +237,7 @@ export function WizardContainer({
             onBack={handleStep2Back}
             onNext={handleStep2Next}
           />
-        )
+        );
 
       case 3:
         return (
@@ -244,15 +251,15 @@ export function WizardContainer({
             onExportPDF={handleExportPDF}
             onOpenPricingModal={onOpenPricingModal}
           />
-        )
+        );
 
       default:
-        return null
+        return null;
     }
-  }
+  };
 
   return (
-    <div className={cn('space-y-8', className)}>
+    <div className={cn("space-y-8", className)}>
       {/* Wizard Steps Indicator */}
       <WizardSteps currentStep={wizardState.currentStep} />
 
@@ -265,7 +272,7 @@ export function WizardContainer({
             initial="enter"
             animate="center"
             exit="exit"
-            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            transition={{ duration: 0.3, ease: "easeInOut" }}
           >
             {renderCurrentStep()}
           </motion.div>
@@ -280,5 +287,5 @@ export function WizardContainer({
         onSelectAnalysis={handleLoadFromHistory}
       />
     </div>
-  )
+  );
 }

--- a/frontend-next/src/components/jobs/job-details-modal.tsx
+++ b/frontend-next/src/components/jobs/job-details-modal.tsx
@@ -41,6 +41,9 @@ import { useSubscription } from "@/contexts/subscription-context";
 import { useAuthenticatedFetch } from "@/hooks/use-authenticated-fetch";
 import { ApplyModal } from "./apply-modal";
 import { InsiderFinderDrawer } from "./insider-finder-drawer";
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || "";
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -78,30 +81,32 @@ export function JobDetailsModal({
     const trackView = async () => {
       try {
         // Use authenticatedFetch to automatically include auth token if user is logged in
-        const response = await authenticatedFetch("/api/jobs/track-view", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
+        const response = await authenticatedFetch(
+          `${BACKEND_URL}/api/jobs/track-view`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ job_id: job.id || job.url }),
           },
-          body: JSON.stringify({ job_id: job.id || job.url }),
-        });
+        );
+
+        // Parse body once — a Response body can only be consumed once
+        const data = await response.json().catch(() => ({}));
 
         if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-
           // Handle quota exceeded (429) - show upgrade modal
           if (
             response.status === 429 &&
-            errorData.detail?.error === "quota_exceeded"
+            data.detail?.error === "quota_exceeded"
           ) {
             console.warn("Job view quota exceeded");
             openPricingModal("job_view");
             onOpenChange(false); // Close the modal
-            return;
           }
+          return;
         }
-
-        const data = await response.json();
 
         if (
           data.success &&

--- a/frontend-next/src/lib/api/huntzen-client.ts
+++ b/frontend-next/src/lib/api/huntzen-client.ts
@@ -1,11 +1,15 @@
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_BACKEND_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  (() => {
+// Resolved lazily inside fetch() to avoid crashing at module load time during
+// Next.js static generation (prerendering), where NEXT_PUBLIC_* vars may be absent.
+function getApiBaseUrl(): string {
+  const url =
+    process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+  if (!url) {
     throw new Error(
       "NEXT_PUBLIC_BACKEND_URL or NEXT_PUBLIC_API_URL is not configured",
     );
-  })();
+  }
+  return url;
+}
 
 export interface Country {
   name: string;
@@ -107,10 +111,14 @@ export interface JobFairSearchResult {
 }
 
 class HuntzenApiClient {
-  private baseUrl: string;
+  private _baseUrl?: string;
 
-  constructor(baseUrl: string = API_BASE_URL) {
-    this.baseUrl = baseUrl;
+  constructor(baseUrl?: string) {
+    this._baseUrl = baseUrl;
+  }
+
+  private get baseUrl(): string {
+    return this._baseUrl ?? getApiBaseUrl();
   }
 
   private async fetch<T>(endpoint: string, options?: RequestInit): Promise<T> {

--- a/frontend-next/src/utils/export-cv-pdf.tsx
+++ b/frontend-next/src/utils/export-cv-pdf.tsx
@@ -5,6 +5,7 @@
 
 import { pdf } from '@react-pdf/renderer';
 import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+import type { CVAnalysisResult } from '@/hooks/use-cv-history';
 
 // PDF Styles
 const styles = StyleSheet.create({
@@ -90,102 +91,90 @@ const styles = StyleSheet.create({
   },
 });
 
-interface CVAnalysisResult {
-  ats_score: {
-    overall_score: number;
-    formatting_score: number;
-    keywords_score: number;
-    structure_score: number;
-    readability_score: number;
-  };
-  strengths: string[];
-  improvements: string[];
-  missing_sections?: string[];
-  keywords_found?: string[];
-  keywords_missing?: string[];
-  analysis_language: 'fr' | 'en';
-  processed_at: string;
-}
-
 // PDF Document Component
-const CVAnalysisPDFDocument = ({ result }: { result: CVAnalysisResult }) => (
-  <Document>
-    <Page size="A4" style={styles.page}>
-      {/* Header */}
-      <View style={styles.header}>
-        <Text style={styles.title}>Analyse de CV - Résultats</Text>
-        <Text style={styles.subtitle}>
-          Généré le {new Date(result.processed_at).toLocaleDateString('fr-FR')}
-        </Text>
-      </View>
+const CVAnalysisPDFDocument = ({ result }: { result: CVAnalysisResult }) => {
+  const analyzedDate =
+    result.analyzedAt instanceof Date
+      ? result.analyzedAt.toLocaleDateString('fr-FR')
+      : new Date(result.analyzedAt).toLocaleDateString('fr-FR');
 
-      {/* Overall Score */}
-      <View style={styles.scoreContainer}>
-        <Text style={styles.scoreText}>{result.ats_score.overall_score}/100</Text>
-        <Text style={styles.scoreLabel}>Score ATS Global</Text>
-      </View>
-
-      {/* Score Breakdown */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Détails du Score</Text>
-        <View style={styles.breakdown}>
-          <Text style={styles.breakdownLabel}>Format</Text>
-          <Text style={styles.breakdownValue}>{result.ats_score.formatting_score}/100</Text>
-        </View>
-        <View style={styles.breakdown}>
-          <Text style={styles.breakdownLabel}>Mots-clés</Text>
-          <Text style={styles.breakdownValue}>{result.ats_score.keywords_score}/100</Text>
-        </View>
-        <View style={styles.breakdown}>
-          <Text style={styles.breakdownLabel}>Structure</Text>
-          <Text style={styles.breakdownValue}>{result.ats_score.structure_score}/100</Text>
-        </View>
-        <View style={styles.breakdown}>
-          <Text style={styles.breakdownLabel}>Lisibilité</Text>
-          <Text style={styles.breakdownValue}>{result.ats_score.readability_score}/100</Text>
-        </View>
-      </View>
-
-      {/* Strengths */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Points Forts</Text>
-        {(result.strengths || []).map((strength, index) => (
-          <Text key={index} style={styles.listItem}>
-            • {strength}
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.title}>Analyse de CV - Résultats</Text>
+          <Text style={styles.subtitle}>
+            {result.fileName} — Généré le {analyzedDate}
           </Text>
-        ))}
-      </View>
-
-      {/* Improvements */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Points à Améliorer</Text>
-        {(result.improvements || []).map((improvement, index) => (
-          <Text key={index} style={styles.listItem}>
-            • {improvement}
-          </Text>
-        ))}
-      </View>
-
-      {/* Missing Sections */}
-      {result.missing_sections && result.missing_sections.length > 0 && (
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Sections Manquantes</Text>
-          {result.missing_sections.map((section, index) => (
-            <Text key={index} style={styles.listItem}>
-              • {section}
-            </Text>
-          ))}
         </View>
-      )}
 
-      {/* Footer */}
-      <View style={styles.footer}>
-        <Text>Généré par HuntZen - Plateforme d'assistance à la recherche d'emploi</Text>
-        <Text>huntzen.fr</Text>
-      </View>
-    </Page>
-  </Document>
-);
+        {/* Overall Score */}
+        <View style={styles.scoreContainer}>
+          <Text style={styles.scoreText}>{result.score}/100</Text>
+          <Text style={styles.scoreLabel}>Score Global</Text>
+        </View>
+
+        {/* Score Breakdown */}
+        {result.breakdown && result.breakdown.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Détails du Score</Text>
+            {result.breakdown.map((item, index) => (
+              <View key={index} style={styles.breakdown}>
+                <Text style={styles.breakdownLabel}>{item.label}</Text>
+                <Text style={styles.breakdownValue}>
+                  {item.value}/{item.max}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Strengths */}
+        {result.strengths && result.strengths.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Points Forts</Text>
+            {result.strengths.map((strength, index) => (
+              <Text key={index} style={styles.listItem}>
+                • {strength}
+              </Text>
+            ))}
+          </View>
+        )}
+
+        {/* Weaknesses */}
+        {result.weaknesses && result.weaknesses.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Points à Améliorer</Text>
+            {result.weaknesses.map((weakness, index) => (
+              <Text key={index} style={styles.listItem}>
+                • {weakness}
+              </Text>
+            ))}
+          </View>
+        )}
+
+        {/* Suggestions */}
+        {result.suggestions && result.suggestions.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Recommandations</Text>
+            {result.suggestions.map((suggestion, index) => (
+              <Text key={index} style={styles.listItem}>
+                • {suggestion.text}
+              </Text>
+            ))}
+          </View>
+        )}
+
+        {/* Footer */}
+        <View style={styles.footer}>
+          <Text>Généré par HuntZen - Plateforme d'assistance à la recherche d'emploi</Text>
+          <Text>huntzen.fr</Text>
+        </View>
+      </Page>
+    </Document>
+  );
+};
 
 /**
  * Export CV analysis results to PDF file
@@ -197,26 +186,19 @@ export async function exportCVAnalysisToPDF(
   fileName?: string
 ): Promise<void> {
   try {
-    // Generate PDF
     const blob = await pdf(<CVAnalysisPDFDocument result={result} />).toBlob();
 
-    // Create download link
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
     link.download = fileName || `cv-analysis-${new Date().toISOString().split('T')[0]}.pdf`;
 
-    // Trigger download
     document.body.appendChild(link);
     link.click();
-
-    // Cleanup
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
-
-    console.log('✅ PDF exported successfully');
   } catch (error) {
     console.error('Failed to export PDF:', error);
-    throw new Error('Échec de l\'export PDF');
+    throw new Error("Échec de l'export PDF");
   }
 }


### PR DESCRIPTION
## Summary

- Fixes Vercel build failure on pages `/assistant`, `/jobs`, `/recruiter-contact`, `/salons`
- `NEXT_PUBLIC_BACKEND_URL` was evaluated at module load time via an IIFE — throwing during Next.js static generation where env vars are absent
- Replaced with a lazy `get baseUrl()` getter that only throws when an actual API call is made at runtime

Closes #103

## Root cause

```ts
// BEFORE — throws at import time ❌
const API_BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL || (() => { throw new Error(...) })();
```

```ts
// AFTER — throws only when fetch() is called at runtime ✅
function getApiBaseUrl(): string { ... }
private get baseUrl(): string { return this._baseUrl ?? getApiBaseUrl(); }
```

## Test plan

- [ ] `next build` passes on Vercel without `NEXT_PUBLIC_BACKEND_URL` set at build time
- [ ] API calls still work at runtime when the env var is set
- [ ] Pages `/assistant`, `/jobs`, `/recruiter-contact`, `/salons` render correctly