### PR TITLE
feat(jobs): direct links, HTML descriptions, cards redesign & quick filters

### DIFF
--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -281,6 +281,18 @@ async def get_market_insights(
     }
 
 
+def _clean_element_html(el) -> str:
+    """
+    Strip unsafe/noisy attributes from all child tags and return inner HTML.
+    """
+    for tag in el.find_all(True):
+        tag.attrs = {
+            k: v for k, v in tag.attrs.items()
+            if k not in ("style", "class", "id") and not k.startswith("on")
+        }
+    return el.decode_contents()
+
+
 @router.post("/description")
 async def get_job_description(request: Request):
     """
@@ -288,6 +300,7 @@ async def get_job_description(request: Request):
 
     Fetches the page and extracts the job description section using common
     CSS selectors, then falls back to the longest paragraph block.
+    Returns HTML content and the final resolved URL after redirects.
     """
     import httpx
     from bs4 import BeautifulSoup
@@ -297,14 +310,16 @@ async def get_job_description(request: Request):
         url = body.get("url", "")
 
         if not url:
-            return {"success": False, "description": ""}
+            return {"success": False, "description": "", "final_url": None}
 
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
             headers = {"User-Agent": "Mozilla/5.0 (compatible; HuntZen/1.0)"}
             response = await client.get(url, headers=headers)
 
+        final_url = str(response.url)
+
         if response.status_code != 200:
-            return {"success": False, "description": ""}
+            return {"success": False, "description": "", "final_url": final_url}
 
         soup = BeautifulSoup(response.text, "html.parser")
 
@@ -322,25 +337,27 @@ async def get_job_description(request: Request):
             'article',
             'main',
         ]
-        text = ""
+        found_el = None
         for selector in selectors:
             el = soup.select_one(selector)
-            if el:
-                text = el.get_text(separator="\n", strip=True)
-                if len(text) > 200:
-                    break
+            if el and len(el.get_text(strip=True)) > 200:
+                found_el = el
+                break
 
-        # Fallback: join longest paragraph blocks
-        if not text or len(text) < 200:
+        if found_el:
+            html_content = _clean_element_html(found_el)
+        else:
+            # Fallback: wrap long paragraphs in <p> tags
             paragraphs = soup.find_all("p")
-            text = "\n".join(
-                p.get_text(strip=True) for p in paragraphs if len(p.get_text()) > 50
+            html_content = "".join(
+                f"<p>{p.get_text(strip=True)}</p>"
+                for p in paragraphs if len(p.get_text()) > 50
             )
 
-        return {"success": True, "description": text[:5000]}
+        return {"success": True, "description": html_content[:8000], "final_url": final_url}
 
     except Exception:
-        return {"success": False, "description": ""}
+        return {"success": False, "description": "", "final_url": None}
 
 
 @router.post("/track-view")

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -4,12 +4,18 @@ Job Search API Routes
 Endpoints for AI-powered job searching.
 """
 
+import logging
 from typing import List
+
+import httpx
+from bs4 import BeautifulSoup
 from fastapi import APIRouter, HTTPException, status, Query, Request
 
 from src.api.deps import ScoutAgentDep
 from src.api.middleware import limiter
 from src.models.schemas import JobSearchRequest, JobSearchResponse, SearchMetadata, Job
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -302,9 +308,6 @@ async def get_job_description(request: Request):
     CSS selectors, then falls back to the longest paragraph block.
     Returns HTML content and the final resolved URL after redirects.
     """
-    import httpx
-    from bs4 import BeautifulSoup
-
     try:
         body = await request.json()
         url = body.get("url", "")
@@ -354,9 +357,12 @@ async def get_job_description(request: Request):
                 for p in paragraphs if len(p.get_text()) > 50
             )
 
+        if not html_content or len(html_content.strip()) < 50:
+            return {"success": False, "description": "", "final_url": final_url}
         return {"success": True, "description": html_content[:8000], "final_url": final_url}
 
     except Exception:
+        logger.exception("description scrape failed for url=%s", url)
         return {"success": False, "description": "", "final_url": None}
 
 

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -41,6 +41,7 @@ import {
   RefreshCw,
   ChevronLeft,
   ChevronRight,
+  Clock,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -56,7 +57,10 @@ import {
 } from "@/components/jobs/gradient-job-card";
 import { JobDetailsModal } from "@/components/jobs/job-details-modal";
 import { SearchLoadingModal } from "@/components/jobs/search-loading-modal";
-import { formatJobSource } from "@/lib/utils/job-source-formatter";
+import {
+  formatJobSource,
+  getSourceColor,
+} from "@/lib/utils/job-source-formatter";
 import {
   SearchFormInline,
   type SearchParams,
@@ -127,6 +131,25 @@ const stripHtmlForPreview = (html: string) =>
     .replace(/&[a-z]+;/gi, " ")
     .replace(/\s+/g, " ")
     .trim();
+
+function formatRelativeDate(dateStr: string): string {
+  try {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return "Aujourd'hui";
+    if (diffDays === 1) return "Hier";
+    if (diffDays < 7) return `Il y a ${diffDays} jours`;
+    if (diffDays < 30)
+      return `Il y a ${Math.floor(diffDays / 7)} semaine${Math.floor(diffDays / 7) > 1 ? "s" : ""}`;
+    if (diffDays < 365) return `Il y a ${Math.floor(diffDays / 30)} mois`;
+    return date.toLocaleDateString("fr-FR");
+  } catch {
+    return dateStr;
+  }
+}
 
 export default function JobsPage() {
   const t = useTranslations("dashboard.jobs");
@@ -1522,8 +1545,17 @@ export default function JobsPage() {
                             {job.title}
                           </CardTitle>
                           <CardDescription className="flex items-center gap-2 mt-3 text-base">
-                            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-[#00D9FF] to-[#00C4EA] flex items-center justify-center flex-shrink-0 shadow-md">
-                              <Building className="h-5 w-5 text-white" />
+                            <div
+                              className={cn(
+                                "w-9 h-9 rounded-xl flex items-center justify-center flex-shrink-0 shadow-md text-white font-bold text-sm",
+                                getSourceColor(job.source),
+                              )}
+                            >
+                              {job.company ? (
+                                job.company.charAt(0).toUpperCase()
+                              ) : (
+                                <Building className="h-4 w-4" />
+                              )}
                             </div>
                             <span className="font-semibold text-slate-800">
                               {job.company}
@@ -1532,11 +1564,21 @@ export default function JobsPage() {
                         </div>
                         <div className="flex flex-col items-end gap-2">
                           <Badge
-                            variant="secondary"
-                            className="shrink-0 font-bold px-3 py-1 bg-slate-100 text-slate-700 border border-slate-200"
+                            className={cn(
+                              "shrink-0 font-bold px-3 py-1 text-white border-0",
+                              getSourceColor(job.source),
+                            )}
                           >
                             {formatJobSource(job.source)}
                           </Badge>
+                          {job.contract_type && (
+                            <Badge
+                              variant="outline"
+                              className="shrink-0 text-xs px-2 py-0.5 text-slate-600 border-slate-300"
+                            >
+                              {job.contract_type}
+                            </Badge>
+                          )}
                           <button
                             onClick={() => handleSaveJob(job)}
                             className={cn(
@@ -1611,11 +1653,19 @@ export default function JobsPage() {
                         </p>
                       </div>
 
-                      {/* URL warning */}
+                      {/* URL indicator */}
                       {job.url_is_direct === false && (
-                        <p className="text-xs text-amber-600 flex items-center gap-1">
-                          <span>⚠️</span>
-                          <span>Le lien peut ouvrir une page de recherche</span>
+                        <span className="text-xs text-slate-400 flex items-center gap-1">
+                          <ExternalLink className="h-3 w-3" />
+                          Via agrégateur
+                        </span>
+                      )}
+
+                      {/* Posted date */}
+                      {job.posted_date && (
+                        <p className="text-xs text-slate-400 flex items-center justify-end gap-1 mt-1">
+                          <Clock className="h-3 w-3" />
+                          {formatRelativeDate(job.posted_date)}
                         </p>
                       )}
 

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -42,6 +42,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
+  SlidersHorizontal,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -151,6 +153,14 @@ function formatRelativeDate(dateStr: string): string {
   }
 }
 
+interface QuickFilters {
+  sources: string[];
+  contractTypes: string[];
+  maxDays: number | null; // null = all dates
+  salaryMin: number | null;
+  directOnly: boolean;
+}
+
 export default function JobsPage() {
   const t = useTranslations("dashboard.jobs");
   const [jobTitle, setJobTitle] = useState("");
@@ -173,6 +183,16 @@ export default function JobsPage() {
   const [advancedFilters, setAdvancedFilters] = useState<AdvancedFilters>({});
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
+
+  // Quick filters state (client-side filtering on loaded results)
+  const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
+  const [quickFilters, setQuickFilters] = useState<QuickFilters>({
+    sources: [],
+    contractTypes: [],
+    maxDays: null,
+    salaryMin: null,
+    directOnly: false,
+  });
 
   // Auth & Query Client
   const auth = useOptionalAuth();
@@ -774,6 +794,32 @@ export default function JobsPage() {
     setModalOpen(true);
   };
 
+  // Derive available filter options from loaded results
+  const availableSources = useMemo(
+    () =>
+      [...new Set(translatedJobs.map((j) => j.source).filter(Boolean))].sort(),
+    [translatedJobs],
+  );
+  const availableContractTypes = useMemo(
+    () =>
+      [
+        ...new Set(
+          translatedJobs
+            .map((j) => j.contract_type)
+            .filter(Boolean) as string[],
+        ),
+      ].sort(),
+    [translatedJobs],
+  );
+
+  // Count active quick filters
+  const activeQuickFiltersCount =
+    quickFilters.sources.length +
+    quickFilters.contractTypes.length +
+    (quickFilters.maxDays !== null ? 1 : 0) +
+    (quickFilters.salaryMin !== null ? 1 : 0) +
+    (quickFilters.directOnly ? 1 : 0);
+
   // Split jobs into visible and blurred
   // Progressive reveal: only show jobs up to visibleJobsCount
   // Use translatedJobs for display (auto-translated when locale ≠ fr)
@@ -781,7 +827,44 @@ export default function JobsPage() {
   const filteredProgressiveJobs = progressiveJobs.filter(
     (j) => j.url_is_direct !== false,
   );
-  const visibleJobs = filteredProgressiveJobs.slice(0, jobsVisibleLimit);
+  // Apply quick filters client-side
+  const quickFilteredJobs = useMemo(() => {
+    let result = filteredProgressiveJobs;
+    if (quickFilters.sources.length > 0) {
+      result = result.filter((j) => quickFilters.sources.includes(j.source));
+    }
+    if (quickFilters.contractTypes.length > 0) {
+      result = result.filter(
+        (j) =>
+          j.contract_type &&
+          quickFilters.contractTypes.includes(j.contract_type),
+      );
+    }
+    if (quickFilters.maxDays !== null) {
+      const cutoff = Date.now() - quickFilters.maxDays * 24 * 60 * 60 * 1000;
+      result = result.filter((j) => {
+        if (!j.posted_date) return true; // keep if no date
+        try {
+          return new Date(j.posted_date).getTime() >= cutoff;
+        } catch {
+          return true;
+        }
+      });
+    }
+    if (quickFilters.salaryMin !== null) {
+      result = result.filter((j) => {
+        if (!j.salary) return false;
+        const match = j.salary.replace(/\s/g, "").match(/\d+/);
+        if (!match) return false;
+        return parseInt(match[0]) >= (quickFilters.salaryMin ?? 0);
+      });
+    }
+    if (quickFilters.directOnly) {
+      result = result.filter((j) => j.url_is_direct === true);
+    }
+    return result;
+  }, [filteredProgressiveJobs, quickFilters]);
+  const visibleJobs = quickFilteredJobs.slice(0, jobsVisibleLimit);
   const totalPages = Math.max(1, Math.ceil(visibleJobs.length / pageSize));
   const safePage = Math.min(currentPage, totalPages);
   const paginatedJobs = visibleJobs.slice(
@@ -1476,6 +1559,25 @@ export default function JobsPage() {
                     {t("results.refresh")}
                   </span>
                 </Button>
+                {/* Quick filter toggle button */}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setQuickFiltersOpen(!quickFiltersOpen)}
+                  className={cn(
+                    "gap-2 bg-white",
+                    quickFiltersOpen && "border-[#00D9FF] text-[#00D9FF]",
+                    activeQuickFiltersCount > 0 && "border-[#00D9FF]",
+                  )}
+                >
+                  <SlidersHorizontal className="w-4 h-4" />
+                  <span className="hidden sm:inline">Filtrer</span>
+                  {activeQuickFiltersCount > 0 && (
+                    <span className="ml-1 bg-[#00D9FF] text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
+                      {activeQuickFiltersCount}
+                    </span>
+                  )}
+                </Button>
               </div>
               <div className="flex flex-col items-end gap-3">
                 {/* Page size selector */}
@@ -1521,6 +1623,186 @@ export default function JobsPage() {
                 )}
               </div>
             </motion.div>
+
+            {/* Quick filter panel */}
+            {quickFiltersOpen && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: "auto" }}
+                exit={{ opacity: 0, height: 0 }}
+                className="bg-white border border-slate-200 rounded-xl p-4 space-y-4 overflow-hidden"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold text-slate-700">
+                    Filtrer les résultats
+                  </h3>
+                  {activeQuickFiltersCount > 0 && (
+                    <button
+                      onClick={() =>
+                        setQuickFilters({
+                          sources: [],
+                          contractTypes: [],
+                          maxDays: null,
+                          salaryMin: null,
+                          directOnly: false,
+                        })
+                      }
+                      className="text-xs text-red-500 hover:text-red-700 flex items-center gap-1"
+                    >
+                      <X className="h-3 w-3" />
+                      Réinitialiser ({activeQuickFiltersCount})
+                    </button>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                  {/* Source filter */}
+                  {availableSources.length > 1 && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-600 mb-2">
+                        Source
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {availableSources.map((source) => (
+                          <button
+                            key={source}
+                            onClick={() =>
+                              setQuickFilters((prev) => ({
+                                ...prev,
+                                sources: prev.sources.includes(source)
+                                  ? prev.sources.filter((s) => s !== source)
+                                  : [...prev.sources, source],
+                              }))
+                            }
+                            className={cn(
+                              "text-xs px-2 py-1 rounded-full border transition-colors",
+                              quickFilters.sources.includes(source)
+                                ? "bg-[#00D9FF] text-white border-[#00D9FF]"
+                                : "bg-white text-slate-600 border-slate-200 hover:border-[#00D9FF]",
+                            )}
+                          >
+                            {formatJobSource(source)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Contract type filter */}
+                  {availableContractTypes.length > 0 && (
+                    <div>
+                      <p className="text-xs font-semibold text-slate-600 mb-2">
+                        Type de contrat
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {availableContractTypes.map((ct) => (
+                          <button
+                            key={ct}
+                            onClick={() =>
+                              setQuickFilters((prev) => ({
+                                ...prev,
+                                contractTypes: prev.contractTypes.includes(ct)
+                                  ? prev.contractTypes.filter((c) => c !== ct)
+                                  : [...prev.contractTypes, ct],
+                              }))
+                            }
+                            className={cn(
+                              "text-xs px-2 py-1 rounded-full border transition-colors",
+                              quickFilters.contractTypes.includes(ct)
+                                ? "bg-[#00D9FF] text-white border-[#00D9FF]"
+                                : "bg-white text-slate-600 border-slate-200 hover:border-[#00D9FF]",
+                            )}
+                          >
+                            {ct}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Date filter */}
+                  <div>
+                    <p className="text-xs font-semibold text-slate-600 mb-2">
+                      Date de publication
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {[
+                        { label: "Aujourd'hui", days: 1 },
+                        { label: "3 jours", days: 3 },
+                        { label: "7 jours", days: 7 },
+                        { label: "30 jours", days: 30 },
+                      ].map(({ label, days }) => (
+                        <button
+                          key={days}
+                          onClick={() =>
+                            setQuickFilters((prev) => ({
+                              ...prev,
+                              maxDays: prev.maxDays === days ? null : days,
+                            }))
+                          }
+                          className={cn(
+                            "text-xs px-2 py-1 rounded-full border transition-colors",
+                            quickFilters.maxDays === days
+                              ? "bg-[#00D9FF] text-white border-[#00D9FF]"
+                              : "bg-white text-slate-600 border-slate-200 hover:border-[#00D9FF]",
+                          )}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Salary + direct-only */}
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-xs font-semibold text-slate-600 mb-2">
+                        Salaire min (€/an)
+                      </p>
+                      <input
+                        type="number"
+                        placeholder="ex: 35000"
+                        value={quickFilters.salaryMin ?? ""}
+                        onChange={(e) =>
+                          setQuickFilters((prev) => ({
+                            ...prev,
+                            salaryMin: e.target.value
+                              ? parseInt(e.target.value)
+                              : null,
+                          }))
+                        }
+                        className="w-full text-xs border border-slate-200 rounded-lg px-2 py-1.5 focus:outline-none focus:border-[#00D9FF]"
+                      />
+                    </div>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={quickFilters.directOnly}
+                        onChange={(e) =>
+                          setQuickFilters((prev) => ({
+                            ...prev,
+                            directOnly: e.target.checked,
+                          }))
+                        }
+                        className="rounded border-slate-300 text-[#00D9FF] focus:ring-[#00D9FF]"
+                      />
+                      <span className="text-xs text-slate-600">
+                        Liens directs uniquement
+                      </span>
+                    </label>
+                  </div>
+                </div>
+
+                {/* Results count */}
+                <p className="text-xs text-slate-500 border-t border-slate-100 pt-2">
+                  {quickFilteredJobs.length} offre
+                  {quickFilteredJobs.length !== 1 ? "s" : ""} affichée
+                  {quickFilteredJobs.length !== 1 ? "s" : ""}
+                  {activeQuickFiltersCount > 0 &&
+                    ` sur ${filteredProgressiveJobs.length} total`}
+                </p>
+              </motion.div>
+            )}
 
             <div
               className={`grid gap-6 auto-rows-fr ${

--- a/frontend-next/src/components/jobs/job-details-modal.tsx
+++ b/frontend-next/src/components/jobs/job-details-modal.tsx
@@ -44,6 +44,30 @@ import { InsiderFinderDrawer } from "./insider-finder-drawer";
 
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_URL || "";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function formatRelativeDate(dateStr: string): string {
+  try {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) return "Aujourd'hui";
+    if (diffDays === 1) return "Hier";
+    if (diffDays < 7) return `Il y a ${diffDays} jours`;
+    if (diffDays < 30)
+      return `Il y a ${Math.floor(diffDays / 7)} semaine${Math.floor(diffDays / 7) > 1 ? "s" : ""}`;
+    if (diffDays < 365) return `Il y a ${Math.floor(diffDays / 30)} mois`;
+    return date.toLocaleDateString("fr-FR");
+  } catch {
+    return dateStr;
+  }
+}
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -71,8 +95,11 @@ export function JobDetailsModal({
   // All hooks must be called before any conditional return (Rules of Hooks)
   const { canUse, openPricingModal } = useSubscription();
   const { authenticatedFetch } = useAuthenticatedFetch();
-  const { description: fullDescription, loading: loadingDescription } =
-    useFullJobDescription(job?.url, job?.source);
+  const {
+    description: fullDescription,
+    finalUrl,
+    loading: loadingDescription,
+  } = useFullJobDescription(job?.url, job?.source);
 
   // Track job view when modal opens — must be before early return (Rules of Hooks)
   React.useEffect(() => {
@@ -133,6 +160,9 @@ export function JobDetailsModal({
 
   if (!job) return null;
 
+  const resolvedUrl = finalUrl || job.url;
+  const isNowDirect = !!finalUrl;
+
   // Format source for display
   const displaySource = formatJobSource(job.source);
 
@@ -156,6 +186,12 @@ export function JobDetailsModal({
       "ul",
       "ol",
       "li",
+      "table",
+      "thead",
+      "tbody",
+      "tr",
+      "td",
+      "th",
       "a",
       "span",
       "div",
@@ -240,12 +276,19 @@ export function JobDetailsModal({
                       </h3>
                       <div className="bg-gray-50 p-5 rounded-lg border border-gray-200">
                         {loadingDescription ? (
-                          <div className="space-y-3">
-                            <Skeleton className="h-4 w-full" />
-                            <Skeleton className="h-4 w-5/6" />
-                            <Skeleton className="h-4 w-4/6" />
-                            <Skeleton className="h-4 w-full" />
-                            <Skeleton className="h-4 w-3/4" />
+                          <div className="space-y-4">
+                            <Skeleton className="h-5 w-1/3" />
+                            <div className="space-y-2 pl-4">
+                              <Skeleton className="h-3.5 w-full" />
+                              <Skeleton className="h-3.5 w-5/6" />
+                              <Skeleton className="h-3.5 w-4/5" />
+                            </div>
+                            <Skeleton className="h-5 w-2/5 mt-2" />
+                            <div className="space-y-2 pl-4">
+                              <Skeleton className="h-3.5 w-full" />
+                              <Skeleton className="h-3.5 w-3/4" />
+                              <Skeleton className="h-3.5 w-5/6" />
+                            </div>
                           </div>
                         ) : (
                           <div
@@ -348,7 +391,20 @@ export function JobDetailsModal({
                         <span className="font-semibold">{t("postedDate")}</span>
                       </div>
                       <p className="text-gray-900 font-medium">
-                        {job.posted_date}
+                        {formatRelativeDate(job.posted_date)}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* Contract Type */}
+                  {job.contract_type && (
+                    <div className="bg-gray-50 p-4 rounded-lg border border-gray-200">
+                      <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
+                        <Briefcase className="h-5 w-5" />
+                        <span className="font-semibold">Contrat</span>
+                      </div>
+                      <p className="text-gray-900 font-medium">
+                        {job.contract_type}
                       </p>
                     </div>
                   )}
@@ -380,16 +436,22 @@ export function JobDetailsModal({
                 {job.url && (
                   <Button
                     asChild
-                    variant={job.url_is_direct ? "default" : "outline"}
+                    variant={
+                      job.url_is_direct || isNowDirect ? "default" : "outline"
+                    }
                     size="sm"
                     className={
-                      job.url_is_direct
+                      job.url_is_direct || isNowDirect
                         ? "flex-1 sm:flex-none bg-green-600 hover:bg-green-700 text-white"
                         : "flex-1 sm:flex-none"
                     }
                   >
-                    <a href={job.url} target="_blank" rel="noopener noreferrer">
-                      {job.url_is_direct
+                    <a
+                      href={resolvedUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {job.url_is_direct || isNowDirect
                         ? "Postuler directement"
                         : t("viewOffer")}
                       <ExternalLink className="ml-2 h-4 w-4" />

--- a/frontend-next/src/hooks/use-full-job-description.ts
+++ b/frontend-next/src/hooks/use-full-job-description.ts
@@ -1,31 +1,40 @@
-import { useState, useEffect } from 'react'
-import { huntzenApi } from '@/lib/api/huntzen-client'
+import { useState, useEffect } from "react";
+import { huntzenApi } from "@/lib/api/huntzen-client";
 
-export function useFullJobDescription(url: string | undefined, source?: string) {
-  const [description, setDescription] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+export function useFullJobDescription(
+  url: string | undefined,
+  source?: string,
+) {
+  const [description, setDescription] = useState<string | null>(null);
+  const [finalUrl, setFinalUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!url) return
+    if (!url) return;
+
+    setFinalUrl(null);
 
     const fetchFullDescription = async () => {
-      setLoading(true)
+      setLoading(true);
       try {
-        const fullDesc = await huntzenApi.getJobDescription(url, source)
-        if (fullDesc && fullDesc.length > 100) {
-          setDescription(fullDesc)
+        const result = await huntzenApi.getJobDescription(url, source);
+        if (result && result.description && result.description.length > 100) {
+          setDescription(result.description);
+        }
+        if (result.final_url && result.final_url !== url) {
+          setFinalUrl(result.final_url);
         }
       } catch (err) {
-        console.error('Failed to fetch full description:', err)
-        setError('Impossible de charger la description complète')
+        console.error("Failed to fetch full description:", err);
+        setError("Impossible de charger la description complète");
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
-    }
+    };
 
-    fetchFullDescription()
-  }, [url, source])
+    fetchFullDescription();
+  }, [url, source]);
 
-  return { description, loading, error }
+  return { description, finalUrl, loading, error };
 }

--- a/frontend-next/src/lib/api/huntzen-client.ts
+++ b/frontend-next/src/lib/api/huntzen-client.ts
@@ -40,6 +40,7 @@ export interface Job {
   posted_date?: string;
   url_is_direct?: boolean;
   description_truncated?: boolean;
+  contract_type?: string;
 }
 
 export interface SavedJob {
@@ -570,15 +571,22 @@ class HuntzenApiClient {
   }
 
   // Job Description
-  async getJobDescription(url: string, source?: string): Promise<string> {
+  async getJobDescription(
+    url: string,
+    source?: string,
+  ): Promise<{ description: string; final_url: string | null }> {
     const response = await this.fetch<{
       success: boolean;
       description: string;
+      final_url?: string;
     }>("/api/jobs/description", {
       method: "POST",
       body: JSON.stringify({ url, source: source || "" }),
     });
-    return response.description || "";
+    return {
+      description: response.description || "",
+      final_url: response.final_url || null,
+    };
   }
 
   // Job Fairs / Salons d'Emploi


### PR DESCRIPTION
## Summary

- **Liens directs** : bouton "Voir l'offre" résout l'URL finale après redirects Adzuna — plus de double clic. Passe en vert "Postuler directement" automatiquement
- **Descriptions HTML** : scraper backend retourne du HTML structuré (titres, listes) au lieu de plain text
- **Cards redessinées** : avatar initiale entreprise colorée par source, badges source colorés, date relative bas-droite, badge contract_type, indicateur "Via agrégateur" sobre
- **Modal améliorée** : dates relatives, contract_type dans les infos, skeleton réaliste, DOMPurify étendu
- **Filtre rapide** : panel collapsible avec filtres client-side par source, contrat, date, salaire minimum, liens directs

## Test plan

- [ ] Offre Adzuna → modal → `final_url` pointe vers domaine employeur (DevTools Network)
- [ ] Bouton passe en vert "Postuler directement" après chargement description
- [ ] Description affiche titres et listes (pas du plain text)
- [ ] Cards : badge source coloré, initiale entreprise, date relative bas-droite
- [ ] Panel "Filtrer" : source / contrat / date / salaire / liens directs fonctionnent
- [ ] Reset filtres remet le compteur à zéro