### PR TITLE
fix(prod): Jour 1 — Supabase Pooler, Sentry backend, Modal spawn

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -52,8 +52,8 @@ async def init_connection_pool_async() -> None:
     try:
         pool = AsyncConnectionPool(
             conninfo=database_url,
-            min_size=10,
-            max_size=50,
+            min_size=2,
+            max_size=10,  # 10/worker × 4 workers × 4 replicas = 160 max → safe avec Supabase Pooler port 6543
             timeout=30,
             max_idle=300,  # 5 minutes
             kwargs={"row_factory": dict_row}
@@ -64,8 +64,8 @@ async def init_connection_pool_async() -> None:
 
         logger.info(
             "connection_pool_initialized",
-            min_size=10,
-            max_size=50,
+            min_size=2,
+            max_size=10,
             timeout=30,
             max_idle=300
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,9 @@ classifiers = [
 ]
 
 dependencies = [
+    # Monitoring
+    "sentry-sdk[fastapi]>=2.0.0",
+
     # FastAPI & Web
     "fastapi>=0.109.0",
     "uvicorn[standard]>=0.27.0",

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     environment: Literal["development", "staging", "production", "test"] = "development"
     
     # --------------------------------------------------------------------------
+    # Monitoring
+    # --------------------------------------------------------------------------
+    sentry_dsn: str = Field(default="", description="Sentry DSN for error tracking")
+
+    # --------------------------------------------------------------------------
     # Server
     # --------------------------------------------------------------------------
     host: str = "0.0.0.0"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -30,6 +30,19 @@ from src.utils.logger import setup_logging, get_logger
 setup_logging()
 logger = get_logger(__name__)
 
+# Sentry — error tracking (active si SENTRY_DSN configuré sur Railway)
+if settings.sentry_dsn:
+    import sentry_sdk
+    from sentry_sdk.integrations.fastapi import FastApiIntegration
+    from sentry_sdk.integrations.starlette import StarletteIntegration
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.environment,
+        traces_sample_rate=0.1,
+        integrations=[StarletteIntegration(), FastApiIntegration()],
+    )
+    logger.info("sentry_initialized", environment=settings.environment)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/scripts/deployment/modal_app.py
+++ b/scripts/deployment/modal_app.py
@@ -740,8 +740,9 @@ async def process_cv_webhook(request_body: dict) -> dict:
         job_description = request_body.get("job_description")
         language = request_body.get("language", "fr")
 
-        # Call main processing function using .local() to run in same container
-        result = await process_cv_analysis.local(
+        # .spawn() — container dédié, retourne en <1s au lieu de bloquer 15s
+        # Railway worker libéré immédiatement — callback /api/cv-analysis/callback déjà en place
+        process_cv_analysis.spawn(
             cv_id=cv_id,
             user_id=user_id,
             pdf_url=pdf_url,
@@ -752,7 +753,8 @@ async def process_cv_webhook(request_body: dict) -> dict:
 
         return {
             "success": True,
-            "result": result
+            "message": "processing_spawned",
+            "cv_id": cv_id
         }
 
     except Exception as e:


### PR DESCRIPTION
## Résumé

- **P1** — `database.py` : pool max_size 50→10 (évite 800 connexions simultanées avec Pooler Supabase)
- **P2** — `main.py` + `settings.py` + `pyproject.toml` : Sentry SDK initialisé si `SENTRY_DSN` présent
- **P3+P4** — `modal_app.py` : `.local()` → `.spawn()` (Railway worker libéré en <1s)

## Action manuelle requise
Changer `DATABASE_URL` Railway → URL Pooler Supabase port 6543

## Test plan
- [ ] Vérifier connexions DB Railway après déploiement (max ~10 par worker)
- [ ] Vérifier erreurs Sentry remontées dans le dashboard
- [ ] Vérifier que les jobs Modal se lancent sans bloquer le worker