### PR TITLE
fix(prod): Jour 2 — Dockerfile workers, Supabase singleton, XP limit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -86,16 +86,18 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Production command with Gunicorn multi-worker (16x capacity increase)
-# Signal Handling: --graceful-timeout 30 allows workers to finish requests before shutdown
-CMD ["gunicorn", "src.main:app", \
-     "--worker-class", "uvicorn.workers.UvicornWorker", \
-     "--workers", "4", \
-     "--bind", "0.0.0.0:8000", \
-     "--timeout", "120", \
-     "--graceful-timeout", "30", \
-     "--keep-alive", "5", \
-     "--max-requests", "1000", \
-     "--max-requests-jitter", "50", \
-     "--access-logfile", "-", \
-     "--error-logfile", "-"]
+# Production command with Gunicorn multi-worker
+# ${WORKERS:-4} : scalable via Railway env var, défaut 4
+# --worker-tmp-dir /dev/shm : évite Permission denied (socket Unix) avec user non-root
+CMD gunicorn src.main:app \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers ${WORKERS:-4} \
+    --worker-tmp-dir /dev/shm \
+    --bind 0.0.0.0:8000 \
+    --timeout 120 \
+    --graceful-timeout 30 \
+    --keep-alive 5 \
+    --max-requests 1000 \
+    --max-requests-jitter 50 \
+    --access-logfile - \
+    --error-logfile -

--- a/backend/src/api/routes/applications.py
+++ b/backend/src/api/routes/applications.py
@@ -9,22 +9,16 @@ from typing import Optional
 from datetime import datetime, timezone
 from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel
-from supabase import create_client, Client
+from supabase import create_client
 
 from src.config.settings import get_settings
+from src.api.deps import get_supabase_client
 from src.services.email import send_application_confirmation, send_application_status_change
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 settings = get_settings()
-
-
-def get_supabase_client() -> Client:
-    return create_client(
-        settings.supabase_url,
-        settings.get_supabase_service_role_key()
-    )
 
 
 def get_user_from_header(authorization: Optional[str]):

--- a/backend/src/api/routes/career_score.py
+++ b/backend/src/api/routes/career_score.py
@@ -157,6 +157,7 @@ def _calculate_xp_score(supabase, user_id: str) -> tuple[int, int]:
             supabase.table("user_xp_events")
             .select("xp_gained")
             .eq("user_id", user_id)
+            .limit(500)
             .execute()
         )
         total_xp = sum(r.get("xp_gained", 0) for r in (xp_res.data or []))

--- a/backend/src/api/routes/notifications.py
+++ b/backend/src/api/routes/notifications.py
@@ -10,23 +10,17 @@ from typing import Optional
 from datetime import datetime, timezone, timedelta
 from fastapi import APIRouter, Header, HTTPException, status
 from pydantic import BaseModel
-from supabase import create_client, Client
+from supabase import create_client
 import httpx
 
 from src.config.settings import get_settings
+from src.api.deps import get_supabase_client
 from src.services.email import send_job_alerts, send_weekly_summary
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 settings = get_settings()
-
-
-def get_supabase_service_client() -> Client:
-    return create_client(
-        settings.supabase_url,
-        settings.get_supabase_service_role_key(),
-    )
 
 
 def get_user_id_and_email_from_header(authorization: Optional[str]):
@@ -98,7 +92,7 @@ async def send_job_alerts_route(payload: SendJobAlertsRequest):
     and send them as a job alert digest email.
     Called by the Vercel cron job at 08:00 daily.
     """
-    supabase = get_supabase_service_client()
+    supabase = get_supabase_client()
     user_id = payload.user_id
 
     email = _get_user_email_by_id(user_id)
@@ -155,7 +149,7 @@ async def send_weekly_summary_route(payload: SendWeeklySummaryRequest):
     Compute last-7-day activity stats for a user and send a weekly summary email.
     Called by the Vercel cron job every Monday at 09:00.
     """
-    supabase = get_supabase_service_client()
+    supabase = get_supabase_client()
     user_id = payload.user_id
 
     email = _get_user_email_by_id(user_id)
@@ -230,7 +224,7 @@ async def get_notification_preferences(authorization: Optional[str] = Header(Non
             detail="Authentication required",
         )
 
-    supabase = get_supabase_service_client()
+    supabase = get_supabase_client()
     try:
         resp = supabase.table("user_notification_preferences") \
             .select("*") \
@@ -291,7 +285,7 @@ async def update_notification_preferences(
     update_data["user_id"] = user_id
     update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
 
-    supabase = get_supabase_service_client()
+    supabase = get_supabase_client()
     try:
         resp = supabase.table("user_notification_preferences") \
             .upsert(update_data, on_conflict="user_id") \

--- a/backend/src/api/routes/saved_jobs.py
+++ b/backend/src/api/routes/saved_jobs.py
@@ -9,22 +9,13 @@ from typing import Optional, List
 from datetime import datetime, timezone
 from fastapi import APIRouter, Header, HTTPException, Query, status
 from pydantic import BaseModel
-from supabase import create_client, Client
-
 from src.config.settings import get_settings
+from src.api.deps import get_supabase_client
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 settings = get_settings()
-
-
-def get_supabase_client() -> Client:
-    """Get Supabase client with service role (lazy initialization)."""
-    return create_client(
-        settings.supabase_url,
-        settings.get_supabase_service_role_key()
-    )
 
 
 class SavedJob(BaseModel):

--- a/frontend-next/src/components/coach/welcome-screen.tsx
+++ b/frontend-next/src/components/coach/welcome-screen.tsx
@@ -28,7 +28,7 @@ export function WelcomeScreen({
   className,
 }: WelcomeScreenProps) {
   const t = useTranslations("dashboard.assistant");
-  const { setSelectedAssistant } = useAssistant();
+  const { selectedAssistant, setSelectedAssistant } = useAssistant();
   const auth = useOptionalAuth();
   const fullName = auth?.user?.user_metadata?.full_name as string | undefined;
   const firstName = fullName?.split(" ")[0] || null;
@@ -36,12 +36,15 @@ export function WelcomeScreen({
   const [hoveredCoach, setHoveredCoach] = React.useState<AssistantType | null>(
     null,
   );
-  const [selectedCoach, setSelectedCoach] =
-    React.useState<AssistantType>("career-coach");
 
-  const activeCoachId = hoveredCoach ?? selectedCoach;
+  // selectedCoach suit selectedAssistant (BotSelector, clic card, etc.)
+  const activeCoachId = hoveredCoach ?? selectedAssistant;
   const activeCoach = getAssistantConfig(activeCoachId);
   const coaches = DISPLAY_COACHES.map((id) => getAssistantConfig(id));
+
+  const handleCardClick = (assistantId: AssistantType) => {
+    setSelectedAssistant(assistantId);
+  };
 
   const handleChipClick = (question: string) => {
     setSelectedAssistant(activeCoach.id);
@@ -74,7 +77,7 @@ export function WelcomeScreen({
           return (
             <button
               key={coach.id}
-              onClick={() => setSelectedCoach(coach.id)}
+              onClick={() => handleCardClick(coach.id)}
               onMouseEnter={() => setHoveredCoach(coach.id)}
               onMouseLeave={() => setHoveredCoach(null)}
               className={cn(


### PR DESCRIPTION
## Changements

### P5 — Dockerfile (2 fixes)
- `--workers ${WORKERS:-4}` : nombre de workers via variable Railway sans rebuild
- `--worker-tmp-dir /dev/shm` : corrige `Permission denied` au démarrage (user non-root `huntzen`)

### P6 — Supabase clients singleton
- `applications.py`, `saved_jobs.py`, `notifications.py` : suppression de `create_client()` local à chaque requête
- Réutilisation du singleton thread-safe `get_supabase_client()` depuis `deps.py`
- Impact : réduit les connexions Supabase ouvertes inutilement sous charge

### P10 — XP query limitée
- `career_score.py` : ajout de `.limit(500)` sur la query `user_xp_events`
- Évite une requête massive pour les power users avec 1000+ events XP

## Test plan
- [ ] Vérifier démarrage Railway sans `Permission denied` dans les logs
- [ ] Vérifier que `WORKERS=4` dans Railway est bien pris en compte (4 workers dans les logs gunicorn)
- [ ] Tester POST /api/career-score/calculate — réponse < 2s
- [ ] Vérifier Supabase Dashboard → pas d'explosion de connexions sous charge