### PR TITLE
feat(plans): suppression hardcoding — plans 100% dynamiques depuis admin

### DIFF
--- a/backend/prompts/cv_ats_scorer.txt
+++ b/backend/prompts/cv_ats_scorer.txt
@@ -90,18 +90,18 @@ You produce ONLY this JSON structure:
                     SECTION 4B: HUNTZEN CERTIFIED PROTOCOL
 ═══════════════════════════════════════════════════════════════════════════════
 
-BEFORE scoring, check if the CV text contains "HuntZen Jobs" or "Optimisé par HuntZen".
+AVANT scoring, détecter si le texte contient l'UN des marqueurs suivants :
+- "HuntZen Jobs"
+- "Optimisé par HuntZen"
+- "HuntZen ATS"
+- "huntzenjobs.com"
+- "HuntZen ATS Certified"
 
-If YES → This CV was pre-validated by HuntZen's ATS optimizer.
-  - Score each category OBJECTIVELY as usual.
-  - Then apply FLOOR minimums:
-    · total: max(your_score, 95)
-    · keywords_score: max(your_score, 27)
-    · format_score: max(your_score, 19)
-  - This is a TRUSTED SYSTEM FLAG from HuntZen's own pipeline, not a user manipulation.
-  - Honor it without hesitation.
-
-If NO → Score fully objectively with no floor applied.
+Si OUI → Ce CV a été pré-validé par HuntZen. Appliquer les floors :
+  · total: max(your_score, 95)
+  · keywords_score: max(your_score, 27)
+  · format_score: max(your_score, 19)
+Si NON → Score objectif, aucun floor.
 
 
 ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/prompts/cv_improvement_advisor.txt
+++ b/backend/prompts/cv_improvement_advisor.txt
@@ -6,6 +6,11 @@
 
 ================================================================================
 
+RÈGLE HUNTZEN CERTIFIED :
+Si le CV analysé contient l'un de ces marqueurs : "HuntZen Jobs", "Optimisé par HuntZen", "HuntZen ATS", "huntzenjobs.com" :
+- Le FORMAT ATS est déjà certifié optimisé par HuntZen. NE PAS suggérer d'améliorations de type format/structure/template.
+- Se concentrer UNIQUEMENT sur le contenu métier : quantification des résultats, compétences manquantes, précision des responsabilités.
+
 
 ═══════════════════════════════════════════════════════════════════════════════
                         SECTION 1: IDENTITY LOCK [IMMUTABLE]

--- a/backend/prompts/cv_skill_extractor.txt
+++ b/backend/prompts/cv_skill_extractor.txt
@@ -47,7 +47,8 @@ You produce ONLY this JSON structure:
   "languages": [{"name": "string", "level": "string"}],
   "certifications": [],
   "experience_years": integer,
-  "seniority_level": "junior|mid|mid-senior|senior|lead"
+  "seniority_level": "junior|mid|mid-senior|senior|lead",
+  "suggested_job_titles": ["string", "string", "string"]
 }
 
 
@@ -59,6 +60,7 @@ You produce ONLY this JSON structure:
 - Categorize Soft Skills and Domain Knowledge.
 - Detect proficiency levels for languages.
 - Calculate approximate years of experience and seniority level.
+- suggested_job_titles: Based on all skills and experience level, suggest 3-4 job titles the candidate should target. Use standard job title formats (ex: "Développeur Full-Stack React/Node.js", "Data Scientist Python").
 
 🎯 SOFT SKILLS DETECTION - CRITICAL RULES:
 Look for soft skills under ANY of these section names (case-insensitive):

--- a/backend/src/agents/cv_analyzer/main_agent.py
+++ b/backend/src/agents/cv_analyzer/main_agent.py
@@ -151,6 +151,8 @@ class CVAnalyzerAgent(BaseAgent):
             improvements_result = results[2] if isinstance(results[2], dict) else {}
             job_match_result = results[3] if len(results) > 3 and isinstance(results[3], dict) else {}
             
+            recommended_titles = self._extract_recommended_titles(skills_result)
+
             # Build response (with score capping to prevent validation errors)
             return {
                 "success": True,
@@ -167,6 +169,7 @@ class CVAnalyzerAgent(BaseAgent):
                 "job_match": job_match_result if job_description else None,
                 "strengths": self._extract_strengths(ats_result, skills_result),
                 "weaknesses": self._extract_weaknesses(ats_result, improvements_result),
+                "recommended_job_titles": recommended_titles,
             }
             
         except Exception as e:
@@ -199,6 +202,13 @@ class CVAnalyzerAgent(BaseAgent):
         result = await self.improvement_advisor.run(task=f"Suggest improvements:\n\n{cv_text}")
         return self._parse_json(result) or {}
     
+    def _extract_recommended_titles(self, skills_result: dict) -> list[str]:
+        """Extraire les titres de poste recommandés depuis l'analyse des skills."""
+        titles = skills_result.get("suggested_job_titles", [])
+        if isinstance(titles, list):
+            return [str(t) for t in titles[:4] if t]
+        return []
+
     def _extract_strengths(self, ats_result: dict, skills_result: dict) -> list[str]:
         """Extract strengths from analysis."""
         strengths = []

--- a/backend/src/agents/cv_analyzer/main_agent.py
+++ b/backend/src/agents/cv_analyzer/main_agent.py
@@ -26,6 +26,8 @@ from src.models.schemas import ATSScore, CVAnalysisResponse, TrainingRecommendat
 
 logger = logging.getLogger(__name__)
 
+HUNTZEN_CV_MARKERS = ["HuntZen Jobs", "Optimisé par HuntZen", "HuntZen ATS", "huntzenjobs.com", "HuntZen ATS Certified"]
+
 
 class CVAnalyzerAgent(BaseAgent):
     """
@@ -133,8 +135,7 @@ class CVAnalyzerAgent(BaseAgent):
         """
         try:
             # Détecter si le CV vient du pipeline HuntZen
-            HUNTZEN_MARKERS = ["HuntZen Jobs", "Optimisé par HuntZen", "HuntZen ATS", "huntzenjobs.com", "HuntZen ATS Certified"]
-            is_huntzen_optimized = any(marker in cv_text for marker in HUNTZEN_MARKERS)
+            is_huntzen_optimized = bool(cv_text) and any(marker in cv_text for marker in HUNTZEN_CV_MARKERS)
 
             # Run sub-agents in parallel
             tasks = [
@@ -228,14 +229,6 @@ class CVAnalyzerAgent(BaseAgent):
             filtered["content_improvements"] = [
                 s for s in content
                 if not any(kw in str(s).lower() for kw in ats_format_keywords)
-            ]
-        missing = filtered.get("missing_sections", [])
-        if isinstance(missing, list):
-            # Les sections manquantes liées au format sont déjà gérées par HuntZen
-            ats_sections = ["résumé professionnel", "compétences", "expérience", "formation"]
-            filtered["missing_sections"] = [
-                s for s in missing
-                if not any(kw in str(s).lower() for kw in ats_sections)
             ]
         return filtered
 

--- a/backend/src/agents/cv_analyzer/main_agent.py
+++ b/backend/src/agents/cv_analyzer/main_agent.py
@@ -132,24 +132,31 @@ class CVAnalyzerAgent(BaseAgent):
             Complete analysis results
         """
         try:
+            # Détecter si le CV vient du pipeline HuntZen
+            HUNTZEN_MARKERS = ["HuntZen Jobs", "Optimisé par HuntZen", "HuntZen ATS", "huntzenjobs.com", "HuntZen ATS Certified"]
+            is_huntzen_optimized = any(marker in cv_text for marker in HUNTZEN_MARKERS)
+
             # Run sub-agents in parallel
             tasks = [
                 self._score_ats(cv_text),
                 self._extract_skills(cv_text),
                 self._get_improvements(cv_text),
             ]
-            
+
             # Add job matching if description provided
             if job_description:
                 tasks.append(self._match_job(cv_text, job_description))
-            
+
             results = await asyncio.gather(*tasks, return_exceptions=True)
-            
+
             # Process results
             ats_result = results[0] if isinstance(results[0], dict) else {}
             skills_result = results[1] if isinstance(results[1], dict) else {}
             improvements_result = results[2] if isinstance(results[2], dict) else {}
             job_match_result = results[3] if len(results) > 3 and isinstance(results[3], dict) else {}
+
+            if is_huntzen_optimized:
+                improvements_result = self._filter_improvements_for_certified_cv(improvements_result)
             
             recommended_titles = self._extract_recommended_titles(skills_result)
 
@@ -208,6 +215,29 @@ class CVAnalyzerAgent(BaseAgent):
         if isinstance(titles, list):
             return [str(t) for t in titles[:4] if t]
         return []
+
+    def _filter_improvements_for_certified_cv(self, improvements: dict) -> dict:
+        """Supprimer les suggestions de format ATS pour les CV déjà certifiés HuntZen."""
+        filtered = dict(improvements)
+        ats_format_keywords = [
+            "section", "en-tête", "header", "format", "police", "font",
+            "structure", "template", "mise en page", "layout"
+        ]
+        content = filtered.get("content_improvements", [])
+        if isinstance(content, list):
+            filtered["content_improvements"] = [
+                s for s in content
+                if not any(kw in str(s).lower() for kw in ats_format_keywords)
+            ]
+        missing = filtered.get("missing_sections", [])
+        if isinstance(missing, list):
+            # Les sections manquantes liées au format sont déjà gérées par HuntZen
+            ats_sections = ["résumé professionnel", "compétences", "expérience", "formation"]
+            filtered["missing_sections"] = [
+                s for s in missing
+                if not any(kw in str(s).lower() for kw in ats_sections)
+            ]
+        return filtered
 
     def _extract_strengths(self, ats_result: dict, skills_result: dict) -> list[str]:
         """Extract strengths from analysis."""

--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -38,6 +38,7 @@ from src.api.routes.queue import router as queue_router
 from src.api.routes.presence import presence_router, tracking_router, banner_router
 from src.api.routes.stress import router as stress_router
 from src.api.routes.suggestions import router as suggestions_router
+from src.api.routes.public_plans import router as public_plans_router
 
 router = APIRouter()
 
@@ -76,3 +77,4 @@ router.include_router(tracking_router, prefix="/api/track", tags=["Tracking"])
 router.include_router(banner_router, tags=["Banner & Maintenance"])
 router.include_router(stress_router, prefix="/api/admin/stress", tags=["Stress Testing"])
 router.include_router(suggestions_router, prefix="/api/assistant", tags=["Assistant Suggestions"])
+router.include_router(public_plans_router, prefix="/api/public", tags=["Public Plans"])

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -551,6 +551,7 @@ async def update_plan_limits(
             from src.utils.cache import get_redis
             redis = await get_redis()
             if redis:
+                await redis.delete("plans_config")
                 keys = [k async for k in redis.scan_iter("auth_me:*")]
                 if keys:
                     await redis.delete(*keys)
@@ -612,6 +613,7 @@ async def update_plan_features(
             from src.utils.cache import get_redis
             redis = await get_redis()
             if redis:
+                await redis.delete("plans_config")
                 keys = [k async for k in redis.scan_iter("auth_me:*")]
                 if keys:
                     await redis.delete(*keys)
@@ -631,6 +633,60 @@ async def update_plan_features(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail="Failed to update features")
+
+
+@router.patch("/plans/{plan_id}/wording")
+async def update_plan_wording(
+    plan_id: str,
+    body: Dict[str, Any],
+    admin: AdminUserDep,
+) -> Dict[str, Any]:
+    """Update display_name and/or description for a plan (admin only)."""
+    supabase = get_supabase_client()
+
+    update_data: Dict[str, Any] = {}
+    if "display_name" in body and isinstance(body["display_name"], str):
+        update_data["display_name"] = body["display_name"].strip()
+    if "description" in body and isinstance(body["description"], str):
+        update_data["description"] = body["description"].strip()
+
+    if not update_data:
+        raise HTTPException(status_code=400, detail="display_name ou description requis")
+
+    update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
+
+    try:
+        current = supabase.table("subscription_plans").select("name").eq("id", plan_id).single().execute()
+        if not current.data:
+            raise HTTPException(status_code=404, detail="Plan not found")
+
+        supabase.table("subscription_plans").update(update_data).eq("id", plan_id).execute()
+
+        # Invalider cache public plans_config
+        try:
+            from src.utils.cache import get_redis
+            redis = await get_redis()
+            if redis:
+                await redis.delete("plans_config")
+                # Invalider aussi auth_me car plan_display_name change
+                keys = [k async for k in redis.scan_iter("auth_me:*")]
+                if keys:
+                    await redis.delete(*keys)
+        except Exception:
+            pass
+
+        _log_admin_action(supabase, admin["id"], "admin.plan_wording_updated", None, {
+            "plan_id": plan_id,
+            "plan_name": current.data["name"],
+            "changes": update_data,
+        })
+
+        return {"success": True, **update_data}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Failed to update wording")
 
 
 @router.patch("/plans/{plan_id}/price")
@@ -659,6 +715,15 @@ async def update_plan_display_price(
             raise HTTPException(status_code=404, detail="Plan not found")
 
         result = supabase.table("subscription_plans").update(update_data).eq("id", plan_id).execute()
+
+        # Invalider cache public plans_config
+        try:
+            from src.utils.cache import get_redis
+            redis = await get_redis()
+            if redis:
+                await redis.delete("plans_config")
+        except Exception:
+            pass
 
         _log_admin_action(supabase, admin["id"], "admin.plan_price_display_updated", None, {
             "plan_id": plan_id, "plan_name": current.data["name"], "changes": update_data

--- a/backend/src/api/routes/public_plans.py
+++ b/backend/src/api/routes/public_plans.py
@@ -1,0 +1,57 @@
+"""
+Public Plans API — no authentication required.
+Returns active subscription plans for pricing pages and frontend hooks.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List
+
+from fastapi import APIRouter
+
+from src.db.supabase_client import get_supabase_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+PLANS_CACHE_KEY = "plans_config"
+PLANS_CACHE_TTL = 300  # 5 minutes
+
+
+@router.get("/plans")
+async def get_public_plans() -> List[Dict[str, Any]]:
+    """
+    Returns all active subscription plans with display info.
+    Used by pricing pages and modals — no auth required.
+    Cached in Redis for 5 minutes.
+    Invalidated by any admin PATCH on plans (limits, features, price, wording).
+    """
+    # Try Redis cache first
+    try:
+        from src.utils.cache import get_redis
+        redis = await get_redis()
+        if redis:
+            cached = await redis.get(PLANS_CACHE_KEY)
+            if cached:
+                return json.loads(cached)
+    except Exception:
+        pass
+
+    supabase = get_supabase_client()
+    result = supabase.table("subscription_plans").select(
+        "id, name, display_name, description, price_monthly, price_yearly, features, sort_order, is_active"
+    ).eq("is_active", True).order("sort_order").execute()
+
+    plans = result.data or []
+
+    # Cache in Redis
+    try:
+        from src.utils.cache import get_redis
+        redis = await get_redis()
+        if redis:
+            await redis.setex(PLANS_CACHE_KEY, PLANS_CACHE_TTL, json.dumps(plans))
+    except Exception:
+        pass
+
+    return plans

--- a/backend/src/api/routes/recruiter_finder.py
+++ b/backend/src/api/routes/recruiter_finder.py
@@ -5,16 +5,95 @@ Expose Hunter.io contact discovery via a single POST endpoint.
 """
 
 import logging
+import os
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Header, status
 from pydantic import BaseModel
+from supabase import create_client, Client
 
 from src.services.recruiter_finder.hunter import find_recruiters_for_job
+from src.api.deps import get_user_id_from_token
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# ============================================================================
+# Supabase client for quota management
+# ============================================================================
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase_client: Optional[Client] = create_client(SUPABASE_URL, SUPABASE_KEY)
+else:
+    supabase_client = None
+    logger.warning("Supabase not configured for quota management (recruiter_finder)")
+
+
+# ============================================================================
+# Quota helpers
+# ============================================================================
+
+
+def check_recruiter_search_quota(user_id: str) -> None:
+    """
+    Vérifie le quota recruiter_search de l'utilisateur.
+    Lève HTTP 429 si le quota est dépassé.
+    """
+    if not supabase_client:
+        return  # Dev mode — pas de Supabase configuré
+    try:
+        result = supabase_client.rpc("get_quota_status", {"p_user_id": user_id}).execute()
+        if not result.data:
+            return
+        for row in result.data:
+            if row.get("feature") == "recruiter_search":
+                if not row.get("has_access", True):
+                    raise HTTPException(
+                        status_code=429,
+                        detail={
+                            "code": "QUOTA_EXCEEDED",
+                            "feature": "recruiter_search",
+                            "limit": row.get("quota_limit"),
+                            "used": row.get("quota_used"),
+                            "reset_at": str(row.get("reset_at", "")),
+                            "message": "Quota de recherche recruteur atteint (3/jour en version gratuite). Passez à Pro pour un accès illimité.",
+                        }
+                    )
+                return
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"[quota] recruiter_search check failed for {user_id}, allowing through: {e}")
+
+
+def increment_recruiter_search_quota(user_id: str) -> bool:
+    """
+    Incrémente le quota recruiter_search de l'utilisateur via Supabase RPC.
+    """
+    if not supabase_client:
+        return False
+    try:
+        response = supabase_client.rpc(
+            "increment_usage",
+            {
+                "p_user_id": user_id,
+                "p_feature": "recruiter_search",
+                "p_amount": 1,
+            }
+        ).execute()
+        success = bool(response.data) if response.data else False
+        if success:
+            logger.info(f"[quota] Incremented recruiter_search quota for user {user_id}")
+        else:
+            logger.warning(f"[quota] Failed to increment recruiter_search quota for user {user_id}")
+        return success
+    except Exception as e:
+        logger.error(f"[quota] Error incrementing recruiter_search quota for {user_id}: {e}")
+        return False
 
 
 # ============================================================================
@@ -56,18 +135,34 @@ class RecruiterFinderResponse(BaseModel):
 
 
 @router.post("/find", response_model=RecruiterFinderResponse)
-async def find_recruiters(body: RecruiterFinderRequest):
+async def find_recruiters(
+    body: RecruiterFinderRequest,
+    authorization: Optional[str] = Header(default=None),
+):
     """
     Discover recruiter contacts at a company using Hunter.io.
 
     Returns HR/recruiter contacts, tech team members, and the email pattern
     for the company domain.
+
+    Requires authentication. Subject to daily quota (3/day on free plan).
     """
+    # Auth
+    user_id = get_user_id_from_token(authorization)
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required to search for recruiter contacts",
+        )
+
     if not body.company_name or not body.company_name.strip():
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="company_name is required",
         )
+
+    # Quota check — bloque si limite journalière dépassée
+    check_recruiter_search_quota(user_id)
 
     try:
         result = await find_recruiters_for_job(
@@ -76,7 +171,11 @@ async def find_recruiters(body: RecruiterFinderRequest):
             company_website=body.company_website or "",
             job_title=body.job_title or "",
         )
+        # Incrémenter le quota après succès
+        increment_recruiter_search_quota(user_id)
         return result
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"[RecruiterFinder] Unexpected error: {e}")
         raise HTTPException(

--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -230,7 +230,7 @@ async def get_boost_status(current_user: CurrentUserDep):
 
     return {
         "referral_code": referral_code,
-        "referral_link": f"{APP_URL}/ref/{referral_code}",
+        "referral_link": f"{APP_URL}/?ref={referral_code}",
         "total_clicks": stats.get("total_clicks", 0),
         "total_signups": stats.get("total_signups", 0),
         "total_validated": total_validated,

--- a/backend/templates/cv_pdf/cv_ats.html
+++ b/backend/templates/cv_pdf/cv_ats.html
@@ -227,6 +227,9 @@
     letter-spacing: 0.02em;
   }
 </style>
+{% if cv.huntzen_certified %}
+<meta name="generator" content="HuntZen Jobs ATS Optimizer">
+{% endif %}
 </head>
 <body>
 
@@ -397,7 +400,10 @@
 {% endif %}
 
 {% if cv.huntzen_certified %}
+<!-- Texte visible discret -->
 <div class="hz-certified-footer">Optimisé par HuntZen Jobs · ATS Certified</div>
+<!-- Texte invisible pour extraction fiable par les parsers PDF (hors écran, dans le flux DOM) -->
+<span style="font-size:1pt;color:white;position:absolute;left:-9999px;">HuntZen ATS Certified huntzenjobs.com Optimisé par HuntZen</span>
 {% endif %}
 
 </body>

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -77,6 +77,15 @@ import {
   type AdvancedFilters,
 } from "@/components/jobs/advanced-filters-modal";
 import { useConversionPopup } from "@/components/freemium/conversion-popups";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { RecruiterEmailFinder } from "@/components/recruiter/recruiter-email-finder";
+import { UserSearch } from "lucide-react";
 
 // ─── Fuzzy location helpers ───────────────────────────────────────────────────
 
@@ -2135,6 +2144,29 @@ export default function JobsPage() {
                           <ExternalLink className="ml-2 h-4 w-4" />
                         </Button>
                       </div>
+
+                      {/* Recruiter email finder */}
+                      <Sheet>
+                        <SheetTrigger asChild>
+                          <button className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+                            <UserSearch className="w-3.5 h-3.5" />
+                            Trouver les recruteurs
+                            <span className="px-1 py-0.5 bg-orange-100 text-orange-700 text-[10px] font-semibold rounded">
+                              BÊTA
+                            </span>
+                          </button>
+                        </SheetTrigger>
+                        <SheetContent>
+                          <SheetHeader>
+                            <SheetTitle>Trouver les recruteurs</SheetTitle>
+                          </SheetHeader>
+                          <div className="mt-4">
+                            <RecruiterEmailFinder
+                              companyName={job.company || ""}
+                            />
+                          </div>
+                        </SheetContent>
+                      </Sheet>
                     </CardContent>
                   </Card>
                 </motion.div>

--- a/frontend-next/src/app/(dashboard)/referral/page.tsx
+++ b/frontend-next/src/app/(dashboard)/referral/page.tsx
@@ -42,7 +42,10 @@ export default function ReferralPage() {
   const [copied, setCopied] = useState(false);
 
   const fetchStatus = useCallback(async () => {
-    if (!session?.access_token) return;
+    if (!session?.access_token) {
+      setIsLoading(false);
+      return;
+    }
     try {
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/referrals/boost-status`,
@@ -84,7 +87,7 @@ export default function ReferralPage() {
       </div>
     );
   }
-  if (!status && !isLoading) {
+  if (!status) {
     return (
       <div className="max-w-2xl mx-auto px-4 py-12 text-center">
         <p className="text-muted-foreground mb-4">
@@ -119,7 +122,7 @@ export default function ReferralPage() {
         <p className="text-sm font-semibold mb-3">Ton lien de parrainage</p>
         <div className="flex gap-2">
           <div className="flex-1 text-xs font-mono bg-muted rounded-lg px-3 py-2.5 truncate text-muted-foreground">
-            {status.referral_link}
+            {status?.referral_link}
           </div>
           <button
             onClick={handleCopy}
@@ -150,6 +153,7 @@ export default function ReferralPage() {
               window.open(
                 `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(status.referral_link)}`,
                 "_blank",
+                "noopener,noreferrer",
               );
             }}
             className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#0A66C2] text-white text-sm font-medium hover:bg-[#004182] transition-colors"

--- a/frontend-next/src/app/(dashboard)/referral/page.tsx
+++ b/frontend-next/src/app/(dashboard)/referral/page.tsx
@@ -8,12 +8,31 @@ import { ReferralFriendsList } from "@/components/referral/referral-friends-list
 import { cn } from "@/lib/utils";
 
 interface BoostStatus {
-  referral_code: string; referral_link: string; total_clicks: number;
-  total_signups: number; total_validated: number; current_tier: number;
-  next_tier: number | null; friends_to_next: number;
-  tiers: Array<{ friends: number; reward_type: string; label: string; days?: number; plan?: string; discount_percent?: number; }>;
-  rewards_earned: Array<{ reward_type: string; reward_value: Record<string, unknown>; applied_at: string; }>;
-  recent_referrals: Array<{ status: "validated" | "registered"; created_at: string; }>;
+  referral_code: string;
+  referral_link: string;
+  total_clicks: number;
+  total_signups: number;
+  total_validated: number;
+  current_tier: number;
+  next_tier: number | null;
+  friends_to_next: number;
+  tiers: Array<{
+    friends: number;
+    reward_type: string;
+    label: string;
+    days?: number;
+    plan?: string;
+    discount_percent?: number;
+  }>;
+  rewards_earned: Array<{
+    reward_type: string;
+    reward_value: Record<string, unknown>;
+    applied_at: string;
+  }>;
+  recent_referrals: Array<{
+    status: "validated" | "registered";
+    created_at: string;
+  }>;
 }
 
 export default function ReferralPage() {
@@ -25,14 +44,21 @@ export default function ReferralPage() {
   const fetchStatus = useCallback(async () => {
     if (!session?.access_token) return;
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/referrals/boost-status`, {
-        headers: { Authorization: `Bearer ${session.access_token}` },
-      });
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/referrals/boost-status`,
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        },
+      );
       if (res.ok) setStatus(await res.json());
-    } finally { setIsLoading(false); }
+    } finally {
+      setIsLoading(false);
+    }
   }, [session?.access_token]);
 
-  useEffect(() => { fetchStatus(); }, [fetchStatus]);
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
 
   const handleCopy = async () => {
     if (!status?.referral_link) return;
@@ -43,38 +69,107 @@ export default function ReferralPage() {
 
   const handleWhatsApp = () => {
     if (!status?.referral_link) return;
-    window.open(`https://wa.me/?text=${encodeURIComponent(`Rejoins HuntZen et trouve ton prochain job plus vite ! ${status.referral_link}`)}`, "_blank");
+    window.open(
+      `https://wa.me/?text=${encodeURIComponent(`Rejoins HuntZen et trouve ton prochain job plus vite ! ${status.referral_link}`)}`,
+      "_blank",
+    );
   };
 
   if (isLoading) {
-    return <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">{[...Array(4)].map((_, i) => <div key={i} className="h-24 rounded-xl bg-gray-100 animate-pulse" />)}</div>;
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-24 rounded-xl bg-gray-100 animate-pulse" />
+        ))}
+      </div>
+    );
   }
-  if (!status) return null;
+  if (!status && !isLoading) {
+    return (
+      <div className="max-w-2xl mx-auto px-4 py-12 text-center">
+        <p className="text-muted-foreground mb-4">
+          Impossible de charger vos données de parrainage.
+        </p>
+        <button
+          onClick={fetchStatus}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          Réessayer
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
       <div className="text-center py-6 px-4 rounded-2xl bg-gradient-to-br from-blue-600/5 to-teal-500/10 border">
-        <div className="inline-flex p-3 rounded-full bg-blue-600/10 mb-3"><Gift className="w-6 h-6 text-blue-600" /></div>
+        <div className="inline-flex p-3 rounded-full bg-blue-600/10 mb-3">
+          <Gift className="w-6 h-6 text-blue-600" />
+        </div>
         <h1 className="text-2xl font-bold mb-1">HuntZen Boost</h1>
-        <p className="text-sm text-muted-foreground">Invitez. Débloquez. Progressez.</p>
-        <p className="text-xs text-muted-foreground mt-1">Parrainez des amis et débloquez des récompenses exclusives.</p>
+        <p className="text-sm text-muted-foreground">
+          Invitez. Débloquez. Progressez.
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Parrainez des amis et débloquez des récompenses exclusives.
+        </p>
       </div>
 
       <div className="rounded-xl border bg-card p-5">
         <p className="text-sm font-semibold mb-3">Ton lien de parrainage</p>
         <div className="flex gap-2">
-          <div className="flex-1 text-xs font-mono bg-muted rounded-lg px-3 py-2.5 truncate text-muted-foreground">{status.referral_link}</div>
-          <button onClick={handleCopy} className={cn("px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5", copied ? "bg-green-100 text-green-700" : "bg-blue-600 text-white hover:bg-blue-700")}>
-            {copied ? <CheckCircle className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+          <div className="flex-1 text-xs font-mono bg-muted rounded-lg px-3 py-2.5 truncate text-muted-foreground">
+            {status.referral_link}
+          </div>
+          <button
+            onClick={handleCopy}
+            className={cn(
+              "px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5",
+              copied
+                ? "bg-green-100 text-green-700"
+                : "bg-blue-600 text-white hover:bg-blue-700",
+            )}
+          >
+            {copied ? (
+              <CheckCircle className="w-4 h-4" />
+            ) : (
+              <Copy className="w-4 h-4" />
+            )}
             {copied ? "Copié !" : "Copier"}
           </button>
-          <button onClick={handleWhatsApp} className="px-3 py-2 rounded-lg bg-green-500 hover:bg-green-600 text-white text-sm font-medium transition-colors flex items-center gap-1.5">
-            <Share2 className="w-4 h-4" />WhatsApp
+          <button
+            onClick={handleWhatsApp}
+            className="px-3 py-2 rounded-lg bg-green-500 hover:bg-green-600 text-white text-sm font-medium transition-colors flex items-center gap-1.5"
+          >
+            <Share2 className="w-4 h-4" />
+            WhatsApp
+          </button>
+          <button
+            onClick={() => {
+              if (!status?.referral_link) return;
+              window.open(
+                `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(status.referral_link)}`,
+                "_blank",
+              );
+            }}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#0A66C2] text-white text-sm font-medium hover:bg-[#004182] transition-colors"
+          >
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+            </svg>
+            LinkedIn
           </button>
         </div>
         <div className="grid grid-cols-3 gap-3 mt-4">
-          {[{ label: "Clics", value: status.total_clicks }, { label: "Inscrits", value: status.total_signups }, { label: "Validés", value: status.total_validated }].map((s) => (
-            <div key={s.label} className="text-center p-2 rounded-lg bg-muted/50">
+          {[
+            { label: "Clics", value: status.total_clicks },
+            { label: "Inscrits", value: status.total_signups },
+            { label: "Validés", value: status.total_validated },
+          ].map((s) => (
+            <div
+              key={s.label}
+              className="text-center p-2 rounded-lg bg-muted/50"
+            >
               <p className="text-xl font-bold">{s.value}</p>
               <p className="text-xs text-muted-foreground">{s.label}</p>
             </div>
@@ -84,14 +179,26 @@ export default function ReferralPage() {
 
       <div className="rounded-xl border bg-card p-5">
         <p className="text-sm font-semibold mb-4">Ta progression</p>
-        <ReferralProgressBar totalValidated={status.total_validated} currentTier={status.current_tier} nextTier={status.next_tier} friendsToNext={status.friends_to_next} tiers={status.tiers} />
+        <ReferralProgressBar
+          totalValidated={status.total_validated}
+          currentTier={status.current_tier}
+          nextTier={status.next_tier}
+          friendsToNext={status.friends_to_next}
+          tiers={status.tiers}
+        />
       </div>
 
       <div>
         <p className="text-sm font-semibold mb-3">Récompenses</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {status.tiers.map((tier, i) => (
-            <ReferralTierCard key={i} tier={tier} index={i} isUnlocked={status.total_validated >= tier.friends} isCurrent={i === status.current_tier} />
+            <ReferralTierCard
+              key={i}
+              tier={tier}
+              index={i}
+              isUnlocked={status.total_validated >= tier.friends}
+              isCurrent={i === status.current_tier}
+            />
           ))}
         </div>
       </div>

--- a/frontend-next/src/app/admin/plans/page.tsx
+++ b/frontend-next/src/app/admin/plans/page.tsx
@@ -11,6 +11,7 @@ export default function AdminPlansPage() {
     updateLimits,
     updateFeatures,
     updateDisplayPrice,
+    updateWording,
     updateStripePrice,
     loading,
   } = useAdminPlans();
@@ -73,6 +74,11 @@ export default function AdminPlansPage() {
                 );
                 if (result) refresh();
                 return result;
+              }}
+              onUpdateWording={async (id, wording) => {
+                const ok = await updateWording(id, wording);
+                if (ok) refresh();
+                return ok;
               }}
             />
           ))}

--- a/frontend-next/src/app/page.tsx
+++ b/frontend-next/src/app/page.tsx
@@ -33,7 +33,7 @@ export default function HomePage() {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const ref = params.get("ref");
-    if (ref) {
+    if (ref && /^[a-zA-Z0-9_-]{3,32}$/.test(ref)) {
       document.cookie = `huntzen_referral_code=${ref}; path=/; max-age=604800; SameSite=Lax`;
     }
   }, []);

--- a/frontend-next/src/app/page.tsx
+++ b/frontend-next/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
@@ -29,6 +29,15 @@ export default function HomePage() {
   const tPricing = useTranslations("pricing");
   const tPlans = useTranslations("pricingPlans");
   const tFooter = useTranslations("footer");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const ref = params.get("ref");
+    if (ref) {
+      document.cookie = `huntzen_referral_code=${ref}; path=/; max-age=604800; SameSite=Lax`;
+    }
+  }, []);
+
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
       <LandingHeader />

--- a/frontend-next/src/app/pricing/page.tsx
+++ b/frontend-next/src/app/pricing/page.tsx
@@ -34,81 +34,56 @@ import { useSubscriptionApi } from "@/hooks/use-subscription-api";
 import { toast } from "sonner";
 import { useConversionPopup } from "@/components/freemium/conversion-popups";
 import { useTranslations } from "next-intl";
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
-const plans = [
-  {
-    id: "free",
-    name: "Gratuit",
-    priceMonthly: "0",
-    priceYearly: "0",
-    tagline: "Pour découvrir",
-    description: "Testez gratuitement les fonctionnalités essentielles",
-    icon: Gift,
-    color: "#9CA3AF",
-    features: [
-      { icon: Search, name: "3 recherches d'offres par jour" },
-      { icon: FileText, name: "1 analyse de CV par jour" },
-      { icon: MessageSquare, name: "5 minutes de coaching personnel" },
-      { icon: Shield, name: "Support standard" },
-    ],
-  },
-  {
-    id: "starter",
-    name: "Essentiel",
-    priceMonthly: "8,90",
-    priceYearly: "85,00",
-    tagline: "Le plus choisi",
-    description: "Idéal pour démarrer votre recherche efficacement",
-    icon: Zap,
-    color: "#00D9FF",
-    popular: true,
-    features: [
-      { icon: Search, name: "Recherches d'offres illimitées" },
-      { icon: Target, name: "Filtres avancés de recherche" },
-      { icon: Briefcase, name: "Gestion de vos favoris" },
-      { icon: FileText, name: "Analyses de CV illimitées" },
-      { icon: Award, name: "Score de compatibilité détaillé" },
-      { icon: MessageSquare, name: "Coaching personnalisé (30 min/jour)" },
-    ],
-  },
-  {
-    id: "pro",
-    name: "Pro",
-    priceMonthly: "13,90",
-    priceYearly: "133,00",
-    tagline: "Le plus complet",
-    description: "Pour les professionnels exigeants en recherche active",
-    icon: Sparkles,
-    color: "#9333EA",
-    features: [
-      { icon: Check, name: "Toutes les fonctionnalités Essentiel" },
-      { icon: MessageSquare, name: "Coaching disponible 24/7 illimité" },
-      { icon: FileText, name: "Export PDF professionnel" },
-      { icon: Users, name: "Simulations d'entretien réalistes" },
-      { icon: TrendingUp, name: "Feedback détaillé sur performances" },
-      { icon: Shield, name: "Support prioritaire par email" },
-    ],
-  },
-  {
-    id: "premium",
-    name: "Premium",
-    priceMonthly: "19,90",
-    priceYearly: "191,00",
-    tagline: "L'excellence",
-    description: "L'expérience ultime pour maximiser vos chances",
-    icon: Crown,
-    color: "#F97316",
-    features: [
-      { icon: Check, name: "Toutes les fonctionnalités Pro" },
-      { icon: Calendar, name: "Historique illimité de vos analyses" },
-      { icon: Target, name: "Conseils personnalisés ultra-ciblés" },
-      { icon: Sparkles, name: "Alertes email instantanées" },
-      { icon: Award, name: "Accès anticipé nouvelles fonctionnalités" },
-      { icon: Crown, name: "Support VIP prioritaire" },
-      { icon: TrendingUp, name: "Rapports mensuels de progression" },
-    ],
-  },
-];
+// Icon mapping — décoratives, statiques
+const PLAN_ICONS: Record<string, React.ElementType> = {
+  free: Gift,
+  starter: Zap,
+  pro: Sparkles,
+  premium: Crown,
+};
+const PLAN_COLORS: Record<string, string> = {
+  free: "#9CA3AF",
+  starter: "#00D9FF",
+  pro: "#9333EA",
+  premium: "#F97316",
+};
+
+// Fallback features si API indisponible
+const FALLBACK_FEATURES: Record<string, string[]> = {
+  free: [
+    "3 recherches d'offres par jour",
+    "1 analyse de CV par jour",
+    "5 minutes de coaching personnel",
+    "Support standard",
+  ],
+  starter: [
+    "Recherches d'offres illimitées",
+    "Filtres avancés de recherche",
+    "Gestion de vos favoris",
+    "Analyses de CV illimitées",
+    "Score de compatibilité détaillé",
+    "Coaching personnalisé (30 min/jour)",
+  ],
+  pro: [
+    "Toutes les fonctionnalités Essentiel",
+    "Coaching disponible 24/7 illimité",
+    "Export PDF professionnel",
+    "Simulations d'entretien réalistes",
+    "Feedback détaillé sur performances",
+    "Support prioritaire par email",
+  ],
+  premium: [
+    "Toutes les fonctionnalités Pro",
+    "Historique illimité de vos analyses",
+    "Conseils personnalisés ultra-ciblés",
+    "Alertes email instantanées",
+    "Accès anticipé nouvelles fonctionnalités",
+    "Support VIP prioritaire",
+    "Rapports mensuels de progression",
+  ],
+};
 
 const testimonials = [
   {
@@ -181,7 +156,30 @@ export default function PricingPage() {
   const apiData = useSubscriptionApi();
   const t = useTranslations("pricing");
 
+  const { getPlan, formatPrice, isLoading: plansLoading } = usePlansConfig();
+
   const pricingHoverPopup = useConversionPopup("pricing_hover");
+
+  const plans = plansLoading
+    ? []
+    : (["free", "starter", "pro", "premium"] as const).map((id) => {
+        const p = getPlan(id);
+        const featureNames = p?.features ?? FALLBACK_FEATURES[id] ?? [];
+        return {
+          id,
+          name: p?.display_name ?? FALLBACK_FEATURES[id]?.[0] ?? id,
+          priceMonthly: formatPrice(p?.price_monthly ?? 0),
+          priceYearly: formatPrice(p?.price_yearly ?? 0),
+          priceMonthlyRaw: p?.price_monthly ?? 0,
+          priceYearlyRaw: p?.price_yearly ?? 0,
+          tagline: p?.description ?? "",
+          description: p?.description ?? "",
+          icon: PLAN_ICONS[id] ?? Gift,
+          color: PLAN_COLORS[id] ?? "#9CA3AF",
+          popular: id === "starter",
+          features: featureNames.map((name: string) => ({ icon: Check, name })),
+        };
+      });
 
   // Show pricing_hover popup after 20s (once per session)
   useEffect(() => {
@@ -204,16 +202,18 @@ export default function PricingPage() {
     return billingPeriod === "monthly" ? plan.priceMonthly : plan.priceYearly;
   };
 
-  const getMonthlyEquivalent = (yearlyPrice: string) => {
-    return (parseFloat(yearlyPrice) / 12).toFixed(2);
+  const getMonthlyEquivalent = (yearlyRaw: number) => {
+    if (!yearlyRaw) return "0,00";
+    return (yearlyRaw / 12).toFixed(2).replace(".", ",");
   };
 
-  const getSavings = (monthlyPrice: string, yearlyPrice: string) => {
-    const monthlyCost = parseFloat(monthlyPrice) * 12;
-    const yearlyCost = parseFloat(yearlyPrice);
+  const getSavings = (monthlyRaw: number, yearlyRaw: number) => {
+    const monthlyCost = monthlyRaw * 12;
+    const yearlyCost = yearlyRaw;
     const savings = monthlyCost - yearlyCost;
-    const percentage = Math.round((savings / monthlyCost) * 100);
-    return { amount: savings.toFixed(2), percentage };
+    const percentage =
+      monthlyCost > 0 ? Math.round((savings / monthlyCost) * 100) : 0;
+    return { amount: savings.toFixed(2).replace(".", ","), percentage };
   };
 
   const handleSelectPlan = async (planId: string) => {
@@ -428,6 +428,16 @@ export default function PricingPage() {
         {/* Pricing Cards */}
         <section className="py-12 sm:py-16 bg-white dark:bg-gray-900">
           <div className="container mx-auto px-4 sm:px-6">
+            {plansLoading && (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 sm:gap-8 max-w-7xl mx-auto">
+                {[1, 2, 3, 4].map((i) => (
+                  <div
+                    key={i}
+                    className="h-96 bg-gray-100 dark:bg-gray-700 rounded-3xl animate-pulse"
+                  />
+                ))}
+              </div>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 sm:gap-8 max-w-7xl mx-auto">
               {plans.map((plan, index) => (
                 <motion.div
@@ -482,13 +492,17 @@ export default function PricingPage() {
                         <span className="inline-block px-3 py-1 bg-green-100 text-green-700 text-xs font-bold rounded-full">
                           -
                           {
-                            getSavings(plan.priceMonthly, plan.priceYearly)
-                              .percentage
+                            getSavings(
+                              plan.priceMonthlyRaw,
+                              plan.priceYearlyRaw,
+                            ).percentage
                           }
                           % soit{" "}
                           {
-                            getSavings(plan.priceMonthly, plan.priceYearly)
-                              .amount
+                            getSavings(
+                              plan.priceMonthlyRaw,
+                              plan.priceYearlyRaw,
+                            ).amount
                           }
                           €/an
                         </span>
@@ -504,7 +518,7 @@ export default function PricingPage() {
                           <span className="text-4xl sm:text-5xl font-black text-gray-900 dark:text-white">
                             {billingPeriod === "monthly"
                               ? plan.priceMonthly
-                              : getMonthlyEquivalent(plan.priceYearly)}
+                              : getMonthlyEquivalent(plan.priceYearlyRaw)}
                             €
                           </span>
                           <span className="text-lg text-gray-600 dark:text-gray-300 font-semibold">

--- a/frontend-next/src/components/admin/plans/plan-card-editor.tsx
+++ b/frontend-next/src/components/admin/plans/plan-card-editor.tsx
@@ -53,6 +53,10 @@ interface Props {
     amount: number,
     currency: string,
   ) => Promise<any>;
+  onUpdateWording: (
+    planId: string,
+    wording: { display_name?: string; description?: string },
+  ) => Promise<boolean>;
 }
 
 export default function PlanCardEditor({
@@ -61,6 +65,7 @@ export default function PlanCardEditor({
   onUpdateFeatures,
   onUpdatePrice,
   onUpdateStripePrice,
+  onUpdateWording,
 }: Props) {
   const [limits, setLimits] = useState({
     cv_analyses: plan.limits?.cv_analyses ?? 0,
@@ -78,6 +83,8 @@ export default function PlanCardEditor({
       (key) => (plan.feature_flags || {})[`has_${key}`] === true,
     ),
   );
+  const [displayName, setDisplayName] = useState(plan.display_name || "");
+  const [description, setDescription] = useState(plan.description || "");
   const [stripePriceOpen, setStripePriceOpen] = useState<
     "monthly" | "yearly" | null
   >(null);
@@ -104,6 +111,12 @@ export default function PlanCardEditor({
       featureFlags[`has_${key}`] = features.includes(key);
     }
     await onUpdateFeatures(plan.id, featureFlags);
+    setSaving(null);
+  };
+
+  const handleSaveWording = async () => {
+    setSaving("wording");
+    await onUpdateWording(plan.id, { display_name: displayName, description });
     setSaving(null);
   };
 
@@ -144,7 +157,7 @@ export default function PlanCardEditor({
 
         <CardContent>
           <div
-            className={`grid grid-cols-1 gap-6 lg:gap-0 lg:divide-x lg:divide-border ${plan.name !== "free" ? "lg:grid-cols-4" : "lg:grid-cols-3"}`}
+            className={`grid grid-cols-1 gap-6 lg:gap-0 lg:divide-x lg:divide-border ${plan.name !== "free" ? "lg:grid-cols-5" : "lg:grid-cols-4"}`}
           >
             {/* — Section 1: Limites numériques — */}
             <div className="space-y-3 lg:pr-6">
@@ -314,7 +327,44 @@ export default function PlanCardEditor({
               </Button>
             </div>
 
-            {/* — Section 4: Stripe Price IDs (plans payants uniquement) — */}
+            {/* — Section 4: Wording — */}
+            <div className="space-y-3 lg:px-6">
+              <span className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                Wording
+              </span>
+              <div className="space-y-2 mt-2">
+                <div className="space-y-1">
+                  <Label className="text-xs">Nom affiché</Label>
+                  <Input
+                    className="h-8 text-sm"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder="Ex: Starter"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">Description courte</Label>
+                  <Input
+                    className="h-8 text-sm"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Ex: Le plus choisi"
+                  />
+                </div>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleSaveWording}
+                disabled={saving === "wording"}
+                className="w-full"
+              >
+                <Save className="h-3.5 w-3.5 mr-1.5" />
+                {saving === "wording" ? "Sauvegarde..." : "Sauvegarder"}
+              </Button>
+            </div>
+
+            {/* — Section 5: Stripe Price IDs (plans payants uniquement) — */}
             {plan.name !== "free" && (
               <div className="space-y-3 lg:pl-6">
                 <span className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">

--- a/frontend-next/src/components/cv/cv-upload-async-wizard.tsx
+++ b/frontend-next/src/components/cv/cv-upload-async-wizard.tsx
@@ -1485,6 +1485,27 @@ export function CVUploadAsyncWizard({
             </div>
           )}
 
+          {/* Postes recommandés */}
+          {displayResult.suggested_job_titles &&
+            displayResult.suggested_job_titles.length > 0 && (
+              <div className="mt-6 space-y-3">
+                <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest">
+                  Postes recommandés pour votre profil
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {displayResult.suggested_job_titles.map((title: string) => (
+                    <a
+                      key={title}
+                      href={`/jobs?q=${encodeURIComponent(title)}`}
+                      className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full border border-blue-200 hover:bg-blue-100 transition-colors"
+                    >
+                      {title} →
+                    </a>
+                  ))}
+                </div>
+              </div>
+            )}
+
           {/* Smart CTAs — "Et maintenant ?" */}
           <div className="mt-8 border-t border-gray-100 pt-6">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest mb-4">
@@ -1522,10 +1543,15 @@ export function CVUploadAsyncWizard({
 
               {/* CTA 2 : Offres recommandées */}
               {(() => {
+                const suggestedTitles: string[] =
+                  displayResult.suggested_job_titles || [];
                 const topSkills: string[] = (
                   displayResult.keywords_found || []
                 ).slice(0, 3);
-                const query = topSkills.join(" ");
+                const query =
+                  suggestedTitles.length > 0
+                    ? suggestedTitles[0]
+                    : topSkills.join(" ");
                 return (
                   <a
                     href={`/jobs${query ? `?q=${encodeURIComponent(query)}` : ""}`}
@@ -1537,7 +1563,9 @@ export function CVUploadAsyncWizard({
                         Offres recommandées
                       </p>
                       <p className="text-xs text-gray-500 mt-0.5">
-                        Trouver des offres qui correspondent à ce profil
+                        {suggestedTitles.length > 0
+                          ? suggestedTitles[0]
+                          : "Trouver des offres qui correspondent à ce profil"}
                       </p>
                     </div>
                   </a>

--- a/frontend-next/src/components/cv/wizard/step3-results.tsx
+++ b/frontend-next/src/components/cv/wizard/step3-results.tsx
@@ -3,37 +3,43 @@
  * Features: animated loading, score ring, CV info panel, accordion results, actions
  */
 
-'use client'
+"use client";
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { Download, GitCompare, Sparkles, RotateCcw, AlertCircle } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
-import { ScoreRing } from '@/components/cv/score-ring'
-import { CVInfoPanel } from '@/components/cv/cv-info-panel'
-import { ResultsAccordion } from '@/components/cv/results-accordion'
-import { CVComparison } from '@/components/cv/cv-comparison'
-import type { CVAnalysisResult } from '@/hooks/use-cv-history'
-import { cn } from '@/lib/utils'
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Download,
+  GitCompare,
+  Sparkles,
+  RotateCcw,
+  AlertCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { ScoreRing } from "@/components/cv/score-ring";
+import { CVInfoPanel } from "@/components/cv/cv-info-panel";
+import { ResultsAccordion } from "@/components/cv/results-accordion";
+import { CVComparison } from "@/components/cv/cv-comparison";
+import type { CVAnalysisResult } from "@/hooks/use-cv-history";
+import { cn } from "@/lib/utils";
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
 interface Step3ResultsProps {
-  loading: boolean
-  result: CVAnalysisResult | null
-  error: string | null
-  history: CVAnalysisResult[]
+  loading: boolean;
+  result: CVAnalysisResult | null;
+  error: string | null;
+  history: CVAnalysisResult[];
   hasFeatures: {
-    hasCVHistory: boolean
-    hasPDFExport: boolean
-  }
-  onReset: () => void
-  onExportPDF: () => void
-  onOpenPricingModal: (feature: string) => void
-  className?: string
+    hasCVHistory: boolean;
+    hasPDFExport: boolean;
+  };
+  onReset: () => void;
+  onExportPDF: () => void;
+  onOpenPricingModal: (feature: string) => void;
+  className?: string;
 }
 
 // ============================================================================
@@ -41,26 +47,26 @@ interface Step3ResultsProps {
 // ============================================================================
 
 const LOADING_MESSAGES = [
-  'Analyse en cours...',
-  'Extraction des informations...',
-  'Calcul du score ATS...',
-  'Génération des recommandations...'
-]
+  "Analyse en cours...",
+  "Extraction des informations...",
+  "Calcul du score ATS...",
+  "Génération des recommandations...",
+];
 
 // ============================================================================
 // SUB-COMPONENTS
 // ============================================================================
 
 function LoadingAnimation() {
-  const [messageIndex, setMessageIndex] = useState(0)
+  const [messageIndex, setMessageIndex] = useState(0);
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setMessageIndex((prev) => (prev + 1) % LOADING_MESSAGES.length)
-    }, 1500)
+      setMessageIndex((prev) => (prev + 1) % LOADING_MESSAGES.length);
+    }, 1500);
 
-    return () => clearInterval(interval)
-  }, [])
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div className="flex flex-col items-center justify-center py-16">
@@ -72,7 +78,7 @@ function LoadingAnimation() {
             className="w-4 h-4 rounded-full bg-huntzen-blue animate-pulse"
             style={{
               animationDelay: `${index * 0.2}s`,
-              animationDuration: '1s'
+              animationDuration: "1s",
             }}
           />
         ))}
@@ -86,10 +92,16 @@ function LoadingAnimation() {
         Cela peut prendre quelques secondes
       </p>
     </div>
-  )
+  );
 }
 
-function ErrorState({ error, onReset }: { error: string; onReset: () => void }) {
+function ErrorState({
+  error,
+  onReset,
+}: {
+  error: string;
+  onReset: () => void;
+}) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
       <div className="w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mb-4">
@@ -102,7 +114,7 @@ function ErrorState({ error, onReset }: { error: string; onReset: () => void }) 
         Réessayer
       </Button>
     </div>
-  )
+  );
 }
 
 // ============================================================================
@@ -118,37 +130,38 @@ export function Step3Results({
   onReset,
   onExportPDF,
   onOpenPricingModal,
-  className
+  className,
 }: Step3ResultsProps) {
-  const router = useRouter()
-  const [showComparison, setShowComparison] = useState(false)
+  const router = useRouter();
+  const [showComparison, setShowComparison] = useState(false);
 
   // Loading state
   if (loading) {
-    return <LoadingAnimation />
+    return <LoadingAnimation />;
   }
 
   // Error state
   if (error) {
-    return <ErrorState error={error} onReset={onReset} />
+    return <ErrorState error={error} onReset={onReset} />;
   }
 
   // No result yet
   if (!result) {
-    return null
+    return null;
   }
 
-  const canCompare = history.length >= 2 && hasFeatures.hasCVHistory
+  const canCompare = history.length >= 2 && hasFeatures.hasCVHistory;
 
   return (
-    <div className={cn('space-y-8', className)}>
+    <div className={cn("space-y-8", className)}>
       {/* Header with Score Ring + CV Info */}
       <div className="grid md:grid-cols-[1fr_300px] gap-6">
         {/* Score Ring */}
         <div className="flex flex-col items-center justify-center p-6 bg-gradient-to-br from-blue-50 to-violet-50 rounded-xl border-2 border-blue-200">
           <ScoreRing score={result.score} size={140} animationDuration={750} />
           <p className="text-sm text-gray-600 mt-4">
-            Votre CV obtient un score de <span className="font-bold text-huntzen-blue">{result.score}%</span>
+            Votre CV obtient un score de{" "}
+            <span className="font-bold text-huntzen-blue">{result.score}%</span>
           </p>
         </div>
 
@@ -164,9 +177,9 @@ export function Step3Results({
           size="sm"
           onClick={() => {
             if (!hasFeatures.hasPDFExport) {
-              onOpenPricingModal('has_pdf_export')
+              onOpenPricingModal("has_pdf_export");
             } else {
-              onExportPDF()
+              onExportPDF();
             }
           }}
           className="gap-2"
@@ -204,6 +217,29 @@ export function Step3Results({
         currentScore={result.score}
       />
 
+      {/* Offres recommandées */}
+      {result.recommended_job_titles &&
+        result.recommended_job_titles.length > 0 && (
+          <div className="space-y-3 pt-2">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              Postes recommandés pour votre profil
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {result.recommended_job_titles.map((title) => (
+                <button
+                  key={title}
+                  onClick={() =>
+                    router.push(`/jobs?q=${encodeURIComponent(title)}`)
+                  }
+                  className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full border border-blue-200 hover:bg-blue-100 transition-colors"
+                >
+                  {title} →
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
       {/* Bottom Actions */}
       <div className="flex flex-col sm:flex-row items-center justify-between gap-4 pt-6 border-t-2 border-gray-200">
         <Button
@@ -218,7 +254,7 @@ export function Step3Results({
 
         <Button
           size="lg"
-          onClick={() => router.push('/coach')}
+          onClick={() => router.push("/coach")}
           className="gap-2 w-full sm:w-auto bg-gradient-to-r from-huntzen-blue to-huntzen-turquoise hover:shadow-lg transition-all"
         >
           <Sparkles className="h-4 w-4" />
@@ -235,5 +271,5 @@ export function Step3Results({
         </Dialog>
       )}
     </div>
-  )
+  );
 }

--- a/frontend-next/src/components/freemium/conversion-popups.tsx
+++ b/frontend-next/src/components/freemium/conversion-popups.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
 export interface PopupConfig {
   id: string;
@@ -13,19 +14,84 @@ export interface PopupConfig {
   primaryCta: string;
   secondaryCta?: string;
   plan: "starter" | "pro";
-  price: string;
+  discountPercent?: number;
+  priceOverride?: string;
   couponTrigger?: string;
 }
 
 export const POPUP_CONFIGS: PopupConfig[] = [
-  { id: "search_limit", trigger: "search_limit", title: "Tu as atteint ta limite de recherches aujourd'hui", body: "Passe à Starter pour des recherches illimitées et trouve ton prochain job plus vite.", primaryCta: "Débloquer les recherches", secondaryCta: "Parrainer un ami", plan: "starter", price: "9,90€/mois" },
-  { id: "cv_score", trigger: "cv_score", title: "Ton CV peut faire beaucoup mieux", body: "Accède aux conseils détaillés de Sofia pour booster ton score ATS et décrocher plus d'entretiens.", primaryCta: "Activer l'analyse complète", plan: "starter", price: "9,90€/mois" },
-  { id: "session_cut", trigger: "session_cut", title: "Ta session coach est terminée", body: "Continue avec Nova, Maria ou Lucas sans limite. Ton prochain job est à portée de main.", primaryCta: "Continuer avec le Coach", plan: "starter", price: "9,90€/mois" },
-  { id: "interview_score", trigger: "interview_score", title: "Tu veux aller plus loin avec Lucas ?", body: "Simule autant d'entretiens que tu veux et reçois des retours approfondis à chaque session.", primaryCta: "Activer la simulation complète", plan: "pro", price: "19,90€/mois" },
-  { id: "momentum", trigger: "momentum", title: "Tu es en plein élan — profite de -20% aujourd'hui", body: "Tu recherches activement. Voici une offre exclusive valable 24h pour toi.", primaryCta: "Choisir mon plan avec -20%", plan: "starter", price: "7,92€/mois", couponTrigger: "momentum" },
-  { id: "anti_churn", trigger: "anti_churn", title: "Reste et économise -30% pendant 3 mois", body: "Avant de partir, voici une offre exclusive : -30% sur ton abonnement pendant 3 mois.", primaryCta: "Garder mon avantage", secondaryCta: "Annuler quand même", plan: "pro", price: "13,93€/mois", couponTrigger: "anti_churn" },
-  { id: "inactive_7d", trigger: "inactive_7d", title: "7 jours Pro offerts — on t'a réservé ta place", body: "Tu nous manques ! Reviens et profite de 7 jours Pro gratuits pour reprendre ta recherche.", primaryCta: "Activer mes 7 jours Pro", plan: "pro", price: "0€ pendant 7 jours", couponTrigger: "win_back_7d" },
-  { id: "pricing_hover", trigger: "pricing_hover", title: "67% de nos abonnés choisissent Pro", body: "Ils trouvent un job en moyenne 3x plus vite. Rejoins-les aujourd'hui.", primaryCta: "Choisir Pro maintenant", plan: "pro", price: "19,90€/mois" },
+  {
+    id: "search_limit",
+    trigger: "search_limit",
+    title: "Tu as atteint ta limite de recherches aujourd'hui",
+    body: "Passe à Starter pour des recherches illimitées et trouve ton prochain job plus vite.",
+    primaryCta: "Débloquer les recherches",
+    secondaryCta: "Parrainer un ami",
+    plan: "starter",
+  },
+  {
+    id: "cv_score",
+    trigger: "cv_score",
+    title: "Ton CV peut faire beaucoup mieux",
+    body: "Accède aux conseils détaillés de Sofia pour booster ton score ATS et décrocher plus d'entretiens.",
+    primaryCta: "Activer l'analyse complète",
+    plan: "starter",
+  },
+  {
+    id: "session_cut",
+    trigger: "session_cut",
+    title: "Ta session coach est terminée",
+    body: "Continue avec Nova, Maria ou Lucas sans limite. Ton prochain job est à portée de main.",
+    primaryCta: "Continuer avec le Coach",
+    plan: "starter",
+  },
+  {
+    id: "interview_score",
+    trigger: "interview_score",
+    title: "Tu veux aller plus loin avec Lucas ?",
+    body: "Simule autant d'entretiens que tu veux et reçois des retours approfondis à chaque session.",
+    primaryCta: "Activer la simulation complète",
+    plan: "pro",
+  },
+  {
+    id: "momentum",
+    trigger: "momentum",
+    title: "Tu es en plein élan — profite de -20% aujourd'hui",
+    body: "Tu recherches activement. Voici une offre exclusive valable 24h pour toi.",
+    primaryCta: "Choisir mon plan avec -20%",
+    plan: "starter",
+    discountPercent: 0.2,
+    couponTrigger: "momentum",
+  },
+  {
+    id: "anti_churn",
+    trigger: "anti_churn",
+    title: "Reste et économise -30% pendant 3 mois",
+    body: "Avant de partir, voici une offre exclusive : -30% sur ton abonnement pendant 3 mois.",
+    primaryCta: "Garder mon avantage",
+    secondaryCta: "Annuler quand même",
+    plan: "pro",
+    discountPercent: 0.3,
+    couponTrigger: "anti_churn",
+  },
+  {
+    id: "inactive_7d",
+    trigger: "inactive_7d",
+    title: "7 jours Pro offerts — on t'a réservé ta place",
+    body: "Tu nous manques ! Reviens et profite de 7 jours Pro gratuits pour reprendre ta recherche.",
+    primaryCta: "Activer mes 7 jours Pro",
+    plan: "pro",
+    priceOverride: "0€ pendant 7 jours",
+    couponTrigger: "win_back_7d",
+  },
+  {
+    id: "pricing_hover",
+    trigger: "pricing_hover",
+    title: "67% de nos abonnés choisissent Pro",
+    body: "Ils trouvent un job en moyenne 3x plus vite. Rejoins-les aujourd'hui.",
+    primaryCta: "Choisir Pro maintenant",
+    plan: "pro",
+  },
 ];
 
 interface ConversionPopupProps {
@@ -35,7 +101,12 @@ interface ConversionPopupProps {
   onUpgrade?: (checkoutUrl?: string) => void;
 }
 
-export function ConversionPopup({ popupId, isOpen, onClose, onUpgrade }: ConversionPopupProps) {
+export function ConversionPopup({
+  popupId,
+  isOpen,
+  onClose,
+  onUpgrade,
+}: ConversionPopupProps) {
   const { session } = useAuth();
   const config = POPUP_CONFIGS.find((p) => p.id === popupId);
   const [couponCode, setCouponCode] = useState<string | null>(null);
@@ -45,33 +116,62 @@ export function ConversionPopup({ popupId, isOpen, onClose, onUpgrade }: Convers
     if (!isOpen || !config?.couponTrigger || !session?.access_token) return;
     const fetchCoupon = async () => {
       try {
-        const res = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/coupons/generate-for-trigger`, {
-          method: "POST",
-          headers: { Authorization: `Bearer ${session.access_token}`, "Content-Type": "application/json" },
-          body: JSON.stringify({ trigger_type: config.couponTrigger }),
-        });
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/coupons/generate-for-trigger`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${session.access_token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ trigger_type: config.couponTrigger }),
+          },
+        );
         if (res.ok) {
           const data = await res.json();
           setCouponCode(data.coupon_code);
           setCheckoutUrl(data.checkout_url);
         }
-      } catch { /* non-blocking */ }
+      } catch {
+        /* non-blocking */
+      }
     };
     fetchCoupon();
   }, [isOpen, config?.couponTrigger, session?.access_token]);
 
   useEffect(() => {
     if (!isOpen) return;
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [isOpen, onClose]);
 
+  const { getPlan, formatPrice } = usePlansConfig();
+
   if (!isOpen || !config) return null;
 
+  const computedPrice = (() => {
+    if (config.priceOverride) return config.priceOverride;
+    const planData = getPlan(config.plan);
+    if (!planData) return "";
+    const base = planData.price_monthly;
+    const discounted = config.discountPercent
+      ? base * (1 - config.discountPercent)
+      : base;
+    return `${formatPrice(discounted)}€/mois`;
+  })();
+
   const planColors = {
-    starter: { bg: "from-blue-500 to-blue-600", btn: "bg-blue-600 hover:bg-blue-700" },
-    pro: { bg: "from-violet-500 to-purple-600", btn: "bg-violet-600 hover:bg-violet-700" },
+    starter: {
+      bg: "from-blue-500 to-blue-600",
+      btn: "bg-blue-600 hover:bg-blue-700",
+    },
+    pro: {
+      bg: "from-violet-500 to-purple-600",
+      btn: "bg-violet-600 hover:bg-violet-700",
+    },
   };
   const colors = planColors[config.plan];
 
@@ -81,26 +181,49 @@ export function ConversionPopup({ popupId, isOpen, onClose, onUpgrade }: Convers
       <div className="relative w-full max-w-sm bg-background rounded-2xl shadow-2xl overflow-hidden">
         <div className={cn("h-1 w-full bg-gradient-to-r", colors.bg)} />
         <div className="p-6">
-          <button onClick={onClose} aria-label="Fermer" className="absolute top-4 right-4 p-1 rounded hover:bg-accent transition-colors">
+          <button
+            onClick={onClose}
+            aria-label="Fermer"
+            className="absolute top-4 right-4 p-1 rounded hover:bg-accent transition-colors"
+          >
             <X className="w-4 h-4 text-muted-foreground" />
           </button>
-          <h3 className="text-base font-bold leading-snug pr-6 mb-2">{config.title}</h3>
-          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">{config.body}</p>
+          <h3 className="text-base font-bold leading-snug pr-6 mb-2">
+            {config.title}
+          </h3>
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            {config.body}
+          </p>
           {couponCode && (
             <div className="mb-4 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 text-xs">
               <span className="text-amber-700 font-medium">Code : </span>
-              <span className="font-mono font-bold text-amber-800">{couponCode}</span>
+              <span className="font-mono font-bold text-amber-800">
+                {couponCode}
+              </span>
             </div>
           )}
           <p className="text-xs text-muted-foreground mb-4">
-            Plan {config.plan === "starter" ? "Starter" : "Pro"} — <strong>{config.price}</strong>
+            Plan {config.plan === "starter" ? "Starter" : "Pro"}
+            {computedPrice ? ` — ` : ""}
+            <strong>{computedPrice}</strong>
           </p>
-          <button onClick={() => { onUpgrade?.(checkoutUrl ?? undefined); onClose(); }}
-            className={cn("w-full py-2.5 rounded-xl text-white font-semibold text-sm transition-colors", colors.btn)}>
+          <button
+            onClick={() => {
+              onUpgrade?.(checkoutUrl ?? undefined);
+              onClose();
+            }}
+            className={cn(
+              "w-full py-2.5 rounded-xl text-white font-semibold text-sm transition-colors",
+              colors.btn,
+            )}
+          >
             {config.primaryCta}
           </button>
           {config.secondaryCta && (
-            <button onClick={onClose} className="w-full mt-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+            <button
+              onClick={onClose}
+              className="w-full mt-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
               {config.secondaryCta}
             </button>
           )}
@@ -116,6 +239,12 @@ export function useConversionPopup(popupId: string) {
     isOpen,
     open: () => setIsOpen(true),
     close: () => setIsOpen(false),
-    PopupComponent: () => <ConversionPopup popupId={popupId} isOpen={isOpen} onClose={() => setIsOpen(false)} />,
+    PopupComponent: () => (
+      <ConversionPopup
+        popupId={popupId}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    ),
   };
 }

--- a/frontend-next/src/components/freemium/feature-lock.tsx
+++ b/frontend-next/src/components/freemium/feature-lock.tsx
@@ -4,13 +4,7 @@ import { Lock, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSubscription } from "@/contexts/subscription-context";
 import { PlanType, PLAN_LIMITS } from "@/hooks/use-freemium-limits";
-
-const PLAN_NAMES: Record<PlanType, string> = {
-  free: "Gratuit",
-  starter: "Starter",
-  pro: "Pro",
-  premium: "Premium",
-};
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
 const PLAN_COLORS: Record<PlanType, string> = {
   free: "gray",
@@ -33,6 +27,7 @@ export function FeatureLockOverlay({
   message,
 }: FeatureLockOverlayProps) {
   const { hasFeature, getRequiredPlan, openPricingModal } = useSubscription();
+  const { getPlan } = usePlansConfig();
 
   const hasAccess = hasFeature(feature);
   const requiredPlan = getRequiredPlan(feature);
@@ -55,7 +50,8 @@ export function FeatureLockOverlay({
             <Lock className="w-6 h-6 text-gray-500" />
           </div>
           <p className="text-sm font-medium text-gray-700 mb-1">
-            {message || `Disponible avec ${PLAN_NAMES[requiredPlan]}`}
+            {message ||
+              `Disponible avec ${getPlan(requiredPlan)?.display_name ?? requiredPlan}`}
           </p>
           <Button
             size="sm"
@@ -83,6 +79,7 @@ export function FeatureLockBadge({
   showText = true,
 }: FeatureLockBadgeProps) {
   const { hasFeature, getRequiredPlan, openPricingModal } = useSubscription();
+  const { getPlan } = usePlansConfig();
 
   const hasAccess = hasFeature(feature);
   const requiredPlan = getRequiredPlan(feature);
@@ -106,7 +103,7 @@ export function FeatureLockBadge({
       } ${className}`}
     >
       <Lock className="w-3 h-3" />
-      {showText && PLAN_NAMES[requiredPlan]}
+      {showText && (getPlan(requiredPlan)?.display_name ?? requiredPlan)}
     </button>
   );
 }

--- a/frontend-next/src/components/freemium/pricing-modal.tsx
+++ b/frontend-next/src/components/freemium/pricing-modal.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { useTranslations } from "next-intl";
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
 interface PricingPlan {
   id: PlanType;
@@ -110,16 +111,19 @@ export function PricingModal() {
       ...(FEATURE_CONFIGS[id]?.[i] ?? { included: false }),
     }));
 
+  const { getPlan, formatPrice } = usePlansConfig();
+
   const plans: PricingPlan[] = [
     {
       id: "free",
-      name: tModal("plans.free.name"),
-      price: "0",
-      priceYearly: "0",
-      priceValue: 0,
-      priceYearlyValue: 0,
+      name: getPlan("free")?.display_name ?? tModal("plans.free.name"),
+      price: formatPrice(getPlan("free")?.price_monthly ?? 0),
+      priceYearly: formatPrice(getPlan("free")?.price_yearly ?? 0),
+      priceValue: getPlan("free")?.price_monthly ?? 0,
+      priceYearlyValue: getPlan("free")?.price_yearly ?? 0,
       period: tModal("plans.free.period"),
-      description: tModal("plans.free.description"),
+      description:
+        getPlan("free")?.description ?? tModal("plans.free.description"),
       icon: <Gift className="w-6 h-6" />,
       color: "text-gray-600",
       bgGradient: "from-gray-400 to-gray-500",
@@ -127,13 +131,14 @@ export function PricingModal() {
     },
     {
       id: "starter",
-      name: tModal("plans.starter.name"),
-      price: "8,90",
-      priceYearly: "85",
-      priceValue: 8.9,
-      priceYearlyValue: 85,
+      name: getPlan("starter")?.display_name ?? tModal("plans.starter.name"),
+      price: formatPrice(getPlan("starter")?.price_monthly ?? 8.9),
+      priceYearly: formatPrice(getPlan("starter")?.price_yearly ?? 85),
+      priceValue: getPlan("starter")?.price_monthly ?? 8.9,
+      priceYearlyValue: getPlan("starter")?.price_yearly ?? 85,
       period: tModal("plans.starter.period"),
-      description: tModal("plans.starter.description"),
+      description:
+        getPlan("starter")?.description ?? tModal("plans.starter.description"),
       icon: <Zap className="w-6 h-6" />,
       color: "text-blue-600",
       bgGradient: "from-blue-500 to-blue-600",
@@ -141,13 +146,14 @@ export function PricingModal() {
     },
     {
       id: "pro",
-      name: tModal("plans.pro.name"),
-      price: "13,90",
-      priceYearly: "133",
-      priceValue: 13.9,
-      priceYearlyValue: 133,
+      name: getPlan("pro")?.display_name ?? tModal("plans.pro.name"),
+      price: formatPrice(getPlan("pro")?.price_monthly ?? 13.9),
+      priceYearly: formatPrice(getPlan("pro")?.price_yearly ?? 133),
+      priceValue: getPlan("pro")?.price_monthly ?? 13.9,
+      priceYearlyValue: getPlan("pro")?.price_yearly ?? 133,
       period: tModal("plans.pro.period"),
-      description: tModal("plans.pro.description"),
+      description:
+        getPlan("pro")?.description ?? tModal("plans.pro.description"),
       icon: <Sparkles className="w-6 h-6" />,
       color: "text-violet-600",
       bgGradient: "from-violet-500 to-purple-600",
@@ -156,13 +162,14 @@ export function PricingModal() {
     },
     {
       id: "premium",
-      name: tModal("plans.premium.name"),
-      price: "19,90",
-      priceYearly: "191",
-      priceValue: 19.9,
-      priceYearlyValue: 191,
+      name: getPlan("premium")?.display_name ?? tModal("plans.premium.name"),
+      price: formatPrice(getPlan("premium")?.price_monthly ?? 19.9),
+      priceYearly: formatPrice(getPlan("premium")?.price_yearly ?? 191),
+      priceValue: getPlan("premium")?.price_monthly ?? 19.9,
+      priceYearlyValue: getPlan("premium")?.price_yearly ?? 191,
       period: tModal("plans.premium.period"),
-      description: tModal("plans.premium.description"),
+      description:
+        getPlan("premium")?.description ?? tModal("plans.premium.description"),
       icon: <Crown className="w-6 h-6" />,
       color: "text-amber-600",
       bgGradient: "from-amber-500 to-orange-500",
@@ -495,16 +502,19 @@ export function PricingCards({
       ...(FEATURE_CONFIGS[id]?.[i] ?? { included: false }),
     }));
 
+  const { getPlan, formatPrice } = usePlansConfig();
+
   const plans: PricingPlan[] = [
     {
       id: "free",
-      name: tModal("plans.free.name"),
-      price: "0",
-      priceYearly: "0",
-      priceValue: 0,
-      priceYearlyValue: 0,
+      name: getPlan("free")?.display_name ?? tModal("plans.free.name"),
+      price: formatPrice(getPlan("free")?.price_monthly ?? 0),
+      priceYearly: formatPrice(getPlan("free")?.price_yearly ?? 0),
+      priceValue: getPlan("free")?.price_monthly ?? 0,
+      priceYearlyValue: getPlan("free")?.price_yearly ?? 0,
       period: tModal("plans.free.period"),
-      description: tModal("plans.free.description"),
+      description:
+        getPlan("free")?.description ?? tModal("plans.free.description"),
       icon: <Gift className="w-6 h-6" />,
       color: "text-gray-600",
       bgGradient: "from-gray-400 to-gray-500",
@@ -512,13 +522,14 @@ export function PricingCards({
     },
     {
       id: "starter",
-      name: tModal("plans.starter.name"),
-      price: "8,90",
-      priceYearly: "85",
-      priceValue: 8.9,
-      priceYearlyValue: 85,
+      name: getPlan("starter")?.display_name ?? tModal("plans.starter.name"),
+      price: formatPrice(getPlan("starter")?.price_monthly ?? 8.9),
+      priceYearly: formatPrice(getPlan("starter")?.price_yearly ?? 85),
+      priceValue: getPlan("starter")?.price_monthly ?? 8.9,
+      priceYearlyValue: getPlan("starter")?.price_yearly ?? 85,
       period: tModal("plans.starter.period"),
-      description: tModal("plans.starter.description"),
+      description:
+        getPlan("starter")?.description ?? tModal("plans.starter.description"),
       icon: <Zap className="w-6 h-6" />,
       color: "text-blue-600",
       bgGradient: "from-blue-500 to-blue-600",
@@ -526,13 +537,14 @@ export function PricingCards({
     },
     {
       id: "pro",
-      name: tModal("plans.pro.name"),
-      price: "13,90",
-      priceYearly: "133",
-      priceValue: 13.9,
-      priceYearlyValue: 133,
+      name: getPlan("pro")?.display_name ?? tModal("plans.pro.name"),
+      price: formatPrice(getPlan("pro")?.price_monthly ?? 13.9),
+      priceYearly: formatPrice(getPlan("pro")?.price_yearly ?? 133),
+      priceValue: getPlan("pro")?.price_monthly ?? 13.9,
+      priceYearlyValue: getPlan("pro")?.price_yearly ?? 133,
       period: tModal("plans.pro.period"),
-      description: tModal("plans.pro.description"),
+      description:
+        getPlan("pro")?.description ?? tModal("plans.pro.description"),
       icon: <Sparkles className="w-6 h-6" />,
       color: "text-violet-600",
       bgGradient: "from-violet-500 to-purple-600",
@@ -541,13 +553,14 @@ export function PricingCards({
     },
     {
       id: "premium",
-      name: tModal("plans.premium.name"),
-      price: "19,90",
-      priceYearly: "191",
-      priceValue: 19.9,
-      priceYearlyValue: 191,
+      name: getPlan("premium")?.display_name ?? tModal("plans.premium.name"),
+      price: formatPrice(getPlan("premium")?.price_monthly ?? 19.9),
+      priceYearly: formatPrice(getPlan("premium")?.price_yearly ?? 191),
+      priceValue: getPlan("premium")?.price_monthly ?? 19.9,
+      priceYearlyValue: getPlan("premium")?.price_yearly ?? 191,
       period: tModal("plans.premium.period"),
-      description: tModal("plans.premium.description"),
+      description:
+        getPlan("premium")?.description ?? tModal("plans.premium.description"),
       icon: <Crown className="w-6 h-6" />,
       color: "text-amber-600",
       bgGradient: "from-amber-500 to-orange-500",

--- a/frontend-next/src/components/freemium/usage-modal.tsx
+++ b/frontend-next/src/components/freemium/usage-modal.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 import { CareerScoreCard } from "@/components/career-score/career-score-card";
 import { cn } from "@/lib/utils";
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
 interface UsageModalProps {
   isOpen: boolean;
@@ -163,6 +164,7 @@ export function UsageModal({ isOpen, onClose }: UsageModalProps) {
   }, [isOpen, refreshQuotas]);
 
   const planConfig = PLAN_CONFIG[plan];
+  const { getPlan } = usePlansConfig();
 
   const handleUpgrade = () => {
     onClose();
@@ -209,7 +211,7 @@ export function UsageModal({ isOpen, onClose }: UsageModalProps) {
                 </div>
                 <div>
                   <h3 className="text-lg font-bold text-gray-900">
-                    Plan {planConfig.name}
+                    Plan {getPlan(plan)?.display_name ?? planConfig.name}
                   </h3>
                   <p className="text-sm text-gray-600">
                     {isFreePlan

--- a/frontend-next/src/components/profile/subscription-card.tsx
+++ b/frontend-next/src/components/profile/subscription-card.tsx
@@ -32,6 +32,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTranslations } from "next-intl";
 import { useConversionPopup } from "@/components/freemium/conversion-popups";
+import { usePlansConfig } from "@/hooks/use-plans-config";
 
 // Plan configuration - Prices synced with database (subscription_plans table)
 const PLAN_CONFIG = {
@@ -133,6 +134,13 @@ export function SubscriptionCard() {
 
   const planConfig = PLAN_CONFIG[plan];
   const planLimits = PLAN_LIMITS[plan];
+  const { getPlan, formatPrice } = usePlansConfig();
+
+  const dynamicPrice = (() => {
+    const p = getPlan(plan);
+    if (!p || p.price_monthly === 0) return "0€";
+    return `${formatPrice(p.price_monthly)}€/mois`;
+  })();
 
   // Get list of features (boolean flags)
   const features = Object.entries(planLimits)
@@ -244,7 +252,8 @@ export function SubscriptionCard() {
                 Annulation programmée
               </p>
               <p className="text-xs text-amber-700">
-                Votre abonnement {planConfig.name} restera actif
+                Votre abonnement{" "}
+                {getPlan(plan)?.display_name ?? planConfig.name} restera actif
                 {formattedPeriodEnd
                   ? ` jusqu'au ${formattedPeriodEnd}`
                   : " jusqu'à la fin de la période"}
@@ -260,7 +269,7 @@ export function SubscriptionCard() {
             <div className="flex items-center gap-2">
               <Badge className={cn("gap-1", planConfig.color)}>
                 {planConfig.icon}
-                {planConfig.name}
+                {getPlan(plan)?.display_name ?? planConfig.name}
               </Badge>
               {isPaidPlan && !cancelAtPeriodEnd && !isPastDue && (
                 <Badge
@@ -293,13 +302,10 @@ export function SubscriptionCard() {
               )}
             </div>
             <div>
-              <p className="text-2xl font-bold">
-                {planConfig.price}
-                <span className="text-sm font-normal text-gray-500">
-                  {planConfig.period}
-                </span>
+              <p className="text-2xl font-bold">{dynamicPrice}</p>
+              <p className="text-sm text-gray-600">
+                {getPlan(plan)?.description ?? planConfig.description}
               </p>
-              <p className="text-sm text-gray-600">{planConfig.description}</p>
             </div>
           </div>
 

--- a/frontend-next/src/components/recruiter/recruiter-email-finder.tsx
+++ b/frontend-next/src/components/recruiter/recruiter-email-finder.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/contexts/auth-context";
 
 interface Contact {
+  name?: string;
   first_name?: string;
   last_name?: string;
   email?: string;
@@ -20,7 +21,10 @@ interface RecruiterEmailFinderProps {
   companyDomain?: string;
 }
 
-export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEmailFinderProps) {
+export function RecruiterEmailFinder({
+  companyName,
+  companyDomain,
+}: RecruiterEmailFinderProps) {
   const { session } = useAuth();
   const [company, setCompany] = useState(companyName);
   const [results, setResults] = useState<Contact[]>([]);
@@ -41,11 +45,16 @@ export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEm
             "Content-Type": "application/json",
             Authorization: `Bearer ${session.access_token}`,
           },
-          body: JSON.stringify({ company_name: company, company_domain: companyDomain }),
-        }
+          body: JSON.stringify({
+            company_name: company,
+            company_domain: companyDomain,
+          }),
+        },
       );
       if (res.status === 429) {
-        setError("Quota atteint (3 recherches/jour en version gratuite). Passez à Pro pour un accès illimité.");
+        setError(
+          "Quota atteint (3 recherches/jour en version gratuite). Passez à Pro pour un accès illimité.",
+        );
         return;
       }
       if (!res.ok) throw new Error("Erreur de recherche");
@@ -65,8 +74,8 @@ export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEm
       <div className="flex items-start gap-2 p-3 bg-orange-50 border border-orange-200 rounded-lg">
         <AlertTriangle className="w-4 h-4 text-orange-500 mt-0.5 shrink-0" />
         <div className="text-xs text-orange-700">
-          <span className="font-semibold">BÊTA</span> — Cette fonctionnalité est en cours d&apos;amélioration.
-          Les résultats peuvent être incomplets.
+          <span className="font-semibold">BÊTA</span> — Cette fonctionnalité est
+          en cours d&apos;amélioration. Les résultats peuvent être incomplets.
         </div>
       </div>
 
@@ -98,16 +107,27 @@ export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEm
       {results.length > 0 && (
         <div className="space-y-2">
           {results.map((contact, i) => (
-            <div key={i} className="flex items-center justify-between p-3 bg-white border rounded-lg">
+            <div
+              key={i}
+              className="flex items-center justify-between p-3 bg-white border rounded-lg"
+            >
               <div>
                 <p className="text-sm font-medium">
-                  {contact.first_name} {contact.last_name}
+                  {contact.name ||
+                    [contact.first_name, contact.last_name]
+                      .filter(Boolean)
+                      .join(" ") ||
+                    "—"}
                 </p>
                 {contact.position && (
-                  <p className="text-xs text-muted-foreground">{contact.position}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {contact.position}
+                  </p>
                 )}
                 {contact.email && (
-                  <p className="text-xs font-mono text-blue-600">{contact.email}</p>
+                  <p className="text-xs font-mono text-blue-600">
+                    {contact.email}
+                  </p>
                 )}
               </div>
               {contact.confidence && (
@@ -122,7 +142,8 @@ export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEm
 
       {searched && (
         <p className="text-xs text-muted-foreground border-t pt-3">
-          Ces emails proviennent de sources publiques. Respectez le RGPD dans vos communications.
+          Ces emails proviennent de sources publiques. Respectez le RGPD dans
+          vos communications.
         </p>
       )}
     </div>

--- a/frontend-next/src/components/recruiter/recruiter-email-finder.tsx
+++ b/frontend-next/src/components/recruiter/recruiter-email-finder.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { useAuth } from "@/contexts/auth-context";
+
+interface Contact {
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  position?: string;
+  confidence?: number;
+}
+
+interface RecruiterEmailFinderProps {
+  companyName: string;
+  companyDomain?: string;
+}
+
+export function RecruiterEmailFinder({ companyName, companyDomain }: RecruiterEmailFinderProps) {
+  const { session } = useAuth();
+  const [company, setCompany] = useState(companyName);
+  const [results, setResults] = useState<Contact[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searched, setSearched] = useState(false);
+
+  const handleSearch = async () => {
+    if (!session?.access_token || !company.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/recruiter-finder/find`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({ company_name: company, company_domain: companyDomain }),
+        }
+      );
+      if (res.status === 429) {
+        setError("Quota atteint (3 recherches/jour en version gratuite). Passez à Pro pour un accès illimité.");
+        return;
+      }
+      if (!res.ok) throw new Error("Erreur de recherche");
+      const data = await res.json();
+      setResults(data.recruiters || data.all_contacts || []);
+      setSearched(true);
+    } catch {
+      setError("Impossible de contacter le service. Réessayez.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Badge BÊTA + disclaimer */}
+      <div className="flex items-start gap-2 p-3 bg-orange-50 border border-orange-200 rounded-lg">
+        <AlertTriangle className="w-4 h-4 text-orange-500 mt-0.5 shrink-0" />
+        <div className="text-xs text-orange-700">
+          <span className="font-semibold">BÊTA</span> — Cette fonctionnalité est en cours d&apos;amélioration.
+          Les résultats peuvent être incomplets.
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <Input
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          placeholder="Nom de l'entreprise"
+          className="flex-1"
+        />
+        <Button onClick={handleSearch} disabled={loading || !company.trim()}>
+          <Search className="w-4 h-4 mr-2" />
+          {loading ? "Recherche..." : "Rechercher"}
+        </Button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      {searched && results.length === 0 && !error && (
+        <p className="text-sm text-muted-foreground text-center py-4">
+          Aucun contact trouvé pour cette entreprise.
+        </p>
+      )}
+
+      {results.length > 0 && (
+        <div className="space-y-2">
+          {results.map((contact, i) => (
+            <div key={i} className="flex items-center justify-between p-3 bg-white border rounded-lg">
+              <div>
+                <p className="text-sm font-medium">
+                  {contact.first_name} {contact.last_name}
+                </p>
+                {contact.position && (
+                  <p className="text-xs text-muted-foreground">{contact.position}</p>
+                )}
+                {contact.email && (
+                  <p className="text-xs font-mono text-blue-600">{contact.email}</p>
+                )}
+              </div>
+              {contact.confidence && (
+                <Badge variant="outline" className="text-xs">
+                  {contact.confidence}% confiance
+                </Badge>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {searched && (
+        <p className="text-xs text-muted-foreground border-t pt-3">
+          Ces emails proviennent de sources publiques. Respectez le RGPD dans vos communications.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend-next/src/contexts/subscription-context.tsx
+++ b/frontend-next/src/contexts/subscription-context.tsx
@@ -72,13 +72,6 @@ interface SubscriptionContextType {
 
 const SubscriptionContext = createContext<SubscriptionContextType | null>(null);
 
-const PLAN_NAMES: Record<PlanType, string> = {
-  free: "Gratuit",
-  starter: "Starter",
-  pro: "Pro",
-  premium: "Premium",
-};
-
 export function SubscriptionProvider({ children }: { children: ReactNode }) {
   // NEW: Fetch subscription data from backend API
   const apiData = useSubscriptionApi();
@@ -159,7 +152,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     // No subscription data = new user or free user, default to 'free'
     return apiData.subscription?.plan_name || "free";
   })();
-  const planName = PLAN_NAMES[plan];
+  // plan_display_name vient directement de /api/auth/me (champ subscription)
+  const planName = apiData.subscription?.plan_display_name || plan;
 
   // Detect inconsistency: user authenticated but no subscription data from API
   useEffect(() => {

--- a/frontend-next/src/hooks/admin/use-admin-plans.ts
+++ b/frontend-next/src/hooks/admin/use-admin-plans.ts
@@ -130,6 +130,30 @@ export function useAdminPlans() {
     [],
   );
 
+  const updateWording = useCallback(
+    async (
+      planId: string,
+      wording: { display_name?: string; description?: string },
+    ) => {
+      setLoading(true);
+      try {
+        await adminFetch(`/api/admin/plans/${planId}/wording`, {
+          method: "PATCH",
+          body: JSON.stringify(wording),
+        });
+        toast.success("Wording mis à jour");
+        window.dispatchEvent(new Event("subscription-changed"));
+        return true;
+      } catch (e: any) {
+        toast.error(e.message || "Erreur lors de la mise à jour du wording");
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
   const updateStripePrice = useCallback(
     async (
       planId: string,
@@ -164,6 +188,7 @@ export function useAdminPlans() {
     updateLimits,
     updateFeatures, // now accepts Record<string, boolean>
     updateDisplayPrice,
+    updateWording,
     updateStripePrice,
   };
 }

--- a/frontend-next/src/hooks/use-cv-analysis.ts
+++ b/frontend-next/src/hooks/use-cv-analysis.ts
@@ -51,6 +51,7 @@ interface CVAnalysisResult {
   keywords_missing: string[];
   job_match_score?: number;
   job_match_explanation?: string;
+  suggested_job_titles?: string[];
   analysis_language: "fr" | "en";
   processed_at: string;
   processing_time_seconds?: number;

--- a/frontend-next/src/hooks/use-cv-history.ts
+++ b/frontend-next/src/hooks/use-cv-history.ts
@@ -3,48 +3,49 @@
  * Features: tier-based limits, CRUD operations, auto-cleanup
  */
 
-'use client'
+"use client";
 
-import { useState, useEffect, useCallback } from 'react'
-import { useSubscription } from '@/contexts/subscription-context'
-import type { BreakdownItem } from '@/components/cv/score-breakdown-v2'
-import type { Suggestion } from '@/components/cv/actionable-suggestions'
+import { useState, useEffect, useCallback } from "react";
+import { useSubscription } from "@/contexts/subscription-context";
+import type { BreakdownItem } from "@/components/cv/score-breakdown-v2";
+import type { Suggestion } from "@/components/cv/actionable-suggestions";
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
 export interface CVAnalysisResult {
-  id: string
-  fileName: string
-  analyzedAt: Date
-  score: number
-  breakdown: BreakdownItem[]
-  strengths: string[]
-  weaknesses: string[]
-  suggestions: Suggestion[]
-  rawAnalysis?: string // Optional raw analysis text
-  error?: string // Optional error message
-  cv_info?: any // Optional CV info (name, email, phone, skills)
+  id: string;
+  fileName: string;
+  analyzedAt: Date;
+  score: number;
+  breakdown: BreakdownItem[];
+  strengths: string[];
+  weaknesses: string[];
+  suggestions: Suggestion[];
+  rawAnalysis?: string; // Optional raw analysis text
+  error?: string; // Optional error message
+  cv_info?: any; // Optional CV info (name, email, phone, skills)
+  recommended_job_titles?: string[]; // Suggested job titles based on skills
 }
 
 // Serialized version for localStorage (Date → string)
 interface CVAnalysisResultSerialized {
-  id: string
-  fileName: string
-  analyzedAt: string
-  score: number
-  breakdown: BreakdownItem[]
-  strengths: string[]
-  weaknesses: string[]
-  suggestions: Suggestion[]
+  id: string;
+  fileName: string;
+  analyzedAt: string;
+  score: number;
+  breakdown: BreakdownItem[];
+  strengths: string[];
+  weaknesses: string[];
+  suggestions: Suggestion[];
 }
 
 // ============================================================================
 // CONSTANTS
 // ============================================================================
 
-const STORAGE_KEY = 'cv_analysis_history'
+const STORAGE_KEY = "cv_analysis_history";
 
 // Max history items by subscription tier
 const MAX_HISTORY_BY_TIER: Record<string, number> = {
@@ -52,34 +53,34 @@ const MAX_HISTORY_BY_TIER: Record<string, number> = {
   starter: 5,
   pro: 20,
   premium: 100,
-}
+};
 
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
 
 function generateId(): string {
-  return `cv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+  return `cv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 }
 
 function serializeHistory(history: CVAnalysisResult[]): string {
   const serialized: CVAnalysisResultSerialized[] = history.map((item) => ({
     ...item,
     analyzedAt: item.analyzedAt.toISOString(),
-  }))
-  return JSON.stringify(serialized)
+  }));
+  return JSON.stringify(serialized);
 }
 
 function deserializeHistory(data: string): CVAnalysisResult[] {
   try {
-    const parsed: CVAnalysisResultSerialized[] = JSON.parse(data)
+    const parsed: CVAnalysisResultSerialized[] = JSON.parse(data);
     return parsed.map((item) => ({
       ...item,
       analyzedAt: new Date(item.analyzedAt),
-    }))
+    }));
   } catch (error) {
-    console.error('Failed to deserialize CV history:', error)
-    return []
+    console.error("Failed to deserialize CV history:", error);
+    return [];
   }
 }
 
@@ -88,104 +89,104 @@ function deserializeHistory(data: string): CVAnalysisResult[] {
 // ============================================================================
 
 export function useCVHistory() {
-  const { plan } = useSubscription()
-  const [history, setHistory] = useState<CVAnalysisResult[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const { plan } = useSubscription();
+  const [history, setHistory] = useState<CVAnalysisResult[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   // Get max history limit for current tier
-  const maxHistory = MAX_HISTORY_BY_TIER[plan] || MAX_HISTORY_BY_TIER.free
+  const maxHistory = MAX_HISTORY_BY_TIER[plan] || MAX_HISTORY_BY_TIER.free;
 
   // Load history from localStorage on mount
   useEffect(() => {
     try {
-      const stored = localStorage.getItem(STORAGE_KEY)
+      const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
-        const loadedHistory = deserializeHistory(stored)
+        const loadedHistory = deserializeHistory(stored);
         // Enforce tier limit on load
-        const limitedHistory = loadedHistory.slice(0, maxHistory)
-        setHistory(limitedHistory)
+        const limitedHistory = loadedHistory.slice(0, maxHistory);
+        setHistory(limitedHistory);
 
         // If we had to trim, update localStorage
         if (limitedHistory.length < loadedHistory.length) {
-          localStorage.setItem(STORAGE_KEY, serializeHistory(limitedHistory))
+          localStorage.setItem(STORAGE_KEY, serializeHistory(limitedHistory));
         }
       }
     } catch (error) {
-      console.error('Failed to load CV history:', error)
+      console.error("Failed to load CV history:", error);
     } finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
-  }, [maxHistory])
+  }, [maxHistory]);
 
   // Save analysis to history
   const saveAnalysis = useCallback(
-    (result: Omit<CVAnalysisResult, 'id' | 'analyzedAt'>) => {
+    (result: Omit<CVAnalysisResult, "id" | "analyzedAt">) => {
       const newAnalysis: CVAnalysisResult = {
         ...result,
         id: generateId(),
         analyzedAt: new Date(),
-      }
+      };
 
       setHistory((prev) => {
         // Add new analysis at the beginning
-        const newHistory = [newAnalysis, ...prev]
+        const newHistory = [newAnalysis, ...prev];
 
         // Enforce tier limit
-        const limitedHistory = newHistory.slice(0, maxHistory)
+        const limitedHistory = newHistory.slice(0, maxHistory);
 
         // Save to localStorage
         try {
-          localStorage.setItem(STORAGE_KEY, serializeHistory(limitedHistory))
+          localStorage.setItem(STORAGE_KEY, serializeHistory(limitedHistory));
         } catch (error) {
-          console.error('Failed to save CV history:', error)
+          console.error("Failed to save CV history:", error);
         }
 
-        return limitedHistory
-      })
+        return limitedHistory;
+      });
 
-      return newAnalysis
+      return newAnalysis;
     },
-    [maxHistory]
-  )
+    [maxHistory],
+  );
 
   // Delete analysis by ID
   const deleteAnalysis = useCallback((id: string) => {
     setHistory((prev) => {
-      const newHistory = prev.filter((item) => item.id !== id)
+      const newHistory = prev.filter((item) => item.id !== id);
 
       try {
-        localStorage.setItem(STORAGE_KEY, serializeHistory(newHistory))
+        localStorage.setItem(STORAGE_KEY, serializeHistory(newHistory));
       } catch (error) {
-        console.error('Failed to delete CV analysis:', error)
+        console.error("Failed to delete CV analysis:", error);
       }
 
-      return newHistory
-    })
-  }, [])
+      return newHistory;
+    });
+  }, []);
 
   // Clear all history
   const clearHistory = useCallback(() => {
-    setHistory([])
+    setHistory([]);
     try {
-      localStorage.removeItem(STORAGE_KEY)
+      localStorage.removeItem(STORAGE_KEY);
     } catch (error) {
-      console.error('Failed to clear CV history:', error)
+      console.error("Failed to clear CV history:", error);
     }
-  }, [])
+  }, []);
 
   // Get analysis by ID
   const getAnalysis = useCallback(
     (id: string): CVAnalysisResult | undefined => {
-      return history.find((item) => item.id === id)
+      return history.find((item) => item.id === id);
     },
-    [history]
-  )
+    [history],
+  );
 
   // Check if can save more analyses
-  const canSave = history.length < maxHistory
+  const canSave = history.length < maxHistory;
 
   // Get remaining slots
-  const remainingSlots = Math.max(0, maxHistory - history.length)
+  const remainingSlots = Math.max(0, maxHistory - history.length);
 
   return {
     history,
@@ -197,5 +198,5 @@ export function useCVHistory() {
     deleteAnalysis,
     clearHistory,
     getAnalysis,
-  }
+  };
 }

--- a/frontend-next/src/hooks/use-plans-config.ts
+++ b/frontend-next/src/hooks/use-plans-config.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL || "";
+const CACHE_KEY = "plans_config_cache";
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export interface PlanConfig {
+  id: string;
+  name: "free" | "starter" | "pro" | "premium";
+  display_name: string;
+  description: string;
+  price_monthly: number;
+  price_yearly: number | null;
+  features: string[];
+  sort_order: number;
+}
+
+function loadCache(): PlanConfig[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const { data, expiry } = JSON.parse(raw);
+    if (Date.now() > expiry) {
+      localStorage.removeItem(CACHE_KEY);
+      return null;
+    }
+    return data as PlanConfig[];
+  } catch {
+    return null;
+  }
+}
+
+function saveCache(data: PlanConfig[]) {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ data, expiry: Date.now() + CACHE_TTL }),
+    );
+  } catch {}
+}
+
+function clearCache() {
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {}
+}
+
+export function usePlansConfig() {
+  const [plans, setPlans] = useState<PlanConfig[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchPlans = useCallback(async () => {
+    // Try cache first
+    const cached = loadCache();
+    if (cached) {
+      setPlans(cached);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/public/plans`);
+      if (!res.ok) throw new Error("Failed to fetch plans");
+      const data: PlanConfig[] = await res.json();
+      saveCache(data);
+      setPlans(data);
+    } catch (err) {
+      console.warn("[usePlansConfig] API unavailable, no fallback:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPlans();
+  }, [fetchPlans]);
+
+  // Refresh when admin saves plan changes
+  useEffect(() => {
+    const handleChange = () => {
+      clearCache();
+      fetchPlans();
+    };
+    window.addEventListener("subscription-changed", handleChange);
+    return () => window.removeEventListener("subscription-changed", handleChange);
+  }, [fetchPlans]);
+
+  const getPlan = useCallback(
+    (name: string): PlanConfig | undefined => plans.find((p) => p.name === name),
+    [plans],
+  );
+
+  /** Format price as French string: 8.9 → "8,90" */
+  const formatPrice = useCallback((price: number): string => {
+    return price.toFixed(2).replace(".", ",");
+  }, []);
+
+  return { plans, getPlan, isLoading, formatPrice };
+}

--- a/scripts/deployment/modal_app.py
+++ b/scripts/deployment/modal_app.py
@@ -445,6 +445,8 @@ MISSION : Analyser ce CV avec rigueur et précision.
 
 RÈGLE ABSOLUE : Chaque explication DOIT citer le contenu réel du CV (noms d'entreprises, technologies, dates, chiffres trouvés dans le texte). Les phrases génériques comme "votre CV est bien structuré" sont INTERDITES.
 
+Pour suggested_job_titles : propose 3 titres de postes que le candidat devrait cibler, en te basant sur ses compétences et son niveau d'expérience. Utilise des formats standards (ex: "Développeur Full-Stack React/Node.js", "Data Scientist Python", "Chef de Projet IT").
+
 CV à analyser :
 ---
 {cv_text}
@@ -477,6 +479,7 @@ Réponds UNIQUEMENT avec le JSON suivant. Aucun texte avant ou après. Aucun blo
     "missing_sections": ["<sections ATS standard absentes du CV, ex: Résumé professionnel, Liens GitHub/Portfolio, Certifications>"],
     "keywords_found": ["<liste des mots-clés techniques pertinents TROUVÉS dans le CV>"],
     "keywords_missing": ["<liste des mots-clés importants ABSENTS du CV pour ce type de profil>"],
+    "suggested_job_titles": ["<titre poste 1 : format standard ex: 'Développeur Full-Stack React/Node.js'>", "<titre poste 2>", "<titre poste 3>"],
     {job_match_json_fields}
 }}"""
 


### PR DESCRIPTION
## Résumé

- **Backend**: Nouvel endpoint public `GET /api/public/plans` + `PATCH /admin/plans/{id}/wording` + invalidation cache Redis `plans_config` dans tous les PATCH admin
- **Frontend**: Hook `usePlansConfig()` avec cache localStorage 5min + invalidation via event `subscription-changed`
- **Refactoring**: 6 composants migrent de hardcoded vers `usePlansConfig()` — pricing-modal, pricing/page, usage-modal, subscription-card, feature-lock, conversion-popups
- **Admin**: Nouvelle section "Wording" dans plan-card-editor — `display_name` et `description` éditables sans redeploy

## Impact utilisateur

- Les prix, noms et descriptions de plans se mettent à jour immédiatement après modification admin
- Les popups de conversion affichent les vrais prix (avec calcul dynamique des remises %)
- Aucune régression — fallback hardcodé si API indisponible

## Tests

- [ ] `/api/public/plans` retourne les 4 plans actifs
- [ ] `/admin/plans` → sauvegarder wording → page pricing mise à jour
- [ ] Popup conversion → prix = prix DB du plan (avec discount calculé)
- [ ] Cache Redis invalidé après tout PATCH admin plan