### PR TITLE
fix(quota): corriger incrément et invalidation cache sur 5 endpoints

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -502,6 +502,28 @@ async def increment_quota(user_id: str, feature: str, amount: int = 1) -> None:
         logger.warning(f"[quota] increment_quota({feature}) failed: {e}")
 
 
+async def increment_and_invalidate_quota(user_id: str, feature: str, amount: int = 1) -> None:
+    """Increment usage counter AND invalidate Redis cache so /api/auth/me returns fresh data.
+
+    Use this instead of calling increment_quota + invalidate_user_quota_cache separately.
+    Best-effort: logs warning on failure, does NOT raise.
+    """
+    try:
+        supabase = get_supabase_client()
+        supabase.rpc("increment_usage", {
+            "p_user_id": user_id,
+            "p_feature": feature,
+            "p_amount": amount,
+        }).execute()
+    except Exception as e:
+        logger.warning(f"[quota] increment_and_invalidate({feature}) failed for {user_id}: {e}")
+    try:
+        from src.services.stripe import invalidate_user_quota_cache
+        await invalidate_user_quota_cache(user_id)
+    except Exception as e:
+        logger.warning(f"[quota] cache invalidation failed for {user_id}: {e}")
+
+
 async def get_current_admin(current_user: dict = Depends(get_current_user)) -> dict:
     """
     Verify the current user has admin privileges (is_admin = TRUE in profiles).

--- a/backend/src/api/routes/coach.py
+++ b/backend/src/api/routes/coach.py
@@ -27,6 +27,7 @@ from src.api.deps import (
 )
 from src.api.middleware import limiter
 from src.models.schemas import CoachRequest, CoachResponse
+from src.services.stripe import invalidate_user_quota_cache
 from src.services.user_events import log_event
 
 # Seuil global (toutes replicas confondues) → au-dessus : queue Redis
@@ -288,6 +289,8 @@ async def coach_chat(
             }).execute()
         except Exception as e:
             logger.warning(f"[coach/chat] increment_coach_message failed for {user_id}/{data.assistant_type}: {e}")
+        # Invalider le cache Redis pour que /api/auth/me retourne les quotas à jour
+        await invalidate_user_quota_cache(user_id)
 
     # Tracking événement coach (best-effort)
     prenom = (current_user.get("email", "") or "").split("@")[0].capitalize() or "Un utilisateur"
@@ -471,6 +474,9 @@ async def sync_coach_time(
                 break
 
         logger.info(f"Coach time synced successfully for user {user_id}: {data.seconds_used}s")
+
+        # Invalider le cache Redis pour que /api/auth/me retourne les quotas à jour
+        await invalidate_user_quota_cache(user_id)
 
         return {
             "success": True,

--- a/backend/src/api/routes/cv_adapter.py
+++ b/backend/src/api/routes/cv_adapter.py
@@ -31,7 +31,7 @@ from src.services.pdf_generator import get_pdf_generator
 logger = logging.getLogger(__name__)
 
 
-def _check_and_increment_quota(user_id: str, feature: str) -> None:
+async def _check_and_increment_quota(user_id: str, feature: str) -> None:
     """Check quota and increment usage for cv_adapt or cover_letter. Raises 429 if exhausted."""
     supabase = get_supabase_client()
     try:
@@ -58,6 +58,9 @@ def _check_and_increment_quota(user_id: str, feature: str) -> None:
             "p_feature": feature,
             "p_amount": 1,
         }).execute()
+        # Invalider le cache Redis pour que /api/auth/me retourne les quotas à jour
+        from src.services.stripe import invalidate_user_quota_cache
+        await invalidate_user_quota_cache(user_id)
     except Exception as e:
         if hasattr(e, "status_code"):
             raise
@@ -236,7 +239,7 @@ async def adapt_cv(
     # Check and increment cv_adapt quota
     user_id = get_user_id_from_token(authorization)
     if user_id:
-        _check_and_increment_quota(user_id, "cv_adapt")
+        await _check_and_increment_quota(user_id, "cv_adapt")
 
     # Resolve CV text — from file or raw text
     if file and file.filename:
@@ -648,7 +651,7 @@ async def generate_cover_letter(request: CoverLetterRequest, authorization: str 
     user_id = get_user_id_from_token(authorization)
     if user_id:
         _require_feature_flag_sync(user_id, "cover_letter", "La generation de lettre de motivation necessite un plan superieur.")
-        _check_and_increment_quota(user_id, "cover_letter")
+        await _check_and_increment_quota(user_id, "cover_letter")
 
     agent = get_adapter_agent()
 
@@ -721,7 +724,7 @@ async def generate_cover_letter_json(
     user_id = get_user_id_from_token(authorization)
     if user_id:
         _require_feature_flag_sync(user_id, "cover_letter", "La generation de lettre de motivation necessite un plan superieur.")
-        _check_and_increment_quota(user_id, "cover_letter")
+        await _check_and_increment_quota(user_id, "cover_letter")
 
     agent = get_adapter_agent()
 

--- a/backend/src/api/routes/jobs.py
+++ b/backend/src/api/routes/jobs.py
@@ -563,6 +563,12 @@ async def search_jobs_get(
         result['metadata']['total_filtered'] = len(filtered_jobs)
         result['metadata']['total_before_filters'] = len(jobs)
 
+    # Incrémenter quota après recherche réussie (comme le POST /search)
+    from_history = request.query_params.get("from_history", "").lower() == "true"
+    if user_id and not from_history:
+        _increment_job_search_quota(user_id)
+        await invalidate_user_quota_cache(user_id)
+
     return result
 
 

--- a/backend/src/api/routes/subscription.py
+++ b/backend/src/api/routes/subscription.py
@@ -20,7 +20,7 @@ router = APIRouter()
 # Import dependencies
 try:
     from src.api.deps import get_current_user
-    from src.services.stripe import supabase_client
+    from src.services.stripe import invalidate_user_quota_cache, supabase_client
 except ImportError as e:
     logger.error(f"Failed to import dependencies: {e}")
     raise
@@ -240,6 +240,7 @@ async def manage_coach_session(
                 }).execute()
 
                 logger.info(f"Incremented coach usage for user {user_id}: {elapsed_seconds}s")
+                await invalidate_user_quota_cache(user_id)
 
             except Exception as e:
                 logger.error(f"Failed to increment coach usage: {e}")


### PR DESCRIPTION
## Summary

- **GET /api/jobs/search** : le frontend utilisait ce endpoint (pas le POST) mais le quota n'était jamais incrémenté côté backend — les recherches étaient "gratuites"
- **POST /api/coach/chat** : l'incrément en DB fonctionnait mais le cache Redis `auth_me:{user_id}` n'était jamais invalidé — le frontend affichait des quotas périmés pendant 5 min
- **POST /api/coach/sync-time** : même problème d'invalidation cache manquante
- **cv_adapter** (cv_adapt + cover_letter) : incrément DB OK mais cache Redis jamais invalidé
- **subscription sync-time** : même problème d'invalidation cache manquante
- **deps.py** : ajout helper `increment_and_invalidate_quota()` réutilisable pour les futures routes

## Bugs corrigés

| Endpoint | Problème | Impact |
|----------|----------|--------|
| `GET /api/jobs/search` | Pas d'incrément quota | Recherches illimitées pour tous les users |
| `POST /api/coach/chat` | Pas d'invalidation cache Redis | Compteur frontend gelé ~5 min |
| `POST /api/coach/sync-time` | Pas d'invalidation cache Redis | Compteur frontend gelé ~5 min |
| `cv_adapter` (3 endpoints) | Pas d'invalidation cache Redis | Compteur frontend gelé ~5 min |
| `subscription sync-time` | Pas d'invalidation cache Redis | Compteur frontend gelé ~5 min |

## Test plan

- [ ] Faire une recherche d'emploi → vérifier que `usage_quotas.job_searches_used` s'incrémente en DB
- [ ] Envoyer un message coach → vérifier que le compteur frontend se met à jour immédiatement (pas après 5 min)
- [ ] Utiliser cv_adapt/cover_letter → vérifier compteur frontend à jour
- [ ] Vérifier qu'un user free atteint bien sa limite de 3 recherches/jour