### PR TITLE
fix(quota): per-coach limits + CV/assistant quota tracking

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -419,52 +419,55 @@ async def get_current_user(authorization: str | None = Header(None)) -> dict:
 CurrentUserDep = Annotated[dict, Depends(get_current_user)]
 
 
-def check_assistant_quota(user_id: str) -> None:
+def check_assistant_quota(user_id: str, coach_type: str = "career-coach") -> None:
     """
-    Check if user has remaining assistant messages quota.
+    Check if user has remaining messages for a specific coach type.
+    Uses per-coach quota (10 messages/day per coach for free plan).
     Raises HTTP 429 if quota exceeded.
     """
     try:
         supabase = get_supabase_client()
-        result = supabase.rpc("get_quota_status", {"p_user_id": user_id}).execute()
+        result = supabase.rpc("check_coach_message_quota", {
+            "p_user_id": user_id,
+            "p_coach_type": coach_type,
+        }).execute()
         if not result.data:
             return  # No quota data = allow through
-        for row in result.data:
-            if row.get("feature") == "assistant_messages":
-                if not row.get("has_access", True):
-                    raise HTTPException(
-                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                        detail={
-                            "code": "QUOTA_EXCEEDED",
-                            "feature": "assistant_messages",
-                            "limit": row.get("quota_limit"),
-                            "used": row.get("quota_used"),
-                            "reset_at": str(row.get("reset_at", "")),
-                            "message": "Quota de messages journalier atteint. Passez à un plan supérieur pour continuer."
-                        }
-                    )
-                return
+        row = result.data[0] if result.data else {}
+        if not row.get("has_access", True):
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail={
+                    "code": "QUOTA_EXCEEDED",
+                    "feature": "assistant_messages",
+                    "coach_type": coach_type,
+                    "limit": row.get("quota_limit"),
+                    "used": row.get("quota_used"),
+                    "message": f"Quota de messages atteint pour {coach_type}. Passez a un plan superieur pour continuer."
+                }
+            )
     except HTTPException:
         raise
     except Exception as e:
-        logger.warning(f"[quota] check failed for {user_id}, allowing through: {e}")
+        logger.warning(f"[quota] check_coach({coach_type}) failed for {user_id}, allowing through: {e}")
 
 
-def increment_assistant_messages(user_id: str) -> None:
+def increment_assistant_messages(user_id: str, coach_type: str = "career-coach") -> None:
     """
-    Increment assistant_messages usage counter for today.
+    Increment per-coach message counter for today.
+    Also increments the global assistant_messages counter.
     Best-effort: logs warning on failure, does NOT raise.
     """
     try:
         supabase = get_supabase_client()
-        result = supabase.rpc("increment_usage", {
+        result = supabase.rpc("increment_coach_message", {
             "p_user_id": user_id,
-            "p_feature": "assistant_messages",
+            "p_coach_type": coach_type,
             "p_amount": 1,
         }).execute()
-        logger.info(f"[quota] INCREMENT OK: user={user_id} feature=assistant_messages result={result.data}")
+        logger.info(f"[quota] INCREMENT OK: user={user_id} coach={coach_type} result={result.data}")
     except Exception as e:
-        logger.error(f"[quota] INCREMENT FAILED: user={user_id} feature=assistant_messages error={e}", exc_info=True)
+        logger.error(f"[quota] INCREMENT FAILED: user={user_id} coach={coach_type} error={e}", exc_info=True)
 
 
 async def check_quota(user_id: str, feature: str) -> None:

--- a/backend/src/api/routes/assistant.py
+++ b/backend/src/api/routes/assistant.py
@@ -160,7 +160,9 @@ async def job_scout_chat(
     market insights, and personalized recommendations.
     """
     user_id = current_user["id"]
-    check_assistant_quota(user_id)
+    check_assistant_quota(user_id, "job-scout")
+    increment_assistant_messages(user_id, "job-scout")
+    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -205,8 +207,6 @@ async def job_scout_chat(
         )
 
     update_session_history(request.session_id, request.message, result["response"])
-    increment_assistant_messages(user_id)
-    await invalidate_user_quota_cache(user_id)
 
     return AssistantResponse(
         success=True,
@@ -230,7 +230,9 @@ async def cv_analyzer_chat(
     Can guide users through the CV optimization process step by step.
     """
     user_id = current_user["id"]
-    check_assistant_quota(user_id)
+    check_assistant_quota(user_id, "cv-analyzer")
+    increment_assistant_messages(user_id, "cv-analyzer")
+    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -275,8 +277,6 @@ async def cv_analyzer_chat(
         )
 
     update_session_history(request.session_id, request.message, result["response"])
-    increment_assistant_messages(user_id)
-    await invalidate_user_quota_cache(user_id)
 
     return AssistantResponse(
         success=True,
@@ -300,7 +300,9 @@ async def cv_adapter_chat(
     Guides users through the adaptation process with strategic recommendations.
     """
     user_id = current_user["id"]
-    check_assistant_quota(user_id)
+    check_assistant_quota(user_id, "cv-adapter")
+    increment_assistant_messages(user_id, "cv-adapter")
+    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -345,8 +347,6 @@ async def cv_adapter_chat(
         )
 
     update_session_history(request.session_id, request.message, result["response"])
-    increment_assistant_messages(user_id)
-    await invalidate_user_quota_cache(user_id)
 
     return AssistantResponse(
         success=True,
@@ -372,7 +372,9 @@ async def interview_sim_chat(
     """
     user_id = current_user["id"]
     _require_feature_flag_sync(user_id, "interview_sim", "Le simulateur d'entretien necessite un plan superieur.")
-    check_assistant_quota(user_id)
+    check_assistant_quota(user_id, "interview-sim")
+    increment_assistant_messages(user_id, "interview-sim")
+    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -417,8 +419,6 @@ async def interview_sim_chat(
         )
 
     update_session_history(request.session_id, request.message, result["response"])
-    increment_assistant_messages(user_id)
-    await invalidate_user_quota_cache(user_id)
 
     return AssistantResponse(
         success=True,
@@ -507,7 +507,9 @@ async def attach_cv_to_chat(
             detail=f"Fichier trop volumineux ({len(pdf_bytes) / 1024 / 1024:.1f}MB, max 10MB)",
         )
 
-    check_assistant_quota(user_id)
+    check_assistant_quota(user_id, assistant_type)
+    increment_assistant_messages(user_id, assistant_type)
+    await invalidate_user_quota_cache(user_id)
 
     try:
         # ── Étape 1 : Extraction texte ────────────────────────────────────────
@@ -565,8 +567,6 @@ async def attach_cv_to_chat(
         # ── Étape 5 : Persister dans l'historique de session ─────────────────
         # CV (user) + réponse IA (assistant) → stockés ensemble.
         # Tous les tours suivants verront le CV via get_session_history().
-        increment_assistant_messages(user_id)
-        await invalidate_user_quota_cache(user_id)
         update_session_history(session_id, cv_message_content, initial_response)
 
         logger.info(

--- a/backend/src/api/routes/cv_analysis.py
+++ b/backend/src/api/routes/cv_analysis.py
@@ -213,6 +213,10 @@ async def analyze_cv_async(
     # ✅ CHECK QUOTA BEFORE PROCESSING — blocks if daily limit exceeded
     check_cv_analysis_quota(user_id)
 
+    # ✅ INCREMENT QUOTA IMMEDIATELY (callback Modal n'est pas garanti)
+    await increment_user_cv_quota(user_id)
+    await invalidate_user_quota_cache(user_id)
+
     return await process_cv_async(
         user_id=user_id,
         file=file,
@@ -369,13 +373,12 @@ async def cv_analysis_callback(
 
         logger.info(f"[CALLBACK] Received: cv_id={cv_id}, user_id={user_id}, status={status}")
 
-        # Increment quota only when processing succeeds
+        # Quota already incremented in POST /async — just log and re-invalidate cache
         if status == "completed" and user_id:
-            success = await increment_user_cv_quota(user_id)
             await invalidate_user_quota_cache(user_id)
             logger.info(
-                f"[CALLBACK] ✅ Incremented cv_analysis quota for user {user_id} "
-                f"after successful CV processing: {cv_id} (success={success})"
+                f"[CALLBACK] ✅ CV completed for user {user_id}, "
+                f"quota already tracked in /async: {cv_id}"
             )
             # Tracking événement analyse CV (best-effort)
             if supabase_client:
@@ -423,7 +426,7 @@ async def cv_analysis_callback(
                 logger.warning(f"[CALLBACK] Admin alert failed: {alert_err}")
             return {
                 "success": True,
-                "quota_incremented": success,
+                "quota_incremented": True,
                 "cv_id": cv_id
             }
         elif status == "failed":


### PR DESCRIPTION
## Summary
- **Per-coach message limits**: Each coach type (job-scout, cv-analyzer, cv-adapter, interview-sim) now has its own independent daily message limit (10/day for free plan) via `increment_coach_message` RPC
- **CV analysis quota fix**: Increment moved from Modal callback (never triggered) to POST /async before processing
- **Assistant quota fix**: Increment moved before ARQ queue bifurcation so queued requests also consume quota

## Includes previous commit
- `searchJobs()` auth token fix (quotas were never tracked because Authorization header was missing)

## Test plan
- [ ] Search jobs → verify `job_searches_used` increments in `usage_quotas`
- [ ] Send assistant message → verify `assistant_messages_by_coach` JSONB shows per-coach count
- [ ] Analyze CV → verify `cv_analyses_used` increments
- [ ] Free user hits 10 messages on one coach → blocked on that coach, can still use others