### PR TITLE
fix(referrals+quota+footer): race conditions, quota fixes and Instagram footer

### DIFF
--- a/frontend-next/src/components/layout/footer.tsx
+++ b/frontend-next/src/components/layout/footer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { Linkedin } from "lucide-react";
+import { Linkedin, Instagram } from "lucide-react";
 
 const PRODUCT_LINKS = [
   { href: "/cv-analysis", key: "cvAnalysis" },
@@ -49,6 +49,15 @@ export function Footer() {
                 aria-label="LinkedIn"
               >
                 <Linkedin className="w-4 h-4" />
+              </a>
+              <a
+                href="https://www.instagram.com/huntzenjobs?igsh=MXNmZTNtZDUwYWxpdg=="
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white/70 hover:text-white transition-colors"
+                aria-label="Instagram"
+              >
+                <Instagram className="w-4 h-4" />
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- **fix(quota)**: per-coach message limits + CV quota increment before processing
- **feat(footer)**: ajout du lien Instagram (@huntzenjobs) à côté de LinkedIn dans le footer

## Changes

- `fix(quota)`: limites de messages par coach et incrément quota CV avant traitement
- `feat(footer)`: icône Instagram avec lien `https://www.instagram.com/huntzenjobs` dans le footer

## Test plan

- [ ] Vérifier que le footer affiche bien les icônes LinkedIn + Instagram côte à côte
- [ ] Vérifier que le lien Instagram ouvre le bon profil
- [ ] Vérifier que les quotas CV s'incrémentent correctement avant traitement