### PR TITLE
fix(referral): RC-1/RC-2/RC-3 — atomic rewards, idempotent tiers, correct columns

### DIFF
--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -214,25 +214,6 @@ async def _auto_apply_tier_rewards(supabase, referrer_id: str, total_signups: in
             if tier.get("friends", 0) != total_signups:
                 continue
 
-            # Vérifier si ce palier a déjà été récompensé (idempotence)
-            try:
-                existing = (
-                    supabase.table("referral_rewards")
-                    .select("id, reward_value, applied")
-                    .eq("referrer_id", referrer_id)
-                    .execute()
-                )
-                already_applied = False
-                for row in (existing.data or []):
-                    rv = row.get("reward_value") or {}
-                    if rv.get("tier_index") == tier_index and row.get("applied"):
-                        already_applied = True
-                        break
-                if already_applied:
-                    continue
-            except Exception:
-                pass
-
             # Récupérer un signup_id pour la FK
             ref_res = (
                 supabase.table("referrals")
@@ -258,15 +239,27 @@ async def _auto_apply_tier_rewards(supabase, referrer_id: str, total_signups: in
             if not signup_id:
                 continue
 
-            # Insérer la récompense (applied=False)
-            reward_res = supabase.table("referral_rewards").insert({
-                "referral_signup_id": signup_id,
-                "referrer_id": referrer_id,
-                "reward_type": tier.get("reward_type", "quota_bonus"),
-                "reward_value": {**tier, "tier_index": tier_index},
-                "applied": False,
-            }).execute()
-            reward_id = reward_res.data[0]["id"] if reward_res.data else None
+            # Insérer la récompense avec idempotence DB-level (ON CONFLICT DO NOTHING).
+            # idx_referral_rewards_tier_unique garantit l'unicité (referrer_id, tier_index).
+            reward_res = supabase.table("referral_rewards").upsert(
+                {
+                    "referral_signup_id": signup_id,
+                    "referrer_id": referrer_id,
+                    "reward_type": tier.get("reward_type", "quota_bonus"),
+                    "reward_value": {**tier, "tier_index": tier_index},
+                    "applied": False,
+                },
+                ignore_duplicates=True,
+            ).execute()
+
+            # ON CONFLICT déclenché → le palier a déjà été récompensé
+            if not reward_res.data:
+                logger.info(
+                    f"[REFERRAL] Tier {tier_index} reward already exists for {referrer_id} — skipped"
+                )
+                continue
+
+            reward_id = reward_res.data[0]["id"]
 
             # Appliquer la récompense
             reward_type_str = tier.get("reward_type", "quota_bonus")

--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -7,6 +7,7 @@ POST /api/referrals/track-click     — increment click counter (unauthenticated
 POST /api/referrals/register        — link a newly created user to a referral code
 """
 
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -239,27 +240,29 @@ async def _auto_apply_tier_rewards(supabase, referrer_id: str, total_signups: in
             if not signup_id:
                 continue
 
-            # Insérer la récompense avec idempotence DB-level (ON CONFLICT DO NOTHING).
-            # idx_referral_rewards_tier_unique garantit l'unicité (referrer_id, tier_index).
-            reward_res = supabase.table("referral_rewards").upsert(
+            # Insérer la récompense avec idempotence DB-level via RPC.
+            # insert_tier_reward() utilise ON CONFLICT DO NOTHING (sans cible)
+            # → attrape idx_referral_rewards_tier_unique correctement.
+            # PostgREST upsert cible ON CONFLICT (id) par défaut, ce qui ne
+            # couvre PAS l'index fonctionnel JSONB — d'où le passage par RPC.
+            reward_value = {**tier, "tier_index": tier_index}
+            reward_result = supabase.rpc(
+                "insert_tier_reward",
                 {
-                    "referral_signup_id": signup_id,
-                    "referrer_id": referrer_id,
-                    "reward_type": tier.get("reward_type", "quota_bonus"),
-                    "reward_value": {**tier, "tier_index": tier_index},
-                    "applied": False,
+                    "p_referral_signup_id": signup_id,
+                    "p_referrer_id": referrer_id,
+                    "p_reward_type": tier.get("reward_type", "quota_bonus"),
+                    "p_reward_value": json.dumps(reward_value),
                 },
-                ignore_duplicates=True,
             ).execute()
 
-            # ON CONFLICT déclenché → le palier a déjà été récompensé
-            if not reward_res.data:
+            # RPC retourne NULL si ON CONFLICT DO NOTHING a été déclenché
+            reward_id = reward_result.data
+            if not reward_id:
                 logger.info(
                     f"[REFERRAL] Tier {tier_index} reward already exists for {referrer_id} — skipped"
                 )
                 continue
-
-            reward_id = reward_res.data[0]["id"]
 
             # Appliquer la récompense
             reward_type_str = tier.get("reward_type", "quota_bonus")

--- a/backend/src/services/referrals.py
+++ b/backend/src/services/referrals.py
@@ -5,7 +5,7 @@ Called from handle_checkout_completed() in stripe.py.
 """
 
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
 
@@ -81,32 +81,21 @@ async def apply_referral_reward(
 
 
 async def _apply_free_days(supabase_client, referrer_id: str, reward_value: dict) -> bool:
-    """Extend the referrer's active subscription by N days."""
+    """Extend the referrer's active subscription by N days (atomic UPDATE)."""
     try:
         # Support both old format {"days": 7} and new format {"reward_value": 7}
         days = int(reward_value.get("days") or reward_value.get("reward_value") or 7)
 
-        sub_res = supabase_client.table("user_subscriptions") \
-            .select("id, current_period_end") \
-            .eq("user_id", referrer_id) \
-            .eq("status", "active") \
-            .order("created_at", desc=True) \
-            .limit(1) \
-            .execute()
+        result = supabase_client.rpc(
+            "extend_subscription_days",
+            {"p_user_id": referrer_id, "p_days": days},
+        ).execute()
 
-        if not sub_res.data:
-            logger.warning(f"[REFERRAL] Referrer {referrer_id} has no active subscription — free_days skipped")
+        if not result.data:
+            logger.warning(
+                f"[REFERRAL] Referrer {referrer_id} has no active subscription — free_days skipped"
+            )
             return False
-
-        sub = sub_res.data[0]
-        current_end_str = sub["current_period_end"].replace("Z", "+00:00")
-        current_end = datetime.fromisoformat(current_end_str)
-        new_end = current_end + timedelta(days=days)
-
-        supabase_client.table("user_subscriptions").update({
-            "current_period_end": new_end.isoformat(),
-            "updated_at": datetime.now(UTC).isoformat(),
-        }).eq("id", sub["id"]).execute()
 
         return True
 

--- a/backend/src/services/referrals.py
+++ b/backend/src/services/referrals.py
@@ -105,36 +105,25 @@ async def _apply_free_days(supabase_client, referrer_id: str, reward_value: dict
 
 
 async def _apply_quota_bonus(supabase_client, referrer_id: str, reward_value: dict) -> bool:
-    """Add bonus quota credits to the referrer for today."""
+    """Add bonus quota credits to the referrer via DB-level decrement of used counters."""
     try:
-        from datetime import date
-        today = date.today().isoformat()
+        cv_bonus = int(reward_value.get("cv_analyses", 0))
+        coach_bonus = int(reward_value.get("coach_seconds", 0))
+        jobs_bonus = int(reward_value.get("job_searches", 0))
 
-        quota_res = supabase_client.table("usage_quotas") \
-            .select("*") \
-            .eq("user_id", referrer_id) \
-            .eq("date", today) \
-            .execute()
+        if not (cv_bonus or coach_bonus or jobs_bonus):
+            logger.info(f"[REFERRAL] No quota bonus values for {referrer_id} — skipped")
+            return True
 
-        if not quota_res.data:
-            logger.info(f"[REFERRAL] No quota record today for {referrer_id} — bonus skipped")
-            return True  # Not a hard failure
-
-        quota = quota_res.data[0]
-        updates = {}
-
-        if bonus_cv := int(reward_value.get("cv_analyses", 0)):
-            updates["cv_analyses_remaining"] = (quota.get("cv_analyses_remaining") or 0) + bonus_cv
-        if bonus_coach := int(reward_value.get("coach_seconds", 0)):
-            updates["coach_seconds_remaining"] = (quota.get("coach_seconds_remaining") or 0) + bonus_coach
-        if bonus_jobs := int(reward_value.get("job_searches", 0)):
-            updates["job_searches_remaining"] = (quota.get("job_searches_remaining") or 0) + bonus_jobs
-
-        if updates:
-            supabase_client.table("usage_quotas").update(updates) \
-                .eq("user_id", referrer_id) \
-                .eq("date", today) \
-                .execute()
+        supabase_client.rpc(
+            "apply_quota_bonus",
+            {
+                "p_user_id": referrer_id,
+                "p_cv_analyses": cv_bonus,
+                "p_coach_seconds": coach_bonus,
+                "p_job_searches": jobs_bonus,
+            },
+        ).execute()
 
         return True
 

--- a/supabase/migrations/20260325000001_atomic_referral_rewards.sql
+++ b/supabase/migrations/20260325000001_atomic_referral_rewards.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- ATOMIC REFERRAL REWARDS
+-- ============================================================
+-- RC-2: extend_subscription_days — UPDATE atomique sans SELECT préalable
+-- RC-3: idx_referral_rewards_tier_unique — contrainte UNIQUE pour ON CONFLICT
+-- RC-1: apply_quota_bonus — décrémente les compteurs used pour donner du bonus
+-- ============================================================
+
+-- ============================================================
+-- RC-2: Extend subscription by N days (atomic)
+-- Remplace le SELECT+UPDATE non atomique dans _apply_free_days.
+-- ============================================================
+CREATE OR REPLACE FUNCTION extend_subscription_days(
+  p_user_id UUID,
+  p_days    INTEGER
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE user_subscriptions
+  SET current_period_end = current_period_end + (p_days || ' days')::INTERVAL,
+      updated_at = NOW()
+  WHERE user_id = p_user_id
+    AND status = 'active';
+  RETURN FOUND;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION extend_subscription_days(UUID, INTEGER) TO service_role;
+
+-- ============================================================
+-- RC-3: Unique index on (referrer_id, tier_index) in referral_rewards
+-- Permet ON CONFLICT DO NOTHING pour éliminer la race condition SELECT+INSERT.
+-- tier_index est stocké dans reward_value JSONB.
+-- ============================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_referral_rewards_tier_unique
+ON referral_rewards (
+  referrer_id,
+  ((reward_value->>'tier_index')::integer)
+)
+WHERE reward_value->>'tier_index' IS NOT NULL;
+
+-- ============================================================
+-- RC-1: Apply quota bonus (decrement used counters)
+-- Remplace l'UPDATE sur des colonnes inexistantes (_remaining).
+-- Utilise GREATEST(0, ...) pour ne jamais passer sous zéro.
+-- ============================================================
+CREATE OR REPLACE FUNCTION apply_quota_bonus(
+  p_user_id       UUID,
+  p_cv_analyses   INTEGER DEFAULT 0,
+  p_coach_seconds INTEGER DEFAULT 0,
+  p_job_searches  INTEGER DEFAULT 0
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF p_cv_analyses = 0 AND p_coach_seconds = 0 AND p_job_searches = 0 THEN
+    RETURN TRUE;
+  END IF;
+
+  INSERT INTO usage_quotas (
+    user_id, quota_date,
+    cv_analyses_used, coach_seconds_used, job_searches_used
+  )
+  VALUES (p_user_id, CURRENT_DATE, 0, 0, 0)
+  ON CONFLICT (user_id, quota_date) DO UPDATE SET
+    cv_analyses_used   = GREATEST(0, usage_quotas.cv_analyses_used   - p_cv_analyses),
+    coach_seconds_used = GREATEST(0, usage_quotas.coach_seconds_used - p_coach_seconds),
+    job_searches_used  = GREATEST(0, usage_quotas.job_searches_used  - p_job_searches),
+    updated_at         = NOW();
+
+  RETURN TRUE;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION apply_quota_bonus(UUID, INTEGER, INTEGER, INTEGER) TO service_role;

--- a/supabase/migrations/20260325000001_atomic_referral_rewards.sql
+++ b/supabase/migrations/20260325000001_atomic_referral_rewards.sql
@@ -43,6 +43,40 @@ ON referral_rewards (
 WHERE reward_value->>'tier_index' IS NOT NULL;
 
 -- ============================================================
+-- RC-3 bis: insert_tier_reward — INSERT avec ON CONFLICT DO NOTHING nu.
+-- PostgREST cible ON CONFLICT (id) par défaut, ce qui ne couvre PAS
+-- l'index fonctionnel idx_referral_rewards_tier_unique.
+-- Cette RPC utilise ON CONFLICT DO NOTHING sans cible → attrape TOUTES
+-- les contraintes unique, y compris l'index fonctionnel sur JSONB.
+-- Retourne l'UUID du reward créé, ou NULL si doublon.
+-- ============================================================
+CREATE OR REPLACE FUNCTION insert_tier_reward(
+  p_referral_signup_id UUID,
+  p_referrer_id        UUID,
+  p_reward_type        TEXT,
+  p_reward_value       JSONB
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_reward_id UUID;
+BEGIN
+  INSERT INTO referral_rewards (
+    referral_signup_id, referrer_id, reward_type, reward_value, applied
+  )
+  VALUES (p_referral_signup_id, p_referrer_id, p_reward_type, p_reward_value, FALSE)
+  ON CONFLICT DO NOTHING
+  RETURNING id INTO v_reward_id;
+
+  RETURN v_reward_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION insert_tier_reward(UUID, UUID, TEXT, JSONB) TO service_role;
+
+-- ============================================================
 -- RC-1: Apply quota bonus (decrement used counters)
 -- Remplace l'UPDATE sur des colonnes inexistantes (_remaining).
 -- Utilise GREATEST(0, ...) pour ne jamais passer sous zéro.


### PR DESCRIPTION
## Summary
- **RC-2**: `_apply_free_days` atomique via RPC `extend_subscription_days` (plus de SELECT+UPDATE)
- **RC-3**: Tier rewards idempotents via RPC `insert_tier_reward` + unique index fonctionnel `(referrer_id, tier_index)` — `ON CONFLICT DO NOTHING` correct meme avec index JSONB
- **RC-1**: `_apply_quota_bonus` corrige — colonnes `_remaining` inexistantes remplacees par RPC `apply_quota_bonus` (decrement `_used` avec `GREATEST(0, ...)`)

## Migration
`20260325000001_atomic_referral_rewards.sql` — 3 RPCs + 1 unique index. **Appliquer AVANT le deploy backend.**

## Test plan
- [ ] Appliquer migration sur Supabase prod
- [ ] Deploy backend sur Railway
- [ ] Verifier avec wissemkarboub@gmail.com : `/api/referrals/boost-status`
- [ ] Tester un signup referral pour valider tier reward idempotent