### PR TITLE
fix(quota): RC-4/5/6/7 — types frontend + quota PDF + increment après succès

### DIFF
--- a/backend/src/api/routes/assistant.py
+++ b/backend/src/api/routes/assistant.py
@@ -161,8 +161,6 @@ async def job_scout_chat(
     """
     user_id = current_user["id"]
     check_assistant_quota(user_id, "job-scout")
-    increment_assistant_messages(user_id, "job-scout")
-    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -184,6 +182,8 @@ async def job_scout_chat(
                     language=request.language,
                     history=history,
                 )
+                increment_assistant_messages(user_id, "job-scout")
+                await invalidate_user_quota_cache(user_id)
                 logger.info(f"[assistant/job-scout] ARQ queued — active={active} job={job.job_id}")
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
@@ -206,6 +206,8 @@ async def job_scout_chat(
             detail=result.get("error", "Job Scout error"),
         )
 
+    increment_assistant_messages(user_id, "job-scout")
+    await invalidate_user_quota_cache(user_id)
     update_session_history(request.session_id, request.message, result["response"])
 
     return AssistantResponse(
@@ -231,8 +233,6 @@ async def cv_analyzer_chat(
     """
     user_id = current_user["id"]
     check_assistant_quota(user_id, "cv-analyzer")
-    increment_assistant_messages(user_id, "cv-analyzer")
-    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -254,6 +254,8 @@ async def cv_analyzer_chat(
                     language=request.language,
                     history=history,
                 )
+                increment_assistant_messages(user_id, "cv-analyzer")
+                await invalidate_user_quota_cache(user_id)
                 logger.info(f"[assistant/cv-analyzer] ARQ queued — active={active} job={job.job_id}")
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
@@ -276,6 +278,8 @@ async def cv_analyzer_chat(
             detail=result.get("error", "CV Analyzer error"),
         )
 
+    increment_assistant_messages(user_id, "cv-analyzer")
+    await invalidate_user_quota_cache(user_id)
     update_session_history(request.session_id, request.message, result["response"])
 
     return AssistantResponse(
@@ -301,8 +305,6 @@ async def cv_adapter_chat(
     """
     user_id = current_user["id"]
     check_assistant_quota(user_id, "cv-adapter")
-    increment_assistant_messages(user_id, "cv-adapter")
-    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -324,6 +326,8 @@ async def cv_adapter_chat(
                     language=request.language,
                     history=history,
                 )
+                increment_assistant_messages(user_id, "cv-adapter")
+                await invalidate_user_quota_cache(user_id)
                 logger.info(f"[assistant/cv-adapter] ARQ queued — active={active} job={job.job_id}")
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
@@ -346,6 +350,8 @@ async def cv_adapter_chat(
             detail=result.get("error", "CV Adapter error"),
         )
 
+    increment_assistant_messages(user_id, "cv-adapter")
+    await invalidate_user_quota_cache(user_id)
     update_session_history(request.session_id, request.message, result["response"])
 
     return AssistantResponse(
@@ -373,8 +379,6 @@ async def interview_sim_chat(
     user_id = current_user["id"]
     _require_feature_flag_sync(user_id, "interview_sim", "Le simulateur d'entretien necessite un plan superieur.")
     check_assistant_quota(user_id, "interview-sim")
-    increment_assistant_messages(user_id, "interview-sim")
-    await invalidate_user_quota_cache(user_id)
 
     history = get_session_history(request.session_id)
 
@@ -396,6 +400,8 @@ async def interview_sim_chat(
                     language=request.language,
                     history=history,
                 )
+                increment_assistant_messages(user_id, "interview-sim")
+                await invalidate_user_quota_cache(user_id)
                 logger.info(f"[assistant/interview-sim] ARQ queued — active={active} job={job.job_id}")
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
@@ -418,6 +424,8 @@ async def interview_sim_chat(
             detail=result.get("error", "Interview Simulator error"),
         )
 
+    increment_assistant_messages(user_id, "interview-sim")
+    await invalidate_user_quota_cache(user_id)
     update_session_history(request.session_id, request.message, result["response"])
 
     return AssistantResponse(
@@ -508,8 +516,6 @@ async def attach_cv_to_chat(
         )
 
     check_assistant_quota(user_id, assistant_type)
-    increment_assistant_messages(user_id, assistant_type)
-    await invalidate_user_quota_cache(user_id)
 
     try:
         # ── Étape 1 : Extraction texte ────────────────────────────────────────
@@ -573,6 +579,9 @@ async def attach_cv_to_chat(
             f"[attach-cv] Done — session={session_id[:8]}... "
             f"cv={len(cv_text)}chars structured={bool(cv_structured)}"
         )
+
+        increment_assistant_messages(user_id, assistant_type)
+        await invalidate_user_quota_cache(user_id)
 
         return {
             "success": True,

--- a/backend/src/api/routes/cv_adapter.py
+++ b/backend/src/api/routes/cv_adapter.py
@@ -334,6 +334,11 @@ async def adapt_cv_to_pdf(
 
     Returns a downloadable PDF file with the adapted CV.
     """
+    # Check and increment cv_adapt quota (same as /adapt)
+    user_id = get_user_id_from_token(authorization)
+    if user_id:
+        await _check_and_increment_quota(user_id, "cv_adapt")
+
     # Resolve CV text — from file or raw text
     if file and file.filename:
         cv_text = await _extract_cv_text_from_file(file)

--- a/frontend-next/src/components/freemium/usage-counter.tsx
+++ b/frontend-next/src/components/freemium/usage-counter.tsx
@@ -76,6 +76,36 @@ const featureConfig: Record<FeatureType, FeatureConfig> = {
         ? t("features.unlimitedShort")
         : `${value}/${max}${t("perDay")}`,
   },
+  cv_adapt: {
+    icon: <FileText className="w-4 h-4" aria-hidden="true" />,
+    labelKey: "features.cvAdapt.label",
+    maxLabel: (max, t) =>
+      max === Infinity ? t("features.unlimited") : `/${max}${t("perDay")}`,
+    formatValue: (value, max, t) =>
+      max === Infinity
+        ? t("features.unlimitedShort")
+        : `${value}/${max}${t("perDay")}`,
+  },
+  cover_letter: {
+    icon: <FileText className="w-4 h-4" aria-hidden="true" />,
+    labelKey: "features.coverLetter.label",
+    maxLabel: (max, t) =>
+      max === Infinity ? t("features.unlimited") : `/${max}${t("perDay")}`,
+    formatValue: (value, max, t) =>
+      max === Infinity
+        ? t("features.unlimitedShort")
+        : `${value}/${max}${t("perDay")}`,
+  },
+  coach: {
+    icon: <Clock className="w-4 h-4" aria-hidden="true" />,
+    labelKey: "features.coach.label",
+    maxLabel: (max, t) =>
+      max === Infinity ? t("features.unlimited") : `/${max}${t("perDay")}`,
+    formatValue: (value, max, t) =>
+      max === Infinity
+        ? t("features.unlimitedShort")
+        : `${value}/${max}${t("perDay")}`,
+  },
 };
 
 export function UsageCounter({

--- a/frontend-next/src/hooks/use-freemium-limits.ts
+++ b/frontend-next/src/hooks/use-freemium-limits.ts
@@ -12,7 +12,10 @@ export type FeatureType =
   | "job_view"
   | "cv_analysis"
   | "assistant_messages"
-  | "recruiter_search";
+  | "recruiter_search"
+  | "cv_adapt"
+  | "cover_letter"
+  | "coach";
 
 // ── Plan limits — Dynamic from Supabase via /api/public/plans ──────────────
 // PLAN_LIMITS is a Proxy that reads from the API cache (localStorage).

--- a/frontend-next/src/hooks/use-subscription-api.ts
+++ b/frontend-next/src/hooks/use-subscription-api.ts
@@ -40,6 +40,8 @@ interface QuotasData {
   assistant_messages: QuotaData;
   job_view?: QuotaData;
   recruiter_search?: QuotaData;
+  cv_adapt?: QuotaData;
+  cover_letter?: QuotaData;
 }
 
 interface SavedJobsQuota {


### PR DESCRIPTION
## Summary
- **RC-4**: `cv_adapt` et `cover_letter` ajoutés à `QuotasData`
- **RC-5**: `cv_adapt`, `cover_letter`, `coach` ajoutés à `FeatureType` + `usage-counter.tsx`
- **RC-6**: Quota check ajouté sur `/api/cv-adapter/adapt/pdf` (manquant)
- **RC-7**: `increment_assistant_messages` déplacé APRÈS succès LLM (5 endpoints)

## Test plan
- [ ] TSC clean, ruff clean
- [ ] Vérifier que les quotas s'affichent pour cv_adapt/cover_letter
- [ ] Vérifier que /adapt/pdf décrémente le quota
- [ ] Vérifier qu'un échec LLM ne consomme pas de crédit assistant