### PR TITLE
fix(admin): page_* feature toggles in user overrides

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -2496,6 +2496,10 @@ ALL_FEATURES = [
     "advanced_filters", "favorites", "ats_score", "pdf_export",
     "cv_history", "interview_sim", "email_alerts", "personalized_advice",
     "coach_history", "cover_letter", "branding",
+    # Page access overrides (per-user)
+    "page_assistant", "page_jobs", "page_saved_jobs", "page_cv_analysis",
+    "page_documents", "page_candidatures", "page_expat", "page_salons",
+    "page_profile", "page_recruiter_contact", "page_referral",
 ]
 
 


### PR DESCRIPTION
## Summary
- Le toggle admin pour `page_saved_jobs` (et toutes les features `page_*`) echouait silencieusement avec HTTP 400 car `ALL_FEATURES` dans `admin.py` ne contenait que les 11 features originales
- Ajoute les 11 features `page_*` (introduites par migration `20260322000002`) a la whitelist

## Test plan
- [ ] Ouvrir le panel admin > detail utilisateur > feature overrides
- [ ] Toggle `page_saved_jobs` → doit fonctionner (pas de 400)
- [ ] Verifier que le toggle persiste apres refresh