### PR TITLE
fix(ux): conversion popup on quota exceeded + admin page toggles

### DIFF
--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -49,7 +49,11 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-import { huntzenApi, type Job } from "@/lib/api/huntzen-client";
+import {
+  huntzenApi,
+  isQuotaExceededError,
+  type Job,
+} from "@/lib/api/huntzen-client";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSubscription } from "@/contexts/subscription-context";
 import { useOptionalAuth } from "@/contexts/auth-context";
@@ -701,34 +705,43 @@ export default function JobsPage() {
         throw new Error(t("error.fillRequired"));
       }
 
-      const data = await huntzenApi.searchJobs(
-        {
-          job_title: jobSearchParams.query,
-          country_code: jobSearchParams.country,
-          city: jobSearchParams.location,
-          contract_type: effectiveContractType,
-          contract_types: effectiveContractTypes,
-          work_days: effectiveWorkDays,
-          work_schedule: effectiveWorkSchedule,
-          includeRemote: jobSearchParams.includeRemote,
-          from_history: jobSearchParams.fromHistory,
-          // Advanced filters (Premium feature)
-          industries: advancedFilters.industries?.join(","),
-          keywords: advancedFilters.keywords?.join(","),
-          experienceLevel: advancedFilters.experienceLevel,
-          salaryMin: advancedFilters.salaryMin,
-          salaryMax: advancedFilters.salaryMax,
-          companySize: advancedFilters.companySize,
-        },
-        auth?.session?.access_token,
-      );
+      try {
+        const data = await huntzenApi.searchJobs(
+          {
+            job_title: jobSearchParams.query,
+            country_code: jobSearchParams.country,
+            city: jobSearchParams.location,
+            contract_type: effectiveContractType,
+            contract_types: effectiveContractTypes,
+            work_days: effectiveWorkDays,
+            work_schedule: effectiveWorkSchedule,
+            includeRemote: jobSearchParams.includeRemote,
+            from_history: jobSearchParams.fromHistory,
+            // Advanced filters (Premium feature)
+            industries: advancedFilters.industries?.join(","),
+            keywords: advancedFilters.keywords?.join(","),
+            experienceLevel: advancedFilters.experienceLevel,
+            salaryMin: advancedFilters.salaryMin,
+            salaryMax: advancedFilters.salaryMax,
+            companySize: advancedFilters.companySize,
+          },
+          auth?.session?.access_token,
+        );
 
-      return data;
+        return data;
+      } catch (err) {
+        if (isQuotaExceededError(err)) {
+          searchLimitPopup.open();
+          return null;
+        }
+        throw err;
+      }
     },
     enabled: !!jobSearchParams,
     staleTime: 1000 * 60 * 30, // 30 min — results stay fresh
     gcTime: 1000 * 60 * 60, // 1h — keep in memory for back navigation
-    retry: 1,
+    retry: (failureCount, error) =>
+      !isQuotaExceededError(error) && failureCount < 1,
   });
 
   /**

--- a/frontend-next/src/lib/api/huntzen-client.ts
+++ b/frontend-next/src/lib/api/huntzen-client.ts
@@ -1,5 +1,27 @@
 import type { CvData } from "@/components/cv-builder/types";
 
+/** Structured 429 quota exceeded detail from backend */
+export interface QuotaDetail {
+  code: "QUOTA_EXCEEDED";
+  feature: string;
+  limit: number;
+  used: number;
+  reset_at?: string;
+  message?: string;
+}
+
+export interface QuotaExceededError extends Error {
+  quotaDetail: QuotaDetail;
+}
+
+export function isQuotaExceededError(err: unknown): err is QuotaExceededError {
+  return (
+    err instanceof Error &&
+    err.message === "QUOTA_EXCEEDED" &&
+    "quotaDetail" in err
+  );
+}
+
 /** Context about a job passed to the interview simulator */
 export interface JobContext {
   title?: string;
@@ -143,7 +165,30 @@ class HuntzenApiClient {
     });
 
     if (!response.ok) {
-      throw new Error(`API Error: ${response.status} ${response.statusText}`);
+      let detail: unknown;
+      try {
+        const body = await response.json();
+        detail = body?.detail;
+      } catch {
+        // body not JSON
+      }
+
+      if (
+        response.status === 429 &&
+        detail &&
+        typeof detail === "object" &&
+        (detail as Record<string, unknown>).code === "QUOTA_EXCEEDED"
+      ) {
+        const err = new Error("QUOTA_EXCEEDED");
+        (err as QuotaExceededError).quotaDetail = detail as QuotaDetail;
+        throw err;
+      }
+
+      throw new Error(
+        typeof detail === "string"
+          ? detail
+          : `API Error: ${response.status} ${response.statusText}`,
+      );
     }
 
     return response.json();


### PR DESCRIPTION
## Summary
- **429 → conversion popup** : Au lieu d'afficher "API Error: 429" quand le quota job search est depasse, le frontend parse le detail structure du backend et ouvre la popup de conversion (upgrade plan)
- **Admin page toggles** : Les 11 features `page_*` sont ajoutees a `ALL_FEATURES` pour permettre aux admins de toggler l'acces aux pages par utilisateur

## Test plan
- [ ] Epuiser le quota job search → la popup de conversion s'affiche (pas d'erreur 429)
- [ ] Admin > detail user > toggle page_saved_jobs → fonctionne
- [ ] React Query ne retry pas sur les erreurs quota