### PR TITLE
feat(admin): conversion popups DB + auto wording generation

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -3889,3 +3889,244 @@ async def test_all_emails(
         "to": to,
         "details": results,
     }
+
+
+# ============================================================
+# CONVERSION POPUP CONFIGS
+# ============================================================
+
+@router.get("/conversion-popups")
+async def list_conversion_popups(admin: AdminUserDep) -> list[dict[str, Any]]:
+    """List all conversion popup configs."""
+    supabase = get_supabase_client()
+    result = supabase.table("conversion_popup_configs").select("*").order("sort_order").execute()
+    return result.data or []
+
+
+@router.post("/conversion-popups")
+async def create_conversion_popup(
+    body: dict[str, Any],
+    admin: AdminUserDep,
+) -> dict[str, Any]:
+    """Create a new conversion popup config."""
+    supabase = get_supabase_client()
+    required = {"trigger_id", "target_plan", "title", "body", "primary_cta"}
+    if not required.issubset(body.keys()):
+        raise HTTPException(status_code=400, detail=f"Missing required fields: {required - body.keys()}")
+
+    allowed = {
+        "trigger_id", "source_plans", "target_plan", "feature_trigger",
+        "title", "body", "primary_cta", "secondary_cta", "price_override",
+        "discount_percent", "coupon_trigger", "is_active", "sort_order",
+    }
+    data = {k: v for k, v in body.items() if k in allowed}
+    result = supabase.table("conversion_popup_configs").insert(data).execute()
+    _log_admin_action(supabase, admin["id"], "admin.popup_created", None, {"trigger_id": data.get("trigger_id")})
+    return (result.data or [{}])[0]
+
+
+@router.patch("/conversion-popups/{popup_id}")
+async def update_conversion_popup(
+    popup_id: str,
+    body: dict[str, Any],
+    admin: AdminUserDep,
+) -> dict[str, Any]:
+    """Update a conversion popup config."""
+    supabase = get_supabase_client()
+    allowed = {
+        "trigger_id", "source_plans", "target_plan", "feature_trigger",
+        "title", "body", "primary_cta", "secondary_cta", "price_override",
+        "discount_percent", "coupon_trigger", "is_active", "sort_order",
+    }
+    data = {k: v for k, v in body.items() if k in allowed}
+    if not data:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+
+    data["updated_at"] = datetime.now(UTC).isoformat()
+    supabase.table("conversion_popup_configs").update(data).eq("id", popup_id).execute()
+    _log_admin_action(supabase, admin["id"], "admin.popup_updated", None, {"popup_id": popup_id, "fields": list(data.keys())})
+    return {"success": True}
+
+
+@router.delete("/conversion-popups/{popup_id}")
+async def delete_conversion_popup(
+    popup_id: str,
+    admin: AdminUserDep,
+) -> dict[str, Any]:
+    """Delete a conversion popup config."""
+    supabase = get_supabase_client()
+    supabase.table("conversion_popup_configs").delete().eq("id", popup_id).execute()
+    _log_admin_action(supabase, admin["id"], "admin.popup_deleted", None, {"popup_id": popup_id})
+    return {"success": True}
+
+
+@router.post("/conversion-popups/{popup_id}/translate")
+async def translate_conversion_popup(
+    popup_id: str,
+    admin: AdminUserDep,
+) -> dict[str, Any]:
+    """Auto-translate popup texts from French to en/es/pt using Groq LLM."""
+    from groq import Groq
+
+    supabase = get_supabase_client()
+    settings = get_settings()
+
+    popup_result = supabase.table("conversion_popup_configs").select("*").eq("id", popup_id).single().execute()
+    if not popup_result.data:
+        raise HTTPException(status_code=404, detail="Popup not found")
+
+    popup = popup_result.data
+    fr_texts = {
+        "title": (popup.get("title") or {}).get("fr", ""),
+        "body": (popup.get("body") or {}).get("fr", ""),
+        "primary_cta": (popup.get("primary_cta") or {}).get("fr", ""),
+        "secondary_cta": ((popup.get("secondary_cta") or {}).get("fr", "") if popup.get("secondary_cta") else ""),
+        "price_override": ((popup.get("price_override") or {}).get("fr", "") if popup.get("price_override") else ""),
+    }
+
+    groq_client = Groq(api_key=settings.get_groq_key())
+    target_languages = {"en": "English", "es": "Spanish", "pt": "Portuguese"}
+    translations: dict[str, dict[str, str]] = {}
+
+    for lang_code, lang_name in target_languages.items():
+        prompt = (
+            f"Translate these conversion popup texts from French to {lang_name}. "
+            "Return ONLY a valid JSON object with these exact keys: "
+            "title, body, primary_cta, secondary_cta, price_override. "
+            "If a value is empty, keep it empty. Keep it short and persuasive. "
+            "Do not include any text outside the JSON.\n\n"
+            f"French source:\n{json.dumps(fr_texts, ensure_ascii=False, indent=2)}"
+        )
+        try:
+            response = groq_client.chat.completions.create(
+                model=settings.llm_model_powerful,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+                max_tokens=1024,
+                response_format={"type": "json_object"},
+            )
+            parsed = json.loads(response.choices[0].message.content or "{}")
+            translations[lang_code] = parsed
+        except Exception as e:
+            logger.warning(f"Failed to translate popup {popup_id} to {lang_code}: {e}")
+            translations[lang_code] = fr_texts
+
+    # Merge translations into existing JSONB fields
+    update_data: dict[str, Any] = {"updated_at": datetime.now(UTC).isoformat()}
+    for field in ["title", "body", "primary_cta", "secondary_cta", "price_override"]:
+        current = popup.get(field) or {}
+        if not isinstance(current, dict):
+            current = {"fr": current} if current else {}
+        for lang_code, texts in translations.items():
+            val = texts.get(field, "")
+            if val:
+                current[lang_code] = val
+        if current:
+            update_data[field] = current
+
+    supabase.table("conversion_popup_configs").update(update_data).eq("id", popup_id).execute()
+    _log_admin_action(supabase, admin["id"], "admin.popup_translated", None, {
+        "popup_id": popup_id,
+        "languages": list(translations.keys()),
+    })
+
+    return {"success": True, "translations": translations}
+
+
+@router.post("/plans/{plan_id}/generate-wording")
+async def generate_plan_wording(
+    plan_id: str,
+    admin: AdminUserDep,
+) -> dict[str, Any]:
+    """
+    Auto-generate features/features_excluded text arrays from plan limits and flags.
+    Returns the generated arrays without saving — admin can review and save manually.
+    """
+    supabase = get_supabase_client()
+    plan_result = supabase.table("subscription_plans").select(
+        "name, limits, feature_flags"
+    ).eq("id", plan_id).single().execute()
+    if not plan_result.data:
+        raise HTTPException(status_code=404, detail="Plan not found")
+
+    plan = plan_result.data
+    limits = plan.get("limits") or {}
+    flags = plan.get("feature_flags") or {}
+
+    # Mapping limits → wording
+    limit_wording = {
+        "job_searches": ("recherches d'offres par jour", "Recherches illimitees"),
+        "cv_analyses": ("analyses CV par jour", "Analyses CV illimitees"),
+        "assistant_messages": ("messages coaching par jour", "Messages coaching illimites"),
+        "cv_adapt": ("adaptations CV par jour", "Adaptations CV illimitees"),
+        "cover_letter": ("lettres de motivation par jour", "Lettres de motivation illimitees"),
+        "saved_jobs": ("offres sauvegardees", "Sauvegardes illimitees"),
+        "jobs_visible": ("offres visibles par jour", "Toutes les offres visibles"),
+        "job_views": ("vues d'offres par jour", "Vues illimitees"),
+        "recruiter_searches": ("recherches recruteur par jour", "Recherches recruteur illimitees"),
+    }
+
+    # Mapping flags → wording
+    flag_wording = {
+        "has_advanced_filters": "Filtres avances",
+        "has_favorites": "Gestion favoris",
+        "has_visual_score": "Score visuel CV",
+        "has_pdf_export": "Export PDF",
+        "has_cv_history": "Historique CV",
+        "has_interview_sim": "Simulation d'entretien",
+        "has_email_alerts": "Alertes email",
+        "has_personalized_advice": "Conseils personnalises",
+        "has_coach_history": "Historique coach",
+        "has_cover_letter": "Lettre de motivation IA",
+        "has_branding": "Branding personnel",
+        "has_cv_details": "Details CV avances",
+    }
+
+    page_wording = {
+        "page_assistant": "Coach IA",
+        "page_jobs": "Recherche emploi",
+        "page_saved_jobs": "Jobs sauvegardes",
+        "page_cv_analysis": "Analyse CV",
+        "page_documents": "Documents",
+        "page_candidatures": "Candidatures",
+        "page_expat": "Expat",
+        "page_salons": "Salons emploi",
+        "page_profile": "Profil",
+        "page_recruiter_contact": "Contact recruteurs",
+        "page_referral": "Parrainage",
+    }
+
+    features: list[str] = []
+    features_excluded: list[str] = []
+
+    # Generate from limits
+    for key, (limited_tpl, unlimited_text) in limit_wording.items():
+        val = limits.get(key, 0)
+        if val == -1:
+            features.append(unlimited_text)
+        elif val > 0:
+            features.append(f"{val} {limited_tpl}")
+        else:
+            features_excluded.append(unlimited_text)
+
+    # Generate from feature flags
+    for key, text in flag_wording.items():
+        if flags.get(key):
+            features.append(text)
+        else:
+            features_excluded.append(text)
+
+    # Generate from page access flags
+    for key, text in page_wording.items():
+        if flags.get(key):
+            features.append(text)
+        else:
+            features_excluded.append(text)
+
+    features.append("Support standard")
+
+    return {
+        "success": True,
+        "features": features,
+        "features_excluded": features_excluded,
+    }

--- a/backend/src/api/routes/public_plans.py
+++ b/backend/src/api/routes/public_plans.py
@@ -100,3 +100,63 @@ async def get_public_plans(
         pass
 
     return plans
+
+
+POPUPS_CACHE_KEY = "conversion_popups"
+POPUPS_CACHE_TTL = 60  # 1 minute
+
+
+@router.get("/conversion-popups")
+async def get_public_conversion_popups(
+    locale: str | None = Query(default=None, description="Language code: fr, en, es, pt"),
+) -> list[dict[str, Any]]:
+    """
+    Returns active conversion popup configs for frontend display.
+    Texts returned in requested locale (falls back to fr).
+    No auth required -- cached in Redis.
+    """
+    effective_locale = locale if locale in SUPPORTED_LOCALES else "fr"
+    cache_key = f"{POPUPS_CACHE_KEY}:{effective_locale}"
+
+    try:
+        from src.utils.cache import get_redis
+        redis = await get_redis()
+        if redis:
+            cached = await redis.get(cache_key)
+            if cached:
+                return json.loads(cached)
+    except Exception:
+        pass
+
+    supabase = get_supabase_client()
+    result = supabase.table("conversion_popup_configs").select("*").eq(
+        "is_active", True
+    ).order("sort_order").execute()
+
+    popups = []
+    for row in result.data or []:
+        popup = {
+            "id": row["id"],
+            "trigger_id": row["trigger_id"],
+            "source_plans": row.get("source_plans", ["free"]),
+            "target_plan": row.get("target_plan", "starter"),
+            "feature_trigger": row.get("feature_trigger"),
+            "discount_percent": float(row["discount_percent"]) if row.get("discount_percent") else None,
+            "coupon_trigger": row.get("coupon_trigger"),
+            "title": (row.get("title") or {}).get(effective_locale, (row.get("title") or {}).get("fr", "")),
+            "body": (row.get("body") or {}).get(effective_locale, (row.get("body") or {}).get("fr", "")),
+            "primary_cta": (row.get("primary_cta") or {}).get(effective_locale, (row.get("primary_cta") or {}).get("fr", "")),
+            "secondary_cta": (row.get("secondary_cta") or {}).get(effective_locale, (row.get("secondary_cta") or {}).get("fr", "")) if row.get("secondary_cta") else None,
+            "price_override": (row.get("price_override") or {}).get(effective_locale, (row.get("price_override") or {}).get("fr", "")) if row.get("price_override") else None,
+        }
+        popups.append(popup)
+
+    try:
+        from src.utils.cache import get_redis
+        redis = await get_redis()
+        if redis:
+            await redis.setex(cache_key, POPUPS_CACHE_TTL, json.dumps(popups))
+    except Exception:
+        pass
+
+    return popups

--- a/frontend-next/src/app/(dashboard)/layout.tsx
+++ b/frontend-next/src/app/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ import { PricingModal } from "@/components/freemium/pricing-modal";
 import { UpgradeBanner } from "@/components/freemium/upgrade-banner";
 import { SupportBubble } from "@/components/support/support-bubble";
 import { PresenceTracker } from "@/components/layout/presence-tracker";
+import { PopupConfigsProvider } from "@/components/freemium/conversion-popups";
 import { getTranslations } from "next-intl/server";
 import DashboardLoading from "./loading";
 
@@ -21,57 +22,59 @@ export default async function DashboardLayout({
 
   return (
     <SubscriptionProvider>
-      <div className="dashboard-force-light min-h-screen bg-white">
-        <NavigationLoader />
-        <Sidebar />
+      <PopupConfigsProvider>
+        <div className="dashboard-force-light min-h-screen bg-white">
+          <NavigationLoader />
+          <Sidebar />
 
-        {/* Main content - offset by sidebar width */}
-        <main
-          id="main-content"
-          className="huntzen-main lg:ml-[280px] min-h-screen transition-all"
-        >
-          {/* Presence heartbeat — tracks user on /dashboard */}
-          <PresenceTracker page="/dashboard" />
+          {/* Main content - offset by sidebar width */}
+          <main
+            id="main-content"
+            className="huntzen-main lg:ml-[280px] min-h-screen transition-all"
+          >
+            {/* Presence heartbeat — tracks user on /dashboard */}
+            <PresenceTracker page="/dashboard" />
 
-          {/* Dashboard top navbar (desktop only) */}
-          <DashboardNavbar />
+            {/* Dashboard top navbar (desktop only) */}
+            <DashboardNavbar />
 
-          {/* Mobile spacer for fixed header */}
-          <div className="h-14 lg:hidden" />
+            {/* Mobile spacer for fixed header */}
+            <div className="h-14 lg:hidden" />
 
-          {/* Upgrade banner for free users - handled by UpgradeBanner component */}
-          <div className="px-4 lg:px-6 pt-4">
-            <UpgradeBanner variant="minimal" />
-          </div>
+            {/* Upgrade banner for free users - handled by UpgradeBanner component */}
+            <div className="px-4 lg:px-6 pt-4">
+              <UpgradeBanner variant="minimal" />
+            </div>
 
-          <div className="p-4 lg:p-6">
-            <Suspense fallback={<DashboardLoading />}>{children}</Suspense>
-          </div>
+            <div className="p-4 lg:p-6">
+              <Suspense fallback={<DashboardLoading />}>{children}</Suspense>
+            </div>
 
-          <footer className="border-t py-3 px-4 text-center">
-            <p className="text-xs text-muted-foreground">
-              &copy; {new Date().getFullYear()} HuntZen &middot;{" "}
-              <Link href="/privacy" className="hover:underline">
-                {t("privacy")}
-              </Link>
-              {" · "}
-              <Link href="/terms" className="hover:underline">
-                {t("terms")}
-              </Link>
-              {" · "}
-              <Link href="/contact" className="hover:underline">
-                {t("contact")}
-              </Link>
-            </p>
-          </footer>
-        </main>
+            <footer className="border-t py-3 px-4 text-center">
+              <p className="text-xs text-muted-foreground">
+                &copy; {new Date().getFullYear()} HuntZen &middot;{" "}
+                <Link href="/privacy" className="hover:underline">
+                  {t("privacy")}
+                </Link>
+                {" · "}
+                <Link href="/terms" className="hover:underline">
+                  {t("terms")}
+                </Link>
+                {" · "}
+                <Link href="/contact" className="hover:underline">
+                  {t("contact")}
+                </Link>
+              </p>
+            </footer>
+          </main>
 
-        {/* Global pricing modal */}
-        <PricingModal />
+          {/* Global pricing modal */}
+          <PricingModal />
 
-        {/* Support chat bubble */}
-        <SupportBubble />
-      </div>
+          {/* Support chat bubble */}
+          <SupportBubble />
+        </div>
+      </PopupConfigsProvider>
     </SubscriptionProvider>
   );
 }

--- a/frontend-next/src/app/admin/plans/page.tsx
+++ b/frontend-next/src/app/admin/plans/page.tsx
@@ -14,6 +14,7 @@ export default function AdminPlansPage() {
     updateWording,
     updateStripePrice,
     translatePlan,
+    generateWording,
     loading,
   } = useAdminPlans();
   const [plans, setPlans] = useState<Plan[]>([]);
@@ -86,6 +87,7 @@ export default function AdminPlansPage() {
                 if (ok) refresh();
                 return ok;
               }}
+              onGenerateWording={generateWording}
             />
           ))}
         </div>

--- a/frontend-next/src/components/admin/plans/plan-card-editor.tsx
+++ b/frontend-next/src/components/admin/plans/plan-card-editor.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Save, Zap, Pencil, ToggleRight, Languages } from "lucide-react";
+import {
+  Save,
+  Zap,
+  Pencil,
+  ToggleRight,
+  Languages,
+  Sparkles,
+} from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
 import {
   AlertDialog,
@@ -98,6 +105,9 @@ interface Props {
     wording: { display_name?: string; description?: string },
   ) => Promise<boolean>;
   onTranslatePlan: (planId: string) => Promise<boolean>;
+  onGenerateWording?: (
+    planId: string,
+  ) => Promise<{ features: string[]; features_excluded: string[] } | null>;
 }
 
 export default function PlanCardEditor({
@@ -108,6 +118,7 @@ export default function PlanCardEditor({
   onUpdateStripePrice,
   onUpdateWording,
   onTranslatePlan,
+  onGenerateWording,
 }: Props) {
   const [limits, setLimits] = useState({
     cv_analyses: plan.limits?.cv_analyses ?? 0,
@@ -574,6 +585,30 @@ export default function PlanCardEditor({
                 {featuresExcludedText.split("\n").filter(Boolean).length}{" "}
                 exclues
               </p>
+              {onGenerateWording && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={saving === "generateWording"}
+                  onClick={async () => {
+                    setSaving("generateWording");
+                    const result = await onGenerateWording(plan.id);
+                    if (result) {
+                      setFeaturesText(result.features.join("\n"));
+                      setFeaturesExcludedText(
+                        result.features_excluded.join("\n"),
+                      );
+                    }
+                    setSaving(null);
+                  }}
+                  className="w-full mt-2"
+                >
+                  <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+                  {saving === "generateWording"
+                    ? "Generation..."
+                    : "Generer automatiquement"}
+                </Button>
+              )}
               <Button
                 size="sm"
                 variant="outline"

--- a/frontend-next/src/components/freemium/conversion-popups.tsx
+++ b/frontend-next/src/components/freemium/conversion-popups.tsx
@@ -1,12 +1,31 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useTranslations } from "next-intl";
+import { useState, useEffect, createContext, useContext, useCallback } from "react";
+import { useTranslations, useLocale } from "next-intl";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
 import { usePlansConfig } from "@/hooks/use-plans-config";
 
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** DB-driven popup config from /api/public/conversion-popups */
+export interface ApiPopupConfig {
+  id: string;
+  trigger_id: string;
+  source_plans: string[];
+  target_plan: string;
+  feature_trigger?: string;
+  title: string;
+  body: string;
+  primary_cta: string;
+  secondary_cta?: string | null;
+  price_override?: string | null;
+  discount_percent?: number | null;
+  coupon_trigger?: string | null;
+}
+
+/** Legacy i18n-key-based config (fallback) */
 export interface PopupConfig {
   id: string;
   trigger: string;
@@ -20,80 +39,48 @@ export interface PopupConfig {
   couponTrigger?: string;
 }
 
+// ── Fallback hardcoded configs (used only when API unavailable) ───────────────
+
 export const POPUP_CONFIGS: PopupConfig[] = [
-  {
-    id: "search_limit",
-    trigger: "search_limit",
-    titleKey: "searchLimit.title",
-    bodyKey: "searchLimit.body",
-    primaryCtaKey: "searchLimit.primaryCta",
-    secondaryCtaKey: "searchLimit.secondaryCta",
-    plan: "starter",
-  },
-  {
-    id: "cv_score",
-    trigger: "cv_score",
-    titleKey: "cvScore.title",
-    bodyKey: "cvScore.body",
-    primaryCtaKey: "cvScore.primaryCta",
-    plan: "starter",
-  },
-  {
-    id: "session_cut",
-    trigger: "session_cut",
-    titleKey: "sessionCut.title",
-    bodyKey: "sessionCut.body",
-    primaryCtaKey: "sessionCut.primaryCta",
-    plan: "starter",
-  },
-  {
-    id: "interview_score",
-    trigger: "interview_score",
-    titleKey: "interviewScore.title",
-    bodyKey: "interviewScore.body",
-    primaryCtaKey: "interviewScore.primaryCta",
-    plan: "pro",
-  },
-  {
-    id: "momentum",
-    trigger: "momentum",
-    titleKey: "momentum.title",
-    bodyKey: "momentum.body",
-    primaryCtaKey: "momentum.primaryCta",
-    plan: "starter",
-    discountPercent: 0.2,
-    couponTrigger: "momentum",
-  },
-  {
-    id: "anti_churn",
-    trigger: "anti_churn",
-    titleKey: "antiChurn.title",
-    bodyKey: "antiChurn.body",
-    primaryCtaKey: "antiChurn.primaryCta",
-    secondaryCtaKey: "antiChurn.secondaryCta",
-    plan: "pro",
-    discountPercent: 0.3,
-    couponTrigger: "anti_churn",
-  },
-  {
-    id: "inactive_7d",
-    trigger: "inactive_7d",
-    titleKey: "inactive7d.title",
-    bodyKey: "inactive7d.body",
-    primaryCtaKey: "inactive7d.primaryCta",
-    plan: "pro",
-    priceOverrideKey: "inactive7d.priceOverride",
-    couponTrigger: "win_back_7d",
-  },
-  {
-    id: "pricing_hover",
-    trigger: "pricing_hover",
-    titleKey: "pricingHover.title",
-    bodyKey: "pricingHover.body",
-    primaryCtaKey: "pricingHover.primaryCta",
-    plan: "pro",
-  },
+  { id: "search_limit", trigger: "search_limit", titleKey: "searchLimit.title", bodyKey: "searchLimit.body", primaryCtaKey: "searchLimit.primaryCta", secondaryCtaKey: "searchLimit.secondaryCta", plan: "starter" },
+  { id: "cv_score", trigger: "cv_score", titleKey: "cvScore.title", bodyKey: "cvScore.body", primaryCtaKey: "cvScore.primaryCta", plan: "starter" },
+  { id: "session_cut", trigger: "session_cut", titleKey: "sessionCut.title", bodyKey: "sessionCut.body", primaryCtaKey: "sessionCut.primaryCta", plan: "starter" },
+  { id: "interview_score", trigger: "interview_score", titleKey: "interviewScore.title", bodyKey: "interviewScore.body", primaryCtaKey: "interviewScore.primaryCta", plan: "pro" },
+  { id: "momentum", trigger: "momentum", titleKey: "momentum.title", bodyKey: "momentum.body", primaryCtaKey: "momentum.primaryCta", plan: "starter", discountPercent: 0.2, couponTrigger: "momentum" },
+  { id: "anti_churn", trigger: "anti_churn", titleKey: "antiChurn.title", bodyKey: "antiChurn.body", primaryCtaKey: "antiChurn.primaryCta", secondaryCtaKey: "antiChurn.secondaryCta", plan: "pro", discountPercent: 0.3, couponTrigger: "anti_churn" },
+  { id: "inactive_7d", trigger: "inactive_7d", titleKey: "inactive7d.title", bodyKey: "inactive7d.body", primaryCtaKey: "inactive7d.primaryCta", plan: "pro", priceOverrideKey: "inactive7d.priceOverride", couponTrigger: "win_back_7d" },
+  { id: "pricing_hover", trigger: "pricing_hover", titleKey: "pricingHover.title", bodyKey: "pricingHover.body", primaryCtaKey: "pricingHover.primaryCta", plan: "pro" },
 ];
+
+// ── Popup configs context (fetched from API) ─────────────────────────────────
+
+const PopupConfigsContext = createContext<ApiPopupConfig[]>([]);
+
+export function PopupConfigsProvider({ children }: { children: React.ReactNode }) {
+  const [configs, setConfigs] = useState<ApiPopupConfig[]>([]);
+  const locale = useLocale();
+
+  useEffect(() => {
+    const url = process.env.NEXT_PUBLIC_BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+    if (!url) return;
+    fetch(`${url}/api/public/conversion-popups?locale=${locale}`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then(setConfigs)
+      .catch(() => {});
+  }, [locale]);
+
+  return (
+    <PopupConfigsContext.Provider value={configs}>
+      {children}
+    </PopupConfigsContext.Provider>
+  );
+}
+
+export function usePopupConfigs() {
+  return useContext(PopupConfigsContext);
+}
+
+// ── ConversionPopup component ─────────────────────────────────────────────────
 
 interface ConversionPopupProps {
   popupId: string;
@@ -112,12 +99,24 @@ export function ConversionPopup({
 }: ConversionPopupProps) {
   const { session } = useAuth();
   const t = useTranslations("popups");
-  const config = POPUP_CONFIGS.find((p) => p.id === popupId);
+  const apiConfigs = usePopupConfigs();
+  const apiConfig = apiConfigs.find((p) => p.trigger_id === popupId);
+  const legacyConfig = POPUP_CONFIGS.find((p) => p.id === popupId);
   const [couponCode, setCouponCode] = useState<string | null>(null);
   const [checkoutUrl, setCheckoutUrl] = useState<string | null>(null);
 
+  // Resolve texts: API first, fallback to i18n keys
+  const title = apiConfig?.title || (legacyConfig ? t(legacyConfig.titleKey) : "");
+  const body = apiConfig?.body || (legacyConfig ? t(legacyConfig.bodyKey) : "");
+  const primaryCta = apiConfig?.primary_cta || (legacyConfig ? t(legacyConfig.primaryCtaKey) : "");
+  const secondaryCta = apiConfig?.secondary_cta || (legacyConfig?.secondaryCtaKey ? t(legacyConfig.secondaryCtaKey) : null);
+  const targetPlan = (apiConfig?.target_plan || legacyConfig?.plan || "starter") as "starter" | "pro";
+  const discountPercent = apiConfig?.discount_percent || legacyConfig?.discountPercent || null;
+  const couponTrigger = apiConfig?.coupon_trigger || legacyConfig?.couponTrigger || null;
+  const priceOverride = apiConfig?.price_override || (legacyConfig?.priceOverrideKey ? t(legacyConfig.priceOverrideKey) : null);
+
   useEffect(() => {
-    if (!isOpen || !config?.couponTrigger || !session?.access_token) return;
+    if (!isOpen || !couponTrigger || !session?.access_token) return;
     const fetchCoupon = async () => {
       try {
         const res = await fetch(
@@ -128,7 +127,7 @@ export function ConversionPopup({
               Authorization: `Bearer ${session.access_token}`,
               "Content-Type": "application/json",
             },
-            body: JSON.stringify({ trigger_type: config.couponTrigger }),
+            body: JSON.stringify({ trigger_type: couponTrigger }),
           },
         );
         if (res.ok) {
@@ -141,7 +140,7 @@ export function ConversionPopup({
       }
     };
     fetchCoupon();
-  }, [isOpen, config?.couponTrigger, session?.access_token]);
+  }, [isOpen, couponTrigger, session?.access_token]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -154,30 +153,23 @@ export function ConversionPopup({
 
   const { getPlan, formatPrice } = usePlansConfig();
 
-  if (!isOpen || !config) return null;
+  if (!isOpen || (!apiConfig && !legacyConfig)) return null;
 
   const computedPrice = (() => {
-    if (config.priceOverrideKey) return t(config.priceOverrideKey);
-    const planData = getPlan(config.plan);
+    if (priceOverride) return priceOverride;
+    const planData = getPlan(targetPlan);
     if (!planData) return "";
     const base = planData.price_monthly;
-    const discounted = config.discountPercent
-      ? base * (1 - config.discountPercent)
-      : base;
+    const discounted = discountPercent ? base * (1 - discountPercent) : base;
     return `${formatPrice(discounted)}${t("currencyPerMonth")}`;
   })();
 
   const planColors = {
-    starter: {
-      bg: "from-blue-500 to-blue-600",
-      btn: "bg-blue-600 hover:bg-blue-700",
-    },
-    pro: {
-      bg: "from-violet-500 to-purple-600",
-      btn: "bg-violet-600 hover:bg-violet-700",
-    },
+    starter: { bg: "from-blue-500 to-blue-600", btn: "bg-blue-600 hover:bg-blue-700" },
+    pro: { bg: "from-violet-500 to-purple-600", btn: "bg-violet-600 hover:bg-violet-700" },
+    premium: { bg: "from-amber-500 to-amber-600", btn: "bg-amber-600 hover:bg-amber-700" },
   };
-  const colors = planColors[config.plan];
+  const colors = planColors[targetPlan] || planColors.starter;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -193,10 +185,10 @@ export function ConversionPopup({
             <X className="w-4 h-4 text-muted-foreground" />
           </button>
           <h3 className="text-base font-bold leading-snug pr-6 mb-2">
-            {t(config.titleKey)}
+            {title}
           </h3>
           <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
-            {t(config.bodyKey)}
+            {body}
           </p>
           {couponCode && (
             <div className="mb-4 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 text-xs">
@@ -209,7 +201,7 @@ export function ConversionPopup({
             </div>
           )}
           <p className="text-xs text-muted-foreground mb-4">
-            {t("planLabel")} {getPlan(config.plan)?.display_name ?? config.plan}
+            {t("planLabel")} {getPlan(targetPlan)?.display_name ?? targetPlan}
             {computedPrice ? " · " : ""}
             <strong>{computedPrice}</strong>
           </p>
@@ -229,9 +221,9 @@ export function ConversionPopup({
               colors.btn,
             )}
           >
-            {t(config.primaryCtaKey)}
+            {primaryCta}
           </button>
-          {config.secondaryCtaKey && (
+          {secondaryCta && (
             <button
               onClick={() => {
                 onSecondaryAction?.();
@@ -239,7 +231,7 @@ export function ConversionPopup({
               }}
               className="w-full mt-2 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
-              {t(config.secondaryCtaKey)}
+              {secondaryCta}
             </button>
           )}
         </div>
@@ -247,6 +239,8 @@ export function ConversionPopup({
     </div>
   );
 }
+
+// ── Hook for using conversion popups ──────────────────────────────────────────
 
 export function useConversionPopup(
   popupId: string,
@@ -258,8 +252,8 @@ export function useConversionPopup(
   const [isOpen, setIsOpen] = useState(false);
   return {
     isOpen,
-    open: () => setIsOpen(true),
-    close: () => setIsOpen(false),
+    open: useCallback(() => setIsOpen(true), []),
+    close: useCallback(() => setIsOpen(false), []),
     PopupComponent: () => (
       <ConversionPopup
         popupId={popupId}

--- a/frontend-next/src/hooks/admin/use-admin-plans.ts
+++ b/frontend-next/src/hooks/admin/use-admin-plans.ts
@@ -230,6 +230,33 @@ export function useAdminPlans() {
     }
   }, []);
 
+  const generateWording = useCallback(
+    async (
+      planId: string,
+    ): Promise<{ features: string[]; features_excluded: string[] } | null> => {
+      setLoading(true);
+      try {
+        const result = await adminFetch(
+          `/api/admin/plans/${planId}/generate-wording`,
+          { method: "POST" },
+        );
+        toast.success("Wording généré automatiquement");
+        return {
+          features: result.features || [],
+          features_excluded: result.features_excluded || [],
+        };
+      } catch (e) {
+        toast.error(
+          e instanceof Error ? e.message : "Erreur génération wording",
+        );
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
   return {
     loading,
     fetchPlans,
@@ -239,5 +266,6 @@ export function useAdminPlans() {
     updateWording,
     updateStripePrice,
     translatePlan,
+    generateWording,
   };
 }

--- a/supabase/migrations/20260326000001_conversion_popup_configs.sql
+++ b/supabase/migrations/20260326000001_conversion_popup_configs.sql
@@ -1,0 +1,115 @@
+-- Conversion Popup Configs — admin-managed popup configurations
+-- Replaces hardcoded POPUP_CONFIGS in conversion-popups.tsx
+
+CREATE TABLE IF NOT EXISTS conversion_popup_configs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trigger_id TEXT NOT NULL UNIQUE,
+    source_plans TEXT[] NOT NULL DEFAULT '{free}',
+    target_plan TEXT NOT NULL DEFAULT 'starter',
+    feature_trigger TEXT,
+    title JSONB NOT NULL DEFAULT '{}',
+    body JSONB NOT NULL DEFAULT '{}',
+    primary_cta JSONB NOT NULL DEFAULT '{}',
+    secondary_cta JSONB,
+    price_override JSONB,
+    discount_percent DECIMAL(5,2),
+    coupon_trigger TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE conversion_popup_configs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read active popups"
+    ON conversion_popup_configs FOR SELECT
+    USING (is_active = true);
+
+-- Seed the 8 existing popups (texts in 4 languages)
+INSERT INTO conversion_popup_configs (trigger_id, source_plans, target_plan, feature_trigger, title, body, primary_cta, secondary_cta, price_override, discount_percent, coupon_trigger, sort_order) VALUES
+(
+    'search_limit',
+    '{free}',
+    'starter',
+    'job_search',
+    '{"fr": "Vous avez atteint votre limite de recherches aujourd''hui", "en": "You''ve reached your daily search limit", "es": "Has alcanzado tu limite de busquedas diarias", "pt": "Voce atingiu seu limite diario de buscas"}',
+    '{"fr": "Passe a Starter pour des recherches illimitees et trouve votre prochain job plus vite.", "en": "Upgrade to Starter for unlimited searches and find your next job faster.", "es": "Pasa a Starter para busquedas ilimitadas y encuentra tu proximo empleo mas rapido.", "pt": "Mude para Starter para buscas ilimitadas e encontre seu proximo emprego mais rapido."}',
+    '{"fr": "Debloquer les recherches", "en": "Unlock searches", "es": "Desbloquear busquedas", "pt": "Desbloquear buscas"}',
+    '{"fr": "Parrainer un ami", "en": "Refer a friend", "es": "Recomendar a un amigo", "pt": "Indicar um amigo"}',
+    NULL, NULL, NULL, 1
+),
+(
+    'cv_score',
+    '{free}',
+    'starter',
+    'cv_analysis',
+    '{"fr": "Ton CV peut faire beaucoup mieux", "en": "Your CV can do much better", "es": "Tu CV puede mejorar mucho", "pt": "Seu CV pode melhorar muito"}',
+    '{"fr": "Accede aux conseils detailles de Sofia pour booster votre score ATS et decrocher plus d''entretiens.", "en": "Get detailed advice from Sofia to boost your ATS score and land more interviews.", "es": "Obtene consejos detallados de Sofia para mejorar tu puntuacion ATS y conseguir mas entrevistas.", "pt": "Obtenha conselhos detalhados da Sofia para melhorar sua pontuacao ATS e conseguir mais entrevistas."}',
+    '{"fr": "Activer l''analyse complete", "en": "Activate full analysis", "es": "Activar analisis completo", "pt": "Ativar analise completa"}',
+    NULL, NULL, NULL, NULL, 2
+),
+(
+    'session_cut',
+    '{free}',
+    'starter',
+    'assistant_messages',
+    '{"fr": "Ta session coach est terminee", "en": "Your coaching session has ended", "es": "Tu sesion de coaching ha terminado", "pt": "Sua sessao de coaching terminou"}',
+    '{"fr": "Continue avec Nova, Maria ou Lucas sans limite. Ton prochain job est a portee de main.", "en": "Continue with Nova, Maria or Lucas with no limits. Your next job is within reach.", "es": "Continua con Nova, Maria o Lucas sin limites. Tu proximo empleo esta al alcance.", "pt": "Continue com Nova, Maria ou Lucas sem limites. Seu proximo emprego esta ao alcance."}',
+    '{"fr": "Continuer avec le Coach", "en": "Continue with the Coach", "es": "Continuar con el Coach", "pt": "Continuar com o Coach"}',
+    NULL, NULL, NULL, NULL, 3
+),
+(
+    'interview_score',
+    '{free,starter}',
+    'pro',
+    'interview_sim',
+    '{"fr": "Vous souhaitez aller plus loin avec Lucas ?", "en": "Want to go further with Lucas?", "es": "Quieres ir mas lejos con Lucas?", "pt": "Quer ir mais longe com Lucas?"}',
+    '{"fr": "Simulez autant d''entretiens que vous voulez et recevez des retours approfondis a chaque session.", "en": "Simulate as many interviews as you want and receive in-depth feedback after each session.", "es": "Simula tantas entrevistas como quieras y recibe comentarios detallados en cada sesion.", "pt": "Simule quantas entrevistas quiser e receba feedback detalhado em cada sessao."}',
+    '{"fr": "Activer la simulation complete", "en": "Activate full simulation", "es": "Activar simulacion completa", "pt": "Ativar simulacao completa"}',
+    NULL, NULL, NULL, NULL, 4
+),
+(
+    'momentum',
+    '{free}',
+    'starter',
+    NULL,
+    '{"fr": "Vous etes en plein elan — profite de -20 % aujourd''hui", "en": "You''re on a roll — enjoy -20% today", "es": "Estas en racha — disfruta de -20% hoy", "pt": "Voce esta em alta — aproveite -20% hoje"}',
+    '{"fr": "Vous recherchez activement. Voici une offre exclusive valable 24 h pour vous.", "en": "You''re actively searching. Here''s an exclusive offer valid for 24 h just for you.", "es": "Estas buscando activamente. Aqui tienes una oferta exclusiva valida 24 h solo para ti.", "pt": "Voce esta buscando ativamente. Aqui esta uma oferta exclusiva valida por 24 h so para voce."}',
+    '{"fr": "Choisir mon plan avec -20 %", "en": "Choose my plan with -20%", "es": "Elegir mi plan con -20%", "pt": "Escolher meu plano com -20%"}',
+    NULL, NULL, 0.20, 'momentum', 5
+),
+(
+    'anti_churn',
+    '{starter,pro}',
+    'pro',
+    NULL,
+    '{"fr": "Reste et economise -30 % pendant 3 mois", "en": "Stay and save -30% for 3 months", "es": "Quedate y ahorra -30% durante 3 meses", "pt": "Fique e economize -30% por 3 meses"}',
+    '{"fr": "Avant de partir, voici une offre exclusive : -30 % sur votre abonnement pendant 3 mois.", "en": "Before you go, here''s an exclusive offer: -30% on your subscription for 3 months.", "es": "Antes de irte, aqui tienes una oferta exclusiva: -30% en tu suscripcion durante 3 meses.", "pt": "Antes de ir, aqui esta uma oferta exclusiva: -30% na sua assinatura por 3 meses."}',
+    '{"fr": "Garder mon avantage", "en": "Keep my advantage", "es": "Mantener mi ventaja", "pt": "Manter minha vantagem"}',
+    '{"fr": "Annuler quand meme", "en": "Cancel anyway", "es": "Cancelar de todos modos", "pt": "Cancelar mesmo assim"}',
+    NULL, 0.30, 'anti_churn', 6
+),
+(
+    'inactive_7d',
+    '{free}',
+    'pro',
+    NULL,
+    '{"fr": "7 jours Accelerateur offerts, nous vous avons reserve votre place", "en": "7 free Accelerator days — your spot is reserved", "es": "7 dias de Acelerador gratis — tu plaza esta reservada", "pt": "7 dias de Acelerador gratis — sua vaga esta reservada"}',
+    '{"fr": "Vous nous manquez ! Revenez et profitez de 7 jours gratuits pour reprendre votre recherche.", "en": "We miss you! Come back and enjoy 7 free days to restart your search.", "es": "Te echamos de menos! Vuelve y disfruta de 7 dias gratis para retomar tu busqueda.", "pt": "Sentimos sua falta! Volte e aproveite 7 dias gratis para retomar sua busca."}',
+    '{"fr": "Activer mes 7 jours gratuits", "en": "Activate my 7 free days", "es": "Activar mis 7 dias gratis", "pt": "Ativar meus 7 dias gratis"}',
+    NULL,
+    '{"fr": "0EUR pendant 7 jours", "en": "EUR0 for 7 days", "es": "0EUR durante 7 dias", "pt": "0EUR por 7 dias"}',
+    NULL, 'win_back_7d', 7
+),
+(
+    'pricing_hover',
+    '{free}',
+    'pro',
+    NULL,
+    '{"fr": "67 % de nos abonnes choisissent Accelerateur", "en": "67% of our subscribers choose Accelerator", "es": "67% de nuestros suscriptores eligen Acelerador", "pt": "67% dos nossos assinantes escolhem Acelerador"}',
+    '{"fr": "Ils trouvent un job en moyenne 3x plus vite. Rejoins-les aujourd''hui.", "en": "They find a job on average 3x faster. Join them today.", "es": "Encuentran empleo en promedio 3x mas rapido. Unete hoy.", "pt": "Eles encontram emprego em media 3x mais rapido. Junte-se hoje."}',
+    '{"fr": "Choisir Accelerateur maintenant", "en": "Choose Accelerator now", "es": "Elegir Acelerador ahora", "pt": "Escolher Acelerador agora"}',
+    NULL, NULL, NULL, NULL, 8
+)
+ON CONFLICT (trigger_id) DO NOTHING;


### PR DESCRIPTION
## Summary
- **Conversion popups en DB** : table `conversion_popup_configs` avec 8 popups seedees en 4 langues (fr/en/es/pt). CRUD admin complet + endpoint public cache + traduction auto via Groq
- **Chargement dynamique** : le frontend charge les popups depuis l'API avec fallback hardcode. PopupConfigsProvider dans le layout dashboard
- **Smart wording** : bouton "Generer automatiquement" dans le plan editor qui cree les textes features/features_excluded a partir des limites et flags du plan
- **Quota 429 → popup** (commit precedent merge) : les erreurs 429 QUOTA_EXCEEDED ouvrent la popup de conversion au lieu d'afficher "API Error"

## Test plan
- [ ] GET /api/public/conversion-popups?locale=fr retourne 8 popups
- [ ] Admin > plans > bouton "Generer automatiquement" peuple les features
- [ ] Quota job search epuise → popup de conversion (pas d'erreur 429)
- [ ] Admin > conversion popups CRUD fonctionne
- [ ] Admin > conversion popups > traduire fonctionne