### PR TITLE
feat(assistant): hub page + per-coach quotas + avatars + CV quota fix

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -271,6 +271,45 @@ async def get_current_user_info(
                     "reset_at": quota["reset_at"]
                 }
 
+        # Enrich assistant_messages with per-coach breakdown
+        if "assistant_messages" in quotas:
+            try:
+                from datetime import date
+                today_str = date.today().isoformat()
+                by_coach_response = supabase.table("usage_quotas").select(
+                    "assistant_messages_by_coach"
+                ).eq("user_id", user_id).eq("quota_date", today_str).maybe_single().execute()
+
+                by_coach_raw: dict = {}
+                if by_coach_response.data and by_coach_response.data.get("assistant_messages_by_coach"):
+                    by_coach_raw = by_coach_response.data["assistant_messages_by_coach"]
+
+                am_limit = quotas["assistant_messages"]["limit"]
+                by_coach_detail: dict = {}
+                any_coach_has_access = False
+
+                for coach_type in ["career-coach", "job-scout", "cv-analyzer", "cv-adapter", "interview-sim", "branding"]:
+                    coach_used = by_coach_raw.get(coach_type, 0)
+                    if am_limit == -1:
+                        coach_remaining = -1
+                        coach_has_access = True
+                    else:
+                        coach_remaining = max(0, am_limit - coach_used)
+                        coach_has_access = coach_used < am_limit
+                    by_coach_detail[coach_type] = {
+                        "used": coach_used,
+                        "remaining": coach_remaining,
+                        "has_access": coach_has_access,
+                    }
+                    if coach_has_access:
+                        any_coach_has_access = True
+
+                quotas["assistant_messages"]["by_coach"] = by_coach_detail
+                # Override has_access: true if at least 1 coach still has quota
+                quotas["assistant_messages"]["has_access"] = any_coach_has_access
+            except Exception as e:
+                logger.warning(f"Could not fetch per-coach breakdown for {user_id}: {e}")
+
         # Saved jobs quota (total, not daily)
         saved_jobs_quota = {"used": 0, "limit": -1}
         try:

--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -942,7 +942,12 @@
       "attachCV": "Attach your CV (PDF)",
       "sendMessage": "Send message",
       "chatInputLabel": "Your message",
-      "messageCounter": "Messages remaining: {remaining} of {total}"
+      "messageCounter": "Messages remaining: {remaining} of {total}",
+      "hubTitle": "Your career team",
+      "hubSubtitle": "Choose an assistant to get started",
+      "hubResponseTime": "Response {time}",
+      "hubPremium": "Premium",
+      "hubComingSoon": "Coming soon"
     },
     "salons": {
       "title": "Job Fairs & Forums",

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -907,7 +907,12 @@
       "switchDialogDescNoHistory": "Your conversation will be lost, history is not available with your current plan.",
       "cancel": "Cancel",
       "switchAssistant": "Switch assistant",
-      "cvUploadError": "Error analyzing the CV. Please make sure the file is a valid PDF."
+      "cvUploadError": "Error analyzing the CV. Please make sure the file is a valid PDF.",
+      "hubTitle": "Tu equipo de carrera",
+      "hubSubtitle": "Elige un asistente para empezar",
+      "hubResponseTime": "Respuesta {time}",
+      "hubPremium": "Premium",
+      "hubComingSoon": "Proximamente"
     },
     "salons": {
       "title": "Ferias y Foros de Empleo",

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -1100,7 +1100,12 @@
       "attachCV": "Joindre votre CV (PDF)",
       "sendMessage": "Envoyer le message",
       "chatInputLabel": "Votre message",
-      "messageCounter": "Messages restants : {remaining} sur {total}"
+      "messageCounter": "Messages restants : {remaining} sur {total}",
+      "hubTitle": "Votre equipe carriere",
+      "hubSubtitle": "Choisissez un assistant pour commencer",
+      "hubResponseTime": "Reponse {time}",
+      "hubPremium": "Premium",
+      "hubComingSoon": "Bientot disponible"
     },
     "salons": {
       "title": "Salons & Forums",

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -907,7 +907,12 @@
       "switchDialogDescNoHistory": "Your conversation will be lost, history is not available with your current plan.",
       "cancel": "Cancel",
       "switchAssistant": "Switch assistant",
-      "cvUploadError": "Error analyzing the CV. Please make sure the file is a valid PDF."
+      "cvUploadError": "Error analyzing the CV. Please make sure the file is a valid PDF.",
+      "hubTitle": "Sua equipe de carreira",
+      "hubSubtitle": "Escolha um assistente para comecar",
+      "hubResponseTime": "Resposta {time}",
+      "hubPremium": "Premium",
+      "hubComingSoon": "Em breve"
     },
     "salons": {
       "title": "Feiras e Fóruns de Emprego",

--- a/frontend-next/src/app/(dashboard)/assistant/page.tsx
+++ b/frontend-next/src/app/(dashboard)/assistant/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -19,7 +19,9 @@ import {
   Paperclip,
   CheckCircle2,
   X,
+  Crown,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { huntzenApi } from "@/lib/api/huntzen-client";
 import type { QueueWaitingState } from "@/lib/api/huntzen-client";
 import { v4 as uuidv4 } from "uuid";
@@ -27,6 +29,7 @@ import { useSubscription } from "@/contexts/subscription-context";
 import { useAssistant } from "@/contexts/assistant-context";
 import {
   getAssistantConfig,
+  getAllAssistants,
   ASSISTANTS_CONFIG,
   ASSISTANT_TO_COACH_ID,
 } from "@/config/assistants";
@@ -98,11 +101,22 @@ export default function AssistantPage() {
   const currentCoachId = ASSISTANT_TO_COACH_ID[selectedAssistant];
   const currentCoach = currentCoachId ? getCoach(currentCoachId) : undefined;
   const [transitioning, setTransitioning] = useState(false);
+  const [showHub, setShowHub] = useState(true);
 
   const triggerTransition = () => {
     setTransitioning(true);
     setTimeout(() => setTransitioning(false), 300);
   };
+
+  // Listen for sidebar re-click on /assistant to return to hub
+  useEffect(() => {
+    const handleHubEvent = () => {
+      setShowHub(true);
+    };
+    window.addEventListener("huntzen:assistant-hub", handleHubEvent);
+    return () =>
+      window.removeEventListener("huntzen:assistant-hub", handleHubEvent);
+  }, []);
 
   // Reset branding state and attached CV when switching assistants
   useEffect(() => {
@@ -396,6 +410,7 @@ export default function AssistantPage() {
     if (messages.length === 0) {
       triggerTransition();
       setSelectedAssistant(newType);
+      setShowHub(true);
       return;
     }
     setPendingAssistant(newType);
@@ -436,14 +451,184 @@ export default function AssistantPage() {
     setSelectedAssistant(pendingAssistant);
     setPendingAssistant(null);
     setMessages([systemMessage]);
+    setShowHub(true);
   };
 
   const handleCancelSwitch = () => {
     setPendingAssistant(null);
   };
 
+  // Handle hub card click — select assistant and go to welcome/chat
+  const handleHubSelect = useCallback(
+    (type: AssistantType) => {
+      const config = getAssistantConfig(type);
+      if (config.isComingSoon) return;
+      if (type !== selectedAssistant) {
+        triggerTransition();
+        setSelectedAssistant(type);
+      }
+      setShowHub(false);
+      setMessages([]);
+      setCurrentConversationId(null);
+      setInput("");
+      setBrandingState(null);
+      setAttachedCV(null);
+      setSessionId(uuidv4());
+    },
+    [selectedAssistant, setSelectedAssistant, setCurrentConversationId],
+  );
+
   // Check if we should show welcome screen (no messages)
   const showWelcome = messages.length === 0;
+
+  // Hub view: grid of assistant cards
+  if (showHub) {
+    const allAssistants = getAllAssistants();
+    return (
+      <PageGate featureFlag="page_assistant">
+        <div className="flex flex-col min-h-screen">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="text-center mb-8"
+          >
+            <h1 className="text-3xl font-black text-slate-900 mb-2">
+              {t("hubTitle")}
+            </h1>
+            <p className="text-slate-600">{t("hubSubtitle")}</p>
+          </motion.div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {allAssistants.map((assistant, index) => {
+              const coachId = ASSISTANT_TO_COACH_ID[assistant.id];
+              const coach = coachId ? getCoach(coachId) : undefined;
+              const isLocked = assistant.isPremium && isFreePlan;
+              const isComingSoon = !!assistant.isComingSoon;
+              const accent = assistant.accentColor ?? assistant.color;
+
+              return (
+                <motion.div
+                  key={assistant.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.08 }}
+                >
+                  <button
+                    onClick={() => {
+                      if (isComingSoon) return;
+                      if (isLocked) {
+                        openPricingModal();
+                        return;
+                      }
+                      handleHubSelect(assistant.id);
+                    }}
+                    className={cn(
+                      "w-full text-left p-5 rounded-2xl border-2 transition-all duration-200 bg-white hover:shadow-lg group relative overflow-hidden",
+                      isComingSoon
+                        ? "opacity-60 cursor-default border-slate-200"
+                        : isLocked
+                          ? "opacity-70 border-slate-200 hover:border-slate-300"
+                          : "border-slate-200 hover:border-[#00D9FF] hover:shadow-[#00D9FF]/10",
+                    )}
+                  >
+                    {/* Badges */}
+                    <div className="absolute top-3 right-3 flex gap-1.5">
+                      {isComingSoon && (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-orange-100 text-orange-600 font-semibold">
+                          {t("hubComingSoon")}
+                        </span>
+                      )}
+                      {assistant.isPremium && !isComingSoon && (
+                        <span className="flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 font-semibold">
+                          <Crown className="w-3 h-3" />
+                          {t("hubPremium")}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Avatar + Name */}
+                    <div className="flex items-center gap-3 mb-3">
+                      {assistant.avatarUrl ? (
+                        <img
+                          src={assistant.avatarUrl}
+                          alt={
+                            assistant.personaName ?? tc(assistant.shortNameKey)
+                          }
+                          className="w-14 h-14 rounded-xl shadow-md"
+                          style={{ backgroundColor: assistant.bgColor }}
+                        />
+                      ) : (
+                        <div
+                          className="w-14 h-14 rounded-xl flex items-center justify-center shadow-md"
+                          style={{ backgroundColor: assistant.bgColor }}
+                        >
+                          <assistant.icon
+                            className="w-7 h-7"
+                            style={{ color: assistant.color }}
+                          />
+                        </div>
+                      )}
+                      <div>
+                        <h3 className="font-bold text-slate-900 text-base">
+                          {assistant.personaName ??
+                            (coach?.short_name || tc(assistant.shortNameKey))}
+                        </h3>
+                        <p className="text-xs text-slate-500">
+                          {coach?.short_name || tc(assistant.shortNameKey)}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Description */}
+                    <p className="text-sm text-slate-600 mb-3 line-clamp-2">
+                      {coach?.description || tc(assistant.descriptionKey)}
+                    </p>
+
+                    {/* Specialties badges */}
+                    <div className="flex flex-wrap gap-1.5 mb-3">
+                      {(coach?.specialties && coach.specialties.length > 0
+                        ? coach.specialties
+                        : assistant.specialtiesKeys.map((key) => tc(key))
+                      )
+                        .slice(0, 3)
+                        .map((label, idx) => (
+                          <span
+                            key={idx}
+                            className="text-[10px] px-2 py-0.5 rounded-full font-medium"
+                            style={{
+                              backgroundColor: assistant.bgColor,
+                              color: assistant.color,
+                            }}
+                          >
+                            {label}
+                          </span>
+                        ))}
+                    </div>
+
+                    {/* Response time */}
+                    {assistant.responseTime && (
+                      <div className="flex items-center gap-1.5 text-xs text-slate-400">
+                        <Clock className="w-3 h-3" />
+                        {t("hubResponseTime", { time: assistant.responseTime })}
+                      </div>
+                    )}
+
+                    {/* Locked overlay */}
+                    {isLocked && !isComingSoon && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-white/40 rounded-2xl">
+                        <Lock className="w-6 h-6 text-slate-400" />
+                      </div>
+                    )}
+                  </button>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </PageGate>
+    );
+  }
 
   return (
     <PageGate featureFlag="page_assistant">

--- a/frontend-next/src/components/layout/sidebar.tsx
+++ b/frontend-next/src/components/layout/sidebar.tsx
@@ -245,6 +245,11 @@ export function Sidebar({ className }: SidebarProps) {
                       e.preventDefault();
                       openPricingModal();
                     }
+                    if (item.href === "/assistant" && isActive) {
+                      window.dispatchEvent(
+                        new CustomEvent("huntzen:assistant-hub"),
+                      );
+                    }
                     if (item.href === "/candidatures" && isCandidaturesNew) {
                       try {
                         localStorage.setItem(

--- a/frontend-next/src/config/assistants.ts
+++ b/frontend-next/src/config/assistants.ts
@@ -58,7 +58,7 @@ export const ASSISTANTS_CONFIG: Record<AssistantType, AssistantConfig> = {
     bgColor: "#d1fae5", // emerald-100
     accentColor: "#0D9488", // teal-600
     avatarUrl:
-      "https://api.dicebear.com/9.x/lorelei/svg?seed=Maria&backgroundColor=d1fae5",
+      "https://api.dicebear.com/9.x/avataaars/svg?seed=Maria-pro&backgroundColor=d1fae5&accessories=prescription02&clotheColor=3c4f5c&clothing=blazerAndSweater&eyebrow=default&eyes=happy&facialHair=blank&hairColor=4a312c&mouth=smile&skinColor=light&top=longHairStraight",
     isPremium: false,
     specialtiesKeys: [
       "maria.specialty1",
@@ -156,7 +156,7 @@ export const ASSISTANTS_CONFIG: Record<AssistantType, AssistantConfig> = {
     bgColor: "#dbeafe",
     accentColor: "#DC2626", // red-600
     avatarUrl:
-      "https://api.dicebear.com/9.x/personas/svg?seed=David&backgroundColor=dbeafe&hair=shortHair&skinColor=light",
+      "https://api.dicebear.com/9.x/avataaars/svg?seed=David-pro&backgroundColor=dbeafe&accessories=blank&clotheColor=3c4f5c&clothing=blazerAndSweater&eyebrow=defaultNatural&eyes=default&facialHair=beardLight&hairColor=2c1b18&mouth=smile&skinColor=light&top=shortHairShortFlat",
     isPremium: false,
     specialtiesKeys: [
       "david.specialty1",

--- a/frontend-next/src/contexts/subscription-context.tsx
+++ b/frontend-next/src/contexts/subscription-context.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/hooks/use-freemium-limits";
 import { useSubscriptionApi } from "@/hooks/use-subscription-api";
 import { useOptionalAuth } from "@/contexts/auth-context";
+import { useOptionalAssistant } from "@/contexts/assistant-context";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { SubscriptionChangedModal } from "@/components/freemium/subscription-changed-modal";
@@ -83,6 +84,9 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
 
   // Get auth session for inconsistency detection
   const auth = useOptionalAuth();
+
+  // Get currently selected assistant for per-coach quota checks
+  const assistantCtx = useOptionalAssistant();
 
   // NEW: Fetch subscription data from backend API
   const apiData = useSubscriptionApi();
@@ -326,6 +330,20 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
                   ? "recruiter_search"
                   : null;
 
+      // Per-coach check for assistant_messages
+      if (
+        feature === "assistant_messages" &&
+        apiData.quotas.assistant_messages?.by_coach
+      ) {
+        const selectedCoach = assistantCtx?.selectedAssistant ?? "career-coach";
+        const coachQuota =
+          apiData.quotas.assistant_messages.by_coach[selectedCoach];
+        if (coachQuota) {
+          return coachQuota.has_access;
+        }
+        // Fallback to global if coach not found in by_coach
+      }
+
       const apiCanUse =
         quotaKey && apiData.quotas[quotaKey]
           ? apiData.quotas[quotaKey].has_access
@@ -338,7 +356,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       // Block if EITHER source says no (most conservative = safest)
       return apiCanUse && localCanUse;
     },
-    [apiData.quotas, freemium],
+    [apiData.quotas, freemium, assistantCtx?.selectedAssistant],
   );
 
   // getRemaining helper: Get remaining quota based on API data for ALL features
@@ -346,6 +364,19 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     (feature: FeatureType): number => {
       const localRemaining = freemium.getRemaining(feature);
       if (!apiData.quotas) return localRemaining;
+
+      // Per-coach remaining for assistant_messages
+      if (
+        feature === "assistant_messages" &&
+        apiData.quotas.assistant_messages?.by_coach
+      ) {
+        const selectedCoach = assistantCtx?.selectedAssistant ?? "career-coach";
+        const coachQuota =
+          apiData.quotas.assistant_messages.by_coach[selectedCoach];
+        if (coachQuota) {
+          return coachQuota.remaining === -1 ? Infinity : coachQuota.remaining;
+        }
+      }
 
       // Generic lookup for all quota-tracked features
       const quotaData = apiData.quotas[feature];
@@ -361,7 +392,7 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       // Return the lower value: if local was decremented but API hasn't refreshed yet
       return Math.min(apiRemaining, localRemaining);
     },
-    [apiData.quotas, freemium],
+    [apiData.quotas, freemium, assistantCtx?.selectedAssistant],
   );
 
   // incrementUsage: Keep local for now (will be removed when backend tracks all usage)
@@ -369,10 +400,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
     (feature: FeatureType, amount?: number) => {
       // Optimistic local update for immediate UI feedback
       freemium.incrementUsage(feature, amount);
-      // Refetch backend data after cache invalidation completes (~1.5s)
-      setTimeout(() => {
-        apiData.refetch();
-      }, 1500);
+      // Direct refetch (no delay) to sync with backend
+      apiData.refetch();
     },
     [freemium, apiData],
   );

--- a/frontend-next/src/hooks/use-subscription-api.ts
+++ b/frontend-next/src/hooks/use-subscription-api.ts
@@ -24,6 +24,12 @@ interface SubscriptionData {
   cancel_at_period_end: boolean;
 }
 
+interface CoachQuotaData {
+  used: number;
+  remaining: number;
+  has_access: boolean;
+}
+
 interface QuotaData {
   limit: number;
   used: number;
@@ -31,6 +37,7 @@ interface QuotaData {
   percentage: number;
   has_access: boolean;
   reset_at: string;
+  by_coach?: Record<string, CoachQuotaData>;
 }
 
 interface QuotasData {


### PR DESCRIPTION
## Summary
- **Hub assistant** : page d'accueil avec 5 cards (Nova, Maria, Sofia, David + Lucas bloque/bientot). Clic card → welcome screen de l'assistant. Re-clic sidebar → retour hub.
- **Quotas par coach** : /api/auth/me retourne `by_coach` breakdown. Frontend verifie quota du coach selectionne (pas global).
- **Avatars** : Maria et David ont des avatars professionnels (style avataaars).
- **Fix quota CV** : suppression du setTimeout(1.5s) qui causait des donnees stale → refetch direct.
- **i18n** : labels hub en fr/en/es/pt.

## Test plan
- [ ] /assistant → hub avec 5 cards, Lucas avec badge "Bientot"
- [ ] Clic sur Nova → welcome screen avec suggestions
- [ ] Re-clic sidebar "Coach IA" → retour au hub
- [ ] Quota assistant: 5 messages avec Nova ne bloque pas Maria
- [ ] Analyse CV: quota s'affiche correctement apres consommation (pas 0)