### PR TITLE
feat(referral): refonte admin parrainage + fix flow + affichage

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1608,7 +1608,7 @@ async def get_referral_leaderboard(
     admin: AdminUserDep,
     limit: int = Query(default=20, ge=1, le=100),
 ) -> dict[str, Any]:
-    """Top referrers sorted by total_conversions."""
+    """Top referrers sorted by total_conversions, enriched with plan + revenue data."""
     supabase = get_supabase_client()
     result = supabase.table("referrals").select(
         "id, referral_code, total_clicks, total_signups, total_conversions, referrer_id"
@@ -1616,24 +1616,82 @@ async def get_referral_leaderboard(
 
     rows = result.data or []
     referrer_ids = list({r["referrer_id"] for r in rows if r.get("referrer_id")})
+    referral_ids = [r["id"] for r in rows]
+
+    # Profiles
     profiles_map: dict[str, Any] = {}
     if referrer_ids:
         pr = supabase.table("profiles").select("id, email, full_name").in_("id", referrer_ids).execute()
         profiles_map = {p["id"]: {"email": p["email"], "full_name": p.get("full_name")} for p in (pr.data or [])}
 
-    leaderboard = [{**r, "profiles": profiles_map.get(r["referrer_id"])} for r in rows]
+    # Subscriptions (referrer's own plan)
+    subs_map: dict[str, dict[str, str | None]] = {}
+    if referrer_ids:
+        sr = supabase.table("user_subscriptions").select("user_id, plan_name, status").in_("user_id", referrer_ids).eq("status", "active").execute()
+        for s in (sr.data or []):
+            subs_map[s["user_id"]] = {"plan": s.get("plan_name"), "status": s.get("status")}
+
+    # Paying referrals + last signup per referral_id
+    paying_map: dict[str, list[str]] = {}  # referral_id -> list of converted_plan
+    last_signup_map: dict[str, str | None] = {}
+    if referral_ids:
+        sig = supabase.table("referral_signups").select(
+            "referral_id, converted_to_paid_at, converted_plan, signed_up_at"
+        ).in_("referral_id", referral_ids).execute()
+        for s in (sig.data or []):
+            rid = s["referral_id"]
+            if s.get("converted_to_paid_at"):
+                paying_map.setdefault(rid, []).append(s.get("converted_plan") or "unknown")
+            cur = last_signup_map.get(rid)
+            if not cur or (s.get("signed_up_at") and s["signed_up_at"] > cur):
+                last_signup_map[rid] = s.get("signed_up_at")
+
+    leaderboard = []
+    for r in rows:
+        sub = subs_map.get(r["referrer_id"], {})
+        paying = paying_map.get(r["id"], [])
+        plans_count: dict[str, int] = {}
+        for p in paying:
+            plans_count[p] = plans_count.get(p, 0) + 1
+        leaderboard.append({
+            **r,
+            "profiles": profiles_map.get(r["referrer_id"]),
+            "referrer_plan": sub.get("plan"),
+            "referrer_plan_status": sub.get("status"),
+            "paying_referrals": len(paying),
+            "paying_plans": plans_count,
+            "last_signup_at": last_signup_map.get(r["id"]),
+        })
     return {"leaderboard": leaderboard}
 
 
 @router.get("/referrals/stats")
 async def get_referral_stats(admin: AdminUserDep) -> dict[str, Any]:
-    """Global referral program statistics."""
+    """Global referral program statistics with conversion rate and revenue breakdown."""
     supabase = get_supabase_client()
+    total_referrers = supabase.table("referrals").select("id", count="exact").execute().count or 0
+    active_referrers = supabase.table("referrals").select("id", count="exact").eq("is_active", True).execute().count or 0
+    total_signups = supabase.table("referral_signups").select("id", count="exact").execute().count or 0
+    total_conversions = supabase.table("referral_signups").select("id", count="exact").not_.is_("converted_to_paid_at", "null").execute().count or 0
+    total_rewards_applied = supabase.table("referral_rewards").select("id", count="exact").eq("applied", True).execute().count or 0
+
+    # Revenue by plan
+    revenue_by_plan: dict[str, int] = {}
+    if total_conversions > 0:
+        conv_res = supabase.table("referral_signups").select("converted_plan").not_.is_("converted_to_paid_at", "null").execute()
+        for row in (conv_res.data or []):
+            plan = row.get("converted_plan") or "unknown"
+            revenue_by_plan[plan] = revenue_by_plan.get(plan, 0) + 1
+
     return {
-        "total_referrers": supabase.table("referrals").select("id", count="exact").execute().count or 0,
-        "total_signups": supabase.table("referral_signups").select("id", count="exact").execute().count or 0,
-        "total_conversions": supabase.table("referral_signups").select("id", count="exact").not_.is_("converted_to_paid_at", "null").execute().count or 0,
-        "total_rewards_applied": supabase.table("referral_rewards").select("id", count="exact").eq("applied", True).execute().count or 0,
+        "total_referrers": total_referrers,
+        "active_referrers": active_referrers,
+        "inactive_referrers": total_referrers - active_referrers,
+        "total_signups": total_signups,
+        "total_conversions": total_conversions,
+        "total_rewards_applied": total_rewards_applied,
+        "conversion_rate": round(total_conversions / total_signups * 100, 1) if total_signups > 0 else 0.0,
+        "revenue_by_plan": revenue_by_plan,
     }
 
 
@@ -1683,6 +1741,159 @@ async def grant_manual_reward(signup_id: str, admin: AdminUserDep) -> dict[str, 
     )
     _log_admin_action(supabase, admin["id"], "admin.referral_reward_granted", {"signup_id": signup_id})
     return {"ok": success}
+
+
+@router.get("/referrals/signups")
+async def get_referral_signups(
+    admin: AdminUserDep,
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=50, ge=1, le=100),
+) -> dict[str, Any]:
+    """All referral signups with full details for admin."""
+    supabase = get_supabase_client()
+    offset = (page - 1) * per_page
+
+    result = supabase.table("referral_signups").select(
+        "id, referral_id, referred_user_id, signed_up_at, converted_to_paid_at, converted_plan",
+        count="exact",
+    ).order("signed_up_at", desc=True).range(offset, offset + per_page - 1).execute()
+
+    rows = result.data or []
+    total = result.count or 0
+
+    referred_ids = list({r["referred_user_id"] for r in rows if r.get("referred_user_id")})
+    referral_ids = list({r["referral_id"] for r in rows if r.get("referral_id")})
+
+    referred_profiles: dict[str, Any] = {}
+    if referred_ids:
+        pr = supabase.table("profiles").select("id, email, full_name").in_("id", referred_ids).execute()
+        referred_profiles = {p["id"]: p for p in (pr.data or [])}
+
+    referrals_map: dict[str, Any] = {}
+    referrer_ids_set: set[str] = set()
+    if referral_ids:
+        rr = supabase.table("referrals").select("id, referrer_id, referral_code").in_("id", referral_ids).execute()
+        for r in (rr.data or []):
+            referrals_map[r["id"]] = r
+            referrer_ids_set.add(r["referrer_id"])
+
+    referrer_profiles: dict[str, Any] = {}
+    if referrer_ids_set:
+        rp = supabase.table("profiles").select("id, email, full_name").in_("id", list(referrer_ids_set)).execute()
+        referrer_profiles = {p["id"]: p for p in (rp.data or [])}
+
+    signups = []
+    for row in rows:
+        ref = referrals_map.get(row.get("referral_id", ""), {})
+        referred_p = referred_profiles.get(row.get("referred_user_id", ""), {})
+        referrer_p = referrer_profiles.get(ref.get("referrer_id", ""), {})
+        signups.append({
+            "id": row["id"],
+            "referred_email": referred_p.get("email", ""),
+            "referred_name": referred_p.get("full_name"),
+            "referrer_email": referrer_p.get("email", ""),
+            "referrer_name": referrer_p.get("full_name"),
+            "referral_code": ref.get("referral_code", ""),
+            "signed_up_at": row.get("signed_up_at"),
+            "converted_to_paid_at": row.get("converted_to_paid_at"),
+            "converted_plan": row.get("converted_plan"),
+        })
+
+    return {"signups": signups, "total": total, "page": page, "per_page": per_page}
+
+
+@router.get("/referrals/rewards")
+async def get_referral_rewards(
+    admin: AdminUserDep,
+    page: int = Query(default=1, ge=1),
+    per_page: int = Query(default=50, ge=1, le=100),
+) -> dict[str, Any]:
+    """All referral rewards with details for admin."""
+    supabase = get_supabase_client()
+    offset = (page - 1) * per_page
+
+    result = supabase.table("referral_rewards").select(
+        "id, referral_signup_id, referrer_id, reward_type, reward_value, applied, applied_at, created_at",
+        count="exact",
+    ).order("created_at", desc=True).range(offset, offset + per_page - 1).execute()
+
+    rows = result.data or []
+    total = result.count or 0
+
+    referrer_ids = list({r["referrer_id"] for r in rows if r.get("referrer_id")})
+    profiles_map: dict[str, Any] = {}
+    if referrer_ids:
+        pr = supabase.table("profiles").select("id, email, full_name").in_("id", referrer_ids).execute()
+        profiles_map = {p["id"]: p for p in (pr.data or [])}
+
+    rewards = []
+    for row in rows:
+        p = profiles_map.get(row.get("referrer_id", ""), {})
+        rv = row.get("reward_value") or {}
+        rewards.append({
+            "id": row["id"],
+            "referrer_email": p.get("email", ""),
+            "referrer_name": p.get("full_name"),
+            "reward_type": row.get("reward_type", ""),
+            "reward_value": rv,
+            "tier_name": rv.get("name", ""),
+            "tier_index": rv.get("tier_index", -1),
+            "applied": row.get("applied", False),
+            "applied_at": row.get("applied_at"),
+            "created_at": row.get("created_at"),
+            "referral_signup_id": row.get("referral_signup_id", ""),
+        })
+
+    return {"rewards": rewards, "total": total, "page": page, "per_page": per_page}
+
+
+class ManualReferralLink(BaseModel):
+    referrer_email: str
+    referred_email: str
+
+
+@router.post("/referrals/link-manual")
+async def link_referral_manually(body: ManualReferralLink, admin: AdminUserDep) -> dict[str, Any]:
+    """Manually link a referred user to a referrer when auto-flow failed."""
+    supabase = get_supabase_client()
+
+    referrer_res = supabase.table("profiles").select("id").eq("email", body.referrer_email).maybe_single().execute()
+    if not referrer_res.data:
+        raise HTTPException(status_code=404, detail=f"Parrain introuvable : {body.referrer_email}")
+    referrer_user_id = referrer_res.data["id"]
+
+    referred_res = supabase.table("profiles").select("id").eq("email", body.referred_email).maybe_single().execute()
+    if not referred_res.data:
+        raise HTTPException(status_code=404, detail=f"Filleul introuvable : {body.referred_email}")
+    referred_user_id = referred_res.data["id"]
+
+    if referrer_user_id == referred_user_id:
+        raise HTTPException(status_code=400, detail="Auto-parrainage interdit")
+
+    ref_res = supabase.table("referrals").select("id").eq("referrer_id", referrer_user_id).eq("is_active", True).maybe_single().execute()
+    if not ref_res.data:
+        raise HTTPException(status_code=404, detail="Ce parrain n'a pas de code de parrainage actif")
+    referral_id = ref_res.data["id"]
+
+    try:
+        supabase.table("referral_signups").insert({
+            "referral_id": referral_id,
+            "referred_user_id": referred_user_id,
+        }).execute()
+
+        supabase.rpc("increment_referral_signups", {"p_referral_id": referral_id}).execute()
+
+        _log_admin_action(supabase, admin["id"], "admin.referral_manual_link", {
+            "referrer_email": body.referrer_email,
+            "referred_email": body.referred_email,
+        })
+
+        return {"ok": True, "message": f"{body.referred_email} lié à {body.referrer_email}"}
+    except Exception as e:
+        if "duplicate" in str(e).lower() or "unique" in str(e).lower():
+            return {"ok": True, "message": "Déjà lié (doublon)"}
+        logger.error(f"[ADMIN] link_referral_manually error: {e}")
+        raise HTTPException(status_code=500, detail="Échec de la liaison") from e
 
 
 # ============================================================

--- a/frontend-next/src/app/admin/referrals/page.tsx
+++ b/frontend-next/src/app/admin/referrals/page.tsx
@@ -7,6 +7,8 @@ import {
   type ReferralStats,
   type ReferralConfig,
   type ReferralTier,
+  type ReferralSignupEntry,
+  type ReferralRewardEntry,
 } from '@/hooks/admin/use-admin-referrals'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -14,6 +16,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   Select,
   SelectContent,
@@ -21,39 +24,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { RefreshCw, Users, TrendingUp, Gift, MousePointerClick, Plus, Trash2 } from 'lucide-react'
+import {
+  RefreshCw, Users, TrendingUp, Gift, MousePointerClick,
+  Plus, Trash2, ChevronLeft, ChevronRight, Link2, Percent,
+  Crown, ArrowRight,
+} from 'lucide-react'
 import { toast } from 'sonner'
 
-function KpiCard({ title, value, icon: Icon }: { title: string; value: string | number; icon: React.ComponentType<{ className?: string }> }) {
-  return (
-    <Card>
-      <CardContent className="pt-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-medium text-muted-foreground">{title}</p>
-            <p className="text-2xl font-bold mt-1">{value}</p>
-          </div>
-          <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
-            <Icon className="h-5 w-5 text-primary" />
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  )
-}
-
 // ---------------------------------------------------------------------------
-// Tier Editor — full CRUD for referral tiers
+// Helpers
 // ---------------------------------------------------------------------------
-
-const EMPTY_TIER: ReferralTier = {
-  name: '',
-  friends: 1,
-  reward_type: 'free_days',
-  reward_value: 7,
-  reward_plan: 'pro',
-  description: '',
-}
 
 const REWARD_TYPE_LABELS: Record<string, string> = {
   free_days: 'Jours offerts',
@@ -65,63 +45,502 @@ const PLAN_LABELS: Record<string, string> = {
   starter: 'Starter',
   pro: 'Accélérateur',
   premium: 'Carrière',
+  free: 'Gratuit',
 }
 
-function TierEditor({
-  tiers: initialTiers,
-  onSave,
-}: {
+function planBadge(plan: string | null) {
+  if (!plan) return <Badge variant="outline" className="text-xs">-</Badge>
+  const colors: Record<string, string> = {
+    premium: 'bg-amber-100 text-amber-800 border-amber-200',
+    pro: 'bg-blue-100 text-blue-800 border-blue-200',
+    starter: 'bg-green-100 text-green-800 border-green-200',
+    free: 'bg-gray-100 text-gray-600 border-gray-200',
+  }
+  return (
+    <Badge variant="outline" className={`text-xs ${colors[plan] || ''}`}>
+      {PLAN_LABELS[plan] || plan}
+    </Badge>
+  )
+}
+
+function formatDate(iso: string | null) {
+  if (!iso) return '-'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' })
+}
+
+function KpiCard({ title, value, subtitle, icon: Icon }: {
+  title: string; value: string | number; subtitle?: string
+  icon: React.ComponentType<{ className?: string }>
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">{title}</p>
+            <p className="text-2xl font-bold mt-1">{value}</p>
+            {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+          </div>
+          <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon className="h-5 w-5 text-primary" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tab 1 : Vue d'ensemble (KPIs + Leaderboard)
+// ---------------------------------------------------------------------------
+
+function OverviewTab({ stats, leaderboard, loading }: {
+  stats: ReferralStats | null
+  leaderboard: ReferralLeaderEntry[]
+  loading: boolean
+}) {
+  if (loading) return <div className="py-12 text-center text-muted-foreground">Chargement...</div>
+
+  return (
+    <div className="space-y-6">
+      {/* KPIs */}
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+          <KpiCard
+            title="Référents actifs"
+            value={stats.active_referrers ?? stats.total_referrers}
+            subtitle={stats.inactive_referrers ? `${stats.inactive_referrers} inactif(s)` : undefined}
+            icon={Users}
+          />
+          <KpiCard title="Inscriptions" value={stats.total_signups} icon={MousePointerClick} />
+          <KpiCard title="Conversions" value={stats.total_conversions} icon={TrendingUp} />
+          <KpiCard title="Récompenses" value={stats.total_rewards_applied} icon={Gift} />
+          <KpiCard
+            title="Taux conversion"
+            value={`${stats.conversion_rate ?? 0}%`}
+            icon={Percent}
+          />
+          <KpiCard
+            title="Revenue plans"
+            value={Object.values(stats.revenue_by_plan || {}).reduce((a, b) => a + b, 0)}
+            subtitle={Object.entries(stats.revenue_by_plan || {}).map(([p, n]) => `${n} ${p}`).join(', ') || 'Aucun'}
+            icon={Crown}
+          />
+        </div>
+      )}
+
+      {/* Leaderboard */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Top référents</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {leaderboard.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">Aucun référent pour l'instant.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs text-muted-foreground">
+                    <th className="py-2 pr-2 w-8">#</th>
+                    <th className="py-2 pr-3">Référent</th>
+                    <th className="py-2 pr-3">Plan</th>
+                    <th className="py-2 pr-3">Code</th>
+                    <th className="py-2 pr-3 text-center">Funnel</th>
+                    <th className="py-2 pr-3 text-center">Revenue</th>
+                    <th className="py-2">Dernière activité</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {leaderboard.map((entry, i) => (
+                    <tr key={entry.id} className="border-b last:border-0">
+                      <td className="py-3 pr-2 text-xs text-muted-foreground font-bold">{i + 1}</td>
+                      <td className="py-3 pr-3">
+                        <p className="font-medium truncate max-w-[200px]">
+                          {entry.profiles?.full_name || entry.profiles?.email || entry.referrer_id.slice(0, 8)}
+                        </p>
+                        {entry.profiles?.full_name && (
+                          <p className="text-xs text-muted-foreground truncate max-w-[200px]">
+                            {entry.profiles.email}
+                          </p>
+                        )}
+                      </td>
+                      <td className="py-3 pr-3">{planBadge(entry.referrer_plan)}</td>
+                      <td className="py-3 pr-3">
+                        <span className="font-mono text-xs text-muted-foreground">{entry.referral_code}</span>
+                      </td>
+                      <td className="py-3 pr-3 text-center">
+                        <div className="flex items-center justify-center gap-1 text-xs">
+                          <span title="Clics">{entry.total_clicks}c</span>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                          <span title="Inscrits">{entry.total_signups}s</span>
+                          <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                          <Badge variant="secondary" className="text-xs">{entry.total_conversions} conv.</Badge>
+                        </div>
+                      </td>
+                      <td className="py-3 pr-3 text-center">
+                        {entry.paying_referrals > 0 ? (
+                          <div className="flex flex-wrap gap-1 justify-center">
+                            {Object.entries(entry.paying_plans || {}).map(([plan, count]) => (
+                              <Badge key={plan} variant="outline" className="text-xs">
+                                {count}x {PLAN_LABELS[plan] || plan}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">-</span>
+                        )}
+                      </td>
+                      <td className="py-3 text-xs text-muted-foreground">
+                        {formatDate(entry.last_signup_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tab 2 : Filleuls
+// ---------------------------------------------------------------------------
+
+function SignupsTab({ fetchSignups, linkManual }: {
+  fetchSignups: (page?: number) => Promise<{ signups: ReferralSignupEntry[]; total: number; page: number; per_page: number }>
+  linkManual: (referrerEmail: string, referredEmail: string) => Promise<boolean>
+}) {
+  const [signups, setSignups] = useState<ReferralSignupEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [linkReferrer, setLinkReferrer] = useState('')
+  const [linkReferred, setLinkReferred] = useState('')
+  const [linking, setLinking] = useState(false)
+
+  const load = useCallback(async (p: number) => {
+    setLoading(true)
+    try {
+      const data = await fetchSignups(p)
+      setSignups(data.signups)
+      setTotal(data.total)
+      setPage(data.page)
+    } catch {
+      toast.error('Erreur chargement filleuls')
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchSignups])
+
+  useEffect(() => { load(1) }, [load])
+
+  const handleLink = async () => {
+    if (!linkReferrer.trim() || !linkReferred.trim()) return
+    setLinking(true)
+    const ok = await linkManual(linkReferrer.trim(), linkReferred.trim())
+    setLinking(false)
+    if (ok) {
+      setLinkReferrer('')
+      setLinkReferred('')
+      load(page)
+    }
+  }
+
+  const totalPages = Math.ceil(total / 50)
+
+  return (
+    <div className="space-y-4">
+      {/* Lien manuel */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Link2 className="h-4 w-4" />
+            Lier manuellement un filleul
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-3 items-end">
+            <div className="flex-1 space-y-1">
+              <Label className="text-xs text-muted-foreground">Email du parrain</Label>
+              <Input
+                value={linkReferrer}
+                onChange={e => setLinkReferrer(e.target.value)}
+                placeholder="parrain@email.com"
+                className="h-9 text-sm"
+              />
+            </div>
+            <div className="flex-1 space-y-1">
+              <Label className="text-xs text-muted-foreground">Email du filleul</Label>
+              <Input
+                value={linkReferred}
+                onChange={e => setLinkReferred(e.target.value)}
+                placeholder="filleul@email.com"
+                className="h-9 text-sm"
+              />
+            </div>
+            <Button size="sm" onClick={handleLink} disabled={linking || !linkReferrer || !linkReferred}>
+              {linking ? 'Liaison...' : 'Lier'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Table */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm font-medium">
+              Tous les filleuls ({total})
+            </CardTitle>
+            <Button variant="outline" size="sm" onClick={() => load(page)} disabled={loading}>
+              <RefreshCw className={`h-3 w-3 mr-1 ${loading ? 'animate-spin' : ''}`} />
+              Actualiser
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="py-8 text-center text-muted-foreground">Chargement...</div>
+          ) : signups.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">Aucun filleul enregistré.</p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-xs text-muted-foreground">
+                      <th className="py-2 pr-3">Filleul</th>
+                      <th className="py-2 pr-3">Parrain</th>
+                      <th className="py-2 pr-3">Code</th>
+                      <th className="py-2 pr-3">Date inscription</th>
+                      <th className="py-2 pr-3">Statut</th>
+                      <th className="py-2">Plan converti</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {signups.map(s => (
+                      <tr key={s.id} className="border-b last:border-0">
+                        <td className="py-3 pr-3">
+                          <p className="font-medium truncate max-w-[180px]">{s.referred_email}</p>
+                          {s.referred_name && <p className="text-xs text-muted-foreground">{s.referred_name}</p>}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <p className="truncate max-w-[180px]">{s.referrer_email}</p>
+                          {s.referrer_name && <p className="text-xs text-muted-foreground">{s.referrer_name}</p>}
+                        </td>
+                        <td className="py-3 pr-3">
+                          <span className="font-mono text-xs text-muted-foreground">{s.referral_code}</span>
+                        </td>
+                        <td className="py-3 pr-3 text-xs">{formatDate(s.signed_up_at)}</td>
+                        <td className="py-3 pr-3">
+                          {s.converted_to_paid_at ? (
+                            <Badge className="bg-green-100 text-green-700 border-green-200 text-xs">Converti</Badge>
+                          ) : (
+                            <Badge variant="secondary" className="text-xs">Inscrit</Badge>
+                          )}
+                        </td>
+                        <td className="py-3">{s.converted_plan ? planBadge(s.converted_plan) : <span className="text-xs text-muted-foreground">-</span>}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-4">
+                  <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => load(page - 1)}>
+                    <ChevronLeft className="h-4 w-4 mr-1" /> Précédent
+                  </Button>
+                  <span className="text-xs text-muted-foreground">Page {page} / {totalPages}</span>
+                  <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => load(page + 1)}>
+                    Suivant <ChevronRight className="h-4 w-4 ml-1" />
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tab 3 : Récompenses
+// ---------------------------------------------------------------------------
+
+function RewardsTab({ fetchRewards, grantReward }: {
+  fetchRewards: (page?: number) => Promise<{ rewards: ReferralRewardEntry[]; total: number; page: number; per_page: number }>
+  grantReward: (signupId: string) => Promise<boolean>
+}) {
+  const [rewards, setRewards] = useState<ReferralRewardEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+
+  const load = useCallback(async (p: number) => {
+    setLoading(true)
+    try {
+      const data = await fetchRewards(p)
+      setRewards(data.rewards)
+      setTotal(data.total)
+      setPage(data.page)
+    } catch {
+      toast.error('Erreur chargement récompenses')
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchRewards])
+
+  useEffect(() => { load(1) }, [load])
+
+  const totalPages = Math.ceil(total / 50)
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            Historique des récompenses ({total})
+          </CardTitle>
+          <Button variant="outline" size="sm" onClick={() => load(page)} disabled={loading}>
+            <RefreshCw className={`h-3 w-3 mr-1 ${loading ? 'animate-spin' : ''}`} />
+            Actualiser
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="py-8 text-center text-muted-foreground">Chargement...</div>
+        ) : rewards.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-4 text-center">Aucune récompense enregistrée.</p>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs text-muted-foreground">
+                    <th className="py-2 pr-3">Référent</th>
+                    <th className="py-2 pr-3">Type</th>
+                    <th className="py-2 pr-3">Palier</th>
+                    <th className="py-2 pr-3">Statut</th>
+                    <th className="py-2 pr-3">Date</th>
+                    <th className="py-2">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rewards.map(r => (
+                    <tr key={r.id} className="border-b last:border-0">
+                      <td className="py-3 pr-3">
+                        <p className="font-medium truncate max-w-[180px]">{r.referrer_email}</p>
+                        {r.referrer_name && <p className="text-xs text-muted-foreground">{r.referrer_name}</p>}
+                      </td>
+                      <td className="py-3 pr-3 text-xs">{REWARD_TYPE_LABELS[r.reward_type] || r.reward_type}</td>
+                      <td className="py-3 pr-3">
+                        {r.tier_name ? (
+                          <Badge variant="outline" className="text-xs">{r.tier_name}</Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">Conversion</span>
+                        )}
+                      </td>
+                      <td className="py-3 pr-3">
+                        {r.applied ? (
+                          <Badge className="bg-green-100 text-green-700 border-green-200 text-xs">Appliqué</Badge>
+                        ) : (
+                          <Badge className="bg-orange-100 text-orange-700 border-orange-200 text-xs">En attente</Badge>
+                        )}
+                      </td>
+                      <td className="py-3 pr-3 text-xs">{formatDate(r.applied_at || r.created_at)}</td>
+                      <td className="py-3">
+                        {!r.applied && r.referral_signup_id && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            onClick={async () => {
+                              const ok = await grantReward(r.referral_signup_id)
+                              if (ok) load(page)
+                            }}
+                          >
+                            Appliquer
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4">
+                <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => load(page - 1)}>
+                  <ChevronLeft className="h-4 w-4 mr-1" /> Précédent
+                </Button>
+                <span className="text-xs text-muted-foreground">Page {page} / {totalPages}</span>
+                <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => load(page + 1)}>
+                  Suivant <ChevronRight className="h-4 w-4 ml-1" />
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tab 4 : Configuration (existant, inchangé)
+// ---------------------------------------------------------------------------
+
+const EMPTY_TIER: ReferralTier = {
+  name: '',
+  friends: 1,
+  reward_type: 'free_days',
+  reward_value: 7,
+  reward_plan: 'pro',
+  description: '',
+}
+
+function TierEditor({ tiers: initialTiers, onSave }: {
   tiers: ReferralTier[]
   onSave: (tiers: ReferralTier[]) => Promise<boolean>
 }) {
   const [tiers, setTiers] = useState<ReferralTier[]>(initialTiers)
   const [saving, setSaving] = useState(false)
 
-  // Sync if parent data changes (e.g. after reload)
-  useEffect(() => {
-    setTiers(initialTiers)
-  }, [initialTiers])
+  useEffect(() => { setTiers(initialTiers) }, [initialTiers])
 
   const updateTier = (index: number, field: keyof ReferralTier, value: string | number) => {
-    setTiers((prev) => {
+    setTiers(prev => {
       const copy = [...prev]
       copy[index] = { ...copy[index], [field]: value }
       return copy
     })
   }
 
-  const addTier = () => {
-    setTiers((prev) => [...prev, { ...EMPTY_TIER }])
-  }
-
-  const removeTier = (index: number) => {
-    setTiers((prev) => prev.filter((_, i) => i !== index))
-  }
+  const addTier = () => setTiers(prev => [...prev, { ...EMPTY_TIER }])
+  const removeTier = (index: number) => setTiers(prev => prev.filter((_, i) => i !== index))
 
   const handleSave = async () => {
-    // Validation basique
     for (const tier of tiers) {
-      if (!tier.name.trim()) {
-        toast.error('Chaque palier doit avoir un nom')
-        return
-      }
-      if (tier.friends < 1) {
-        toast.error('Le nombre d\'amis doit être >= 1')
-        return
-      }
-      if (tier.reward_value < 1) {
-        toast.error('La valeur de récompense doit être >= 1')
-        return
-      }
+      if (!tier.name.trim()) { toast.error('Chaque palier doit avoir un nom'); return }
+      if (tier.friends < 1) { toast.error("Le nombre d'amis doit être >= 1"); return }
+      if (tier.reward_value < 1) { toast.error('La valeur de récompense doit être >= 1'); return }
     }
-
     setSaving(true)
     await onSave(tiers)
     setSaving(false)
   }
 
   return (
-    <Card className="md:col-span-2">
+    <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="text-sm font-medium">Paliers de récompenses</CardTitle>
@@ -133,130 +552,63 @@ function TierEditor({
       </CardHeader>
       <CardContent className="space-y-4">
         {tiers.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            Aucun palier configuré.
-          </p>
+          <p className="text-sm text-muted-foreground py-4 text-center">Aucun palier configuré.</p>
         ) : (
           <div className="space-y-4">
             {tiers.map((tier, index) => (
-              <div
-                key={index}
-                className="border rounded-lg p-4 space-y-3 relative"
-              >
+              <div key={index} className="border rounded-lg p-4 space-y-3 relative">
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                    Palier {index + 1}
-                  </span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                    onClick={() => removeTier(index)}
-                  >
+                  <span className="text-xs font-bold text-muted-foreground uppercase tracking-wider">Palier {index + 1}</span>
+                  <Button variant="ghost" size="sm" className="h-7 w-7 p-0 text-destructive hover:text-destructive" onClick={() => removeTier(index)}>
                     <Trash2 className="h-4 w-4" />
                   </Button>
                 </div>
-
                 <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                  {/* Nom */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">Nom</Label>
-                    <Input
-                      value={tier.name}
-                      onChange={(e) => updateTier(index, 'name', e.target.value)}
-                      placeholder="Bronze"
-                      className="h-8 text-sm"
-                    />
+                    <Input value={tier.name} onChange={e => updateTier(index, 'name', e.target.value)} placeholder="Bronze" className="h-8 text-sm" />
                   </div>
-
-                  {/* Friends threshold */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">Amis requis</Label>
-                    <Input
-                      type="number"
-                      min="1"
-                      max="100"
-                      value={tier.friends}
-                      onChange={(e) => updateTier(index, 'friends', parseInt(e.target.value) || 1)}
-                      className="h-8 text-sm"
-                    />
+                    <Input type="number" min="1" max="100" value={tier.friends} onChange={e => updateTier(index, 'friends', parseInt(e.target.value) || 1)} className="h-8 text-sm" />
                   </div>
-
-                  {/* Reward type */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">Type de récompense</Label>
-                    <Select
-                      value={tier.reward_type}
-                      onValueChange={(v) => updateTier(index, 'reward_type', v)}
-                    >
-                      <SelectTrigger className="h-8 text-sm">
-                        <SelectValue />
-                      </SelectTrigger>
+                    <Select value={tier.reward_type} onValueChange={v => updateTier(index, 'reward_type', v)}>
+                      <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
                       <SelectContent>
                         {Object.entries(REWARD_TYPE_LABELS).map(([key, label]) => (
-                          <SelectItem key={key} value={key}>
-                            {label}
-                          </SelectItem>
+                          <SelectItem key={key} value={key}>{label}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
-
-                  {/* Reward value */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">
-                      {tier.reward_type === 'free_days'
-                        ? 'Jours'
-                        : tier.reward_type === 'quota_bonus'
-                          ? 'Bonus quota'
-                          : 'Réduction (%)'}
+                      {tier.reward_type === 'free_days' ? 'Jours' : tier.reward_type === 'quota_bonus' ? 'Bonus quota' : 'Réduction (%)'}
                     </Label>
-                    <Input
-                      type="number"
-                      min="1"
-                      max={tier.reward_type === 'stripe_coupon' ? 100 : 365}
-                      value={tier.reward_value}
-                      onChange={(e) => updateTier(index, 'reward_value', parseInt(e.target.value) || 1)}
-                      className="h-8 text-sm"
-                    />
+                    <Input type="number" min="1" max={tier.reward_type === 'stripe_coupon' ? 100 : 365} value={tier.reward_value} onChange={e => updateTier(index, 'reward_value', parseInt(e.target.value) || 1)} className="h-8 text-sm" />
                   </div>
-
-                  {/* Reward plan */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">Plan concerné</Label>
-                    <Select
-                      value={tier.reward_plan}
-                      onValueChange={(v) => updateTier(index, 'reward_plan', v)}
-                    >
-                      <SelectTrigger className="h-8 text-sm">
-                        <SelectValue />
-                      </SelectTrigger>
+                    <Select value={tier.reward_plan} onValueChange={v => updateTier(index, 'reward_plan', v)}>
+                      <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
                       <SelectContent>
-                        {Object.entries(PLAN_LABELS).map(([key, label]) => (
-                          <SelectItem key={key} value={key}>
-                            {label}
-                          </SelectItem>
+                        {Object.entries(PLAN_LABELS).filter(([k]) => k !== 'free').map(([key, label]) => (
+                          <SelectItem key={key} value={key}>{label}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>
                   </div>
-
-                  {/* Description */}
                   <div className="space-y-1">
                     <Label className="text-xs text-muted-foreground">Description</Label>
-                    <Input
-                      value={tier.description}
-                      onChange={(e) => updateTier(index, 'description', e.target.value)}
-                      placeholder="7 jours Accélérateur offerts"
-                      className="h-8 text-sm"
-                    />
+                    <Input value={tier.description} onChange={e => updateTier(index, 'description', e.target.value)} placeholder="7 jours Accélérateur offerts" className="h-8 text-sm" />
                   </div>
                 </div>
               </div>
             ))}
           </div>
         )}
-
         <Button size="sm" onClick={handleSave} disabled={saving}>
           {saving ? 'Sauvegarde...' : 'Sauvegarder les paliers'}
         </Button>
@@ -265,19 +617,12 @@ function TierEditor({
   )
 }
 
-// ---------------------------------------------------------------------------
-// Config Editor — programme on/off + conversion reward type
-// ---------------------------------------------------------------------------
-
-function ConfigEditor({
-  config,
-  onSave,
-}: {
+function ConfigEditor({ config, onSave }: {
   config: ReferralConfig
   onSave: (updates: Record<string, unknown>) => Promise<boolean>
 }) {
   const [rewardType, setRewardType] = useState(config.conversion_reward_type)
-  const [days, setDays] = useState(String(config.conversion_reward_value?.days ?? 7))
+  const [days, setDays] = useState(String((config.conversion_reward_value as Record<string, number>)?.days ?? 7))
   const [active, setActive] = useState(config.is_active)
   const [saving, setSaving] = useState(false)
 
@@ -303,37 +648,22 @@ function ConfigEditor({
           <Label className="text-sm">Programme actif</Label>
           <Switch checked={active} onCheckedChange={setActive} />
         </div>
-
         <div className="space-y-2">
           <Label className="text-sm">Type de récompense (conversion)</Label>
           <div className="flex gap-2">
-            {(['free_days', 'quota_bonus', 'stripe_coupon'] as const).map((t) => (
-              <Button
-                key={t}
-                size="sm"
-                variant={rewardType === t ? 'default' : 'outline'}
-                onClick={() => setRewardType(t)}
-              >
+            {(['free_days', 'quota_bonus', 'stripe_coupon'] as const).map(t => (
+              <Button key={t} size="sm" variant={rewardType === t ? 'default' : 'outline'} onClick={() => setRewardType(t)}>
                 {REWARD_TYPE_LABELS[t]}
               </Button>
             ))}
           </div>
         </div>
-
         {rewardType === 'free_days' && (
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Nombre de jours offerts</Label>
-            <Input
-              type="number"
-              min="1"
-              max="365"
-              value={days}
-              onChange={(e) => setDays(e.target.value)}
-              className="h-8 w-24 text-sm"
-            />
+            <Input type="number" min="1" max="365" value={days} onChange={e => setDays(e.target.value)} className="h-8 w-24 text-sm" />
           </div>
         )}
-
         <Button size="sm" onClick={handleSave} disabled={saving}>
           {saving ? 'Sauvegarde...' : 'Sauvegarder'}
         </Button>
@@ -347,7 +677,11 @@ function ConfigEditor({
 // ---------------------------------------------------------------------------
 
 export default function AdminReferralsPage() {
-  const { fetchLeaderboard, fetchStats, fetchConfig, updateConfig } = useAdminReferrals()
+  const {
+    fetchLeaderboard, fetchStats, fetchConfig, updateConfig,
+    grantReward, fetchSignups, fetchRewards, linkManual,
+  } = useAdminReferrals()
+
   const [leaderboard, setLeaderboard] = useState<ReferralLeaderEntry[]>([])
   const [stats, setStats] = useState<ReferralStats | null>(null)
   const [config, setConfig] = useState<ReferralConfig | null>(null)
@@ -387,7 +721,7 @@ export default function AdminReferralsPage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Système de Parrainage</h1>
           <p className="text-muted-foreground text-sm mt-1">
-            Leaderboard, statistiques et configuration des récompenses.
+            Analytics, filleuls, récompenses et configuration.
           </p>
         </div>
         <Button variant="outline" size="sm" onClick={load} disabled={loading}>
@@ -396,58 +730,33 @@ export default function AdminReferralsPage() {
         </Button>
       </div>
 
-      {/* KPIs */}
-      {stats && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <KpiCard title="Référents actifs" value={stats.total_referrers} icon={Users} />
-          <KpiCard title="Inscriptions" value={stats.total_signups} icon={MousePointerClick} />
-          <KpiCard title="Conversions" value={stats.total_conversions} icon={TrendingUp} />
-          <KpiCard title="Récompenses appliquées" value={stats.total_rewards_applied} icon={Gift} />
-        </div>
-      )}
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Vue d&apos;ensemble</TabsTrigger>
+          <TabsTrigger value="signups">Filleuls</TabsTrigger>
+          <TabsTrigger value="rewards">Récompenses</TabsTrigger>
+          <TabsTrigger value="config">Configuration</TabsTrigger>
+        </TabsList>
 
-      <div className="grid md:grid-cols-2 gap-6">
-        {/* Config */}
-        {config && <ConfigEditor config={config} onSave={handleSaveConfig} />}
+        <TabsContent value="overview" className="mt-4">
+          <OverviewTab stats={stats} leaderboard={leaderboard} loading={loading} />
+        </TabsContent>
 
-        {/* Leaderboard */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-sm font-medium">Top référents</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {leaderboard.length === 0 ? (
-              <p className="text-sm text-muted-foreground py-4 text-center">
-                Aucun référent pour l'instant.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {leaderboard.map((entry, i) => (
-                  <div key={entry.id} className="flex items-center gap-3 py-2 border-b last:border-0">
-                    <span className="text-xs text-muted-foreground w-5 text-center font-bold">{i + 1}</span>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium truncate">
-                        {entry.profiles?.email || entry.referrer_id.slice(0, 8)}
-                      </p>
-                      <p className="text-xs text-muted-foreground font-mono">{entry.referral_code}</p>
-                    </div>
-                    <div className="flex gap-3 text-xs text-muted-foreground">
-                      <span title="Clics">{entry.total_clicks}c</span>
-                      <span title="Inscriptions">{entry.total_signups}s</span>
-                      <Badge variant="secondary" className="text-xs">
-                        {entry.total_conversions} conv.
-                      </Badge>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+        <TabsContent value="signups" className="mt-4">
+          <SignupsTab fetchSignups={fetchSignups} linkManual={linkManual} />
+        </TabsContent>
 
-      {/* Tier Editor — full width */}
-      {config && <TierEditor tiers={config.tiers || []} onSave={handleSaveTiers} />}
+        <TabsContent value="rewards" className="mt-4">
+          <RewardsTab fetchRewards={fetchRewards} grantReward={grantReward} />
+        </TabsContent>
+
+        <TabsContent value="config" className="mt-4">
+          <div className="space-y-6">
+            {config && <ConfigEditor config={config} onSave={handleSaveConfig} />}
+            {config && <TierEditor tiers={config.tiers || []} onSave={handleSaveTiers} />}
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/frontend-next/src/app/onboarding/page.tsx
+++ b/frontend-next/src/app/onboarding/page.tsx
@@ -22,7 +22,10 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { PromoCodeInput } from "@/components/auth/promo-code-input";
+import {
+  PromoCodeInput,
+  type CodeValidationResult,
+} from "@/components/auth/promo-code-input";
 
 const TOTAL_STEPS = 7;
 
@@ -121,6 +124,9 @@ function OnboardingWizard() {
   // Step 5 - Discovery
   const [discoverySource, setDiscoverySource] = useState("");
 
+  // User ID for referral registration
+  const [userId, setUserId] = useState<string | null>(null);
+
   // Guard: if already onboarded, redirect
   useEffect(() => {
     let cancelled = false;
@@ -135,6 +141,8 @@ function OnboardingWizard() {
           router.replace("/login");
           return;
         }
+
+        if (!cancelled) setUserId(user.id);
 
         if (user.user_metadata?.onboarding_completed) {
           router.replace("/jobs");
@@ -562,9 +570,41 @@ function OnboardingWizard() {
                     </p>
                   </div>
                   <PromoCodeInput
-                    onCodeValidated={(code) => {
+                    defaultOpen
+                    onCodeValidated={(
+                      code: string,
+                      result: CodeValidationResult,
+                    ) => {
+                      // Store as backup (auth-context will retry if POST fails)
                       document.cookie = `huntzen_referral_code=${code}; path=/; max-age=${30 * 24 * 60 * 60}; SameSite=Lax`;
                       localStorage.setItem("huntzen_referral_code", code);
+
+                      // Register referral immediately if applicable
+                      if (result.type === "referral" && userId) {
+                        const backendUrl =
+                          process.env.NEXT_PUBLIC_API_URL ||
+                          process.env.NEXT_PUBLIC_BACKEND_URL ||
+                          "";
+                        fetch(`${backendUrl}/api/referrals/register`, {
+                          method: "POST",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({ code, new_user_id: userId }),
+                        })
+                          .then((res) => {
+                            if (res.ok) {
+                              localStorage.setItem(
+                                "huntzen_referral_registered",
+                                "true",
+                              );
+                              localStorage.removeItem("huntzen_referral_code");
+                              document.cookie =
+                                "huntzen_referral_code=; path=/; max-age=0; SameSite=Lax";
+                            }
+                          })
+                          .catch(() => {
+                            // Silently continue — auth-context will retry
+                          });
+                      }
                     }}
                     className="[&_input]:bg-white/10 [&_input]:border-white/20 [&_input]:text-white [&_input]:placeholder:text-gray-500"
                   />

--- a/frontend-next/src/components/auth/promo-code-input.tsx
+++ b/frontend-next/src/components/auth/promo-code-input.tsx
@@ -20,46 +20,57 @@ export interface CodeValidationResult {
 interface PromoCodeInputProps {
   onCodeValidated: (code: string, result: CodeValidationResult) => void;
   initialCode?: string;
+  defaultOpen?: boolean;
   className?: string;
 }
 
-export function PromoCodeInput({ onCodeValidated, initialCode, className }: PromoCodeInputProps) {
+export function PromoCodeInput({
+  onCodeValidated,
+  initialCode,
+  defaultOpen,
+  className,
+}: PromoCodeInputProps) {
   const t = useTranslations("auth.promoCode");
-  const [isOpen, setIsOpen] = useState(!!initialCode);
+  const [isOpen, setIsOpen] = useState(!!initialCode || !!defaultOpen);
   const [code, setCode] = useState(initialCode || "");
-  const [status, setStatus] = useState<"idle" | "loading" | "valid" | "invalid">("idle");
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "valid" | "invalid"
+  >("idle");
   const [result, setResult] = useState<CodeValidationResult | null>(null);
 
-  const validate = useCallback(async (codeToValidate: string) => {
-    if (!codeToValidate.trim()) return;
-    setStatus("loading");
+  const validate = useCallback(
+    async (codeToValidate: string) => {
+      if (!codeToValidate.trim()) return;
+      setStatus("loading");
 
-    try {
-      const backendUrl = process.env.NEXT_PUBLIC_API_URL || "";
-      const res = await fetch(`${backendUrl}/api/codes/validate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code: codeToValidate.trim() }),
-      });
+      try {
+        const backendUrl = process.env.NEXT_PUBLIC_API_URL || "";
+        const res = await fetch(`${backendUrl}/api/codes/validate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code: codeToValidate.trim() }),
+        });
 
-      if (!res.ok) {
+        if (!res.ok) {
+          setStatus("invalid");
+          return;
+        }
+
+        const data: CodeValidationResult = await res.json();
+        setResult(data);
+
+        if (data.valid) {
+          setStatus("valid");
+          onCodeValidated(codeToValidate.trim().toUpperCase(), data);
+        } else {
+          setStatus("invalid");
+        }
+      } catch {
         setStatus("invalid");
-        return;
       }
-
-      const data: CodeValidationResult = await res.json();
-      setResult(data);
-
-      if (data.valid) {
-        setStatus("valid");
-        onCodeValidated(codeToValidate.trim().toUpperCase(), data);
-      } else {
-        setStatus("invalid");
-      }
-    } catch {
-      setStatus("invalid");
-    }
-  }, [onCodeValidated]);
+    },
+    [onCodeValidated],
+  );
 
   useEffect(() => {
     if (initialCode) {
@@ -95,7 +106,8 @@ export function PromoCodeInput({ onCodeValidated, initialCode, className }: Prom
           placeholder={t("placeholder")}
           className={cn(
             "h-10 text-sm",
-            status === "valid" && "border-green-500 focus-visible:ring-green-500",
+            status === "valid" &&
+              "border-green-500 focus-visible:ring-green-500",
             status === "invalid" && "border-red-500 focus-visible:ring-red-500",
           )}
           disabled={status === "loading"}

--- a/frontend-next/src/components/referral/referral-progress-bar.tsx
+++ b/frontend-next/src/components/referral/referral-progress-bar.tsx
@@ -2,7 +2,11 @@
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
-interface Tier { friends: number; label: string; }
+interface Tier {
+  friends: number;
+  label?: string;
+  name?: string;
+}
 interface ReferralProgressBarProps {
   totalValidated: number;
   currentTier: number;
@@ -11,7 +15,12 @@ interface ReferralProgressBarProps {
   tiers: Tier[];
 }
 
-export function ReferralProgressBar({ totalValidated, nextTier, friendsToNext, tiers }: ReferralProgressBarProps) {
+export function ReferralProgressBar({
+  totalValidated,
+  nextTier,
+  friendsToNext,
+  tiers,
+}: ReferralProgressBarProps) {
   const t = useTranslations("referral.progress");
   const maxFriends = tiers[tiers.length - 1]?.friends ?? 10;
   const progress = Math.min(100, (totalValidated / maxFriends) * 100);
@@ -19,18 +28,36 @@ export function ReferralProgressBar({ totalValidated, nextTier, friendsToNext, t
     <div className="space-y-3">
       <div className="flex justify-between text-xs text-muted-foreground">
         {tiers.map((tier) => (
-          <span key={tier.friends} className={cn("font-medium", totalValidated >= tier.friends && "text-teal-500")}>{tier.friends}</span>
+          <span
+            key={tier.friends}
+            className={cn(
+              "font-medium",
+              totalValidated >= tier.friends && "text-teal-500",
+            )}
+          >
+            {tier.friends}
+          </span>
         ))}
       </div>
       <div className="h-3 bg-gray-100 rounded-full overflow-hidden">
-        <div className="h-full bg-gradient-to-r from-blue-600 to-teal-500 rounded-full transition-all duration-700" style={{ width: `${progress}%` }} />
+        <div
+          className="h-full bg-gradient-to-r from-blue-600 to-teal-500 rounded-full transition-all duration-700"
+          style={{ width: `${progress}%` }}
+        />
       </div>
       {nextTier !== null && friendsToNext > 0 && (
         <p className="text-xs text-muted-foreground text-center">
-          {t("remaining", { count: friendsToNext, label: tiers[nextTier]?.label })}
+          {t("remaining", {
+            count: friendsToNext,
+            label: tiers[nextTier]?.label || tiers[nextTier]?.name || "",
+          })}
         </p>
       )}
-      {friendsToNext === 0 && <p className="text-xs text-green-600 font-medium text-center">{t("allUnlocked")}</p>}
+      {friendsToNext === 0 && (
+        <p className="text-xs text-green-600 font-medium text-center">
+          {t("allUnlocked")}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend-next/src/components/referral/referral-tier-card.tsx
+++ b/frontend-next/src/components/referral/referral-tier-card.tsx
@@ -3,24 +3,73 @@ import { useTranslations } from "next-intl";
 import { CheckCircle2, Lock, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-interface Tier { friends: number; reward_type: string; label: string; days?: number; plan?: string; discount_percent?: number; }
-interface ReferralTierCardProps { tier: Tier; index: number; isUnlocked: boolean; isCurrent: boolean; }
+interface Tier {
+  friends: number;
+  reward_type: string;
+  label?: string;
+  name?: string;
+  description?: string;
+  days?: number;
+  reward_value?: number;
+  reward_plan?: string;
+  plan?: string;
+  discount_percent?: number;
+}
+interface ReferralTierCardProps {
+  tier: Tier;
+  index: number;
+  isUnlocked: boolean;
+  isCurrent: boolean;
+}
 
-export function ReferralTierCard({ tier, index, isUnlocked, isCurrent }: ReferralTierCardProps) {
+export function ReferralTierCard({
+  tier,
+  index,
+  isUnlocked,
+  isCurrent,
+}: ReferralTierCardProps) {
   const t = useTranslations("referral.tier");
+  const tierName = tier.label || tier.name || "";
+  const tierDescription = tier.description || "";
   return (
-    <div className={cn("rounded-xl border p-4 transition-all", isUnlocked && "border-teal-400/40 bg-teal-50/30", isCurrent && "ring-2 ring-teal-400", !isUnlocked && "opacity-60")}>
+    <div
+      className={cn(
+        "rounded-xl border p-4 transition-all",
+        isUnlocked && "border-teal-400/40 bg-teal-50/30",
+        isCurrent && "ring-2 ring-teal-400",
+        !isUnlocked && "opacity-60",
+      )}
+    >
       <div className="flex items-start justify-between gap-2">
         <div>
-          <p className="text-xs text-muted-foreground mb-1">{t("label", { index: index + 1, count: tier.friends })}</p>
-          <p className="text-sm font-semibold">{tier.label}</p>
+          <p className="text-xs text-muted-foreground mb-1">
+            {t("label", { index: index + 1, count: tier.friends })}
+          </p>
+          <p className="text-sm font-semibold">{tierName}</p>
+          {tierDescription && (
+            <p className="text-xs text-muted-foreground mt-1">
+              {tierDescription}
+            </p>
+          )}
         </div>
         <div className="flex-shrink-0 mt-0.5">
-          {isUnlocked ? <CheckCircle2 className="w-5 h-5 text-teal-500" /> : isCurrent ? <Clock className="w-5 h-5 text-amber-500" /> : <Lock className="w-5 h-5 text-muted-foreground/50" />}
+          {isUnlocked ? (
+            <CheckCircle2 className="w-5 h-5 text-teal-500" />
+          ) : isCurrent ? (
+            <Clock className="w-5 h-5 text-amber-500" />
+          ) : (
+            <Lock className="w-5 h-5 text-muted-foreground/50" />
+          )}
         </div>
       </div>
       <p className="mt-2 text-xs font-medium">
-        {isUnlocked ? <span className="text-teal-600">{t("reached")}</span> : isCurrent ? <span className="text-amber-500">{t("inProgress")}</span> : <span className="text-muted-foreground">{t("locked")}</span>}
+        {isUnlocked ? (
+          <span className="text-teal-600">{t("reached")}</span>
+        ) : isCurrent ? (
+          <span className="text-amber-500">{t("inProgress")}</span>
+        ) : (
+          <span className="text-muted-foreground">{t("locked")}</span>
+        )}
       </p>
     </div>
   );

--- a/frontend-next/src/contexts/auth-context.tsx
+++ b/frontend-next/src/contexts/auth-context.tsx
@@ -178,7 +178,9 @@ export function AuthProvider({
                       localStorage.setItem("huntzen_referral_registered", "1");
                     }
                   })
-                  .catch(() => {});
+                  .catch((err) => {
+                    console.warn("[REFERRAL] register failed:", err);
+                  });
               } else {
                 // Promo code flow (any other format)
                 fetch(`${backendUrl}/api/codes/apply`, {

--- a/frontend-next/src/hooks/admin/use-admin-referrals.ts
+++ b/frontend-next/src/hooks/admin/use-admin-referrals.ts
@@ -25,6 +25,10 @@ async function adminFetch(path: string, options?: RequestInit) {
   return res.json();
 }
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 export interface ReferralLeaderEntry {
   id: string;
   referral_code: string;
@@ -33,6 +37,11 @@ export interface ReferralLeaderEntry {
   total_conversions: number;
   referrer_id: string;
   profiles: { email: string; full_name: string | null } | null;
+  referrer_plan: string | null;
+  referrer_plan_status: string | null;
+  paying_referrals: number;
+  paying_plans: Record<string, number>;
+  last_signup_at: string | null;
 }
 
 export interface ReferralStats {
@@ -40,6 +49,10 @@ export interface ReferralStats {
   total_signups: number;
   total_conversions: number;
   total_rewards_applied: number;
+  active_referrers: number;
+  inactive_referrers: number;
+  conversion_rate: number;
+  revenue_by_plan: Record<string, number>;
 }
 
 export interface ReferralTier {
@@ -54,13 +67,57 @@ export interface ReferralTier {
 export interface ReferralConfig {
   id: number;
   signup_reward_type: string | null;
-  signup_reward_value: Record<string, any> | null;
+  signup_reward_value: Record<string, unknown> | null;
   conversion_reward_type: string;
-  conversion_reward_value: Record<string, any>;
+  conversion_reward_value: Record<string, unknown>;
   is_active: boolean;
   updated_at: string;
   tiers: ReferralTier[];
 }
+
+export interface ReferralSignupEntry {
+  id: string;
+  referred_email: string;
+  referred_name: string | null;
+  referrer_email: string;
+  referrer_name: string | null;
+  referral_code: string;
+  signed_up_at: string;
+  converted_to_paid_at: string | null;
+  converted_plan: string | null;
+}
+
+export interface ReferralRewardEntry {
+  id: string;
+  referrer_email: string;
+  referrer_name: string | null;
+  reward_type: string;
+  reward_value: Record<string, unknown>;
+  tier_name: string;
+  tier_index: number;
+  applied: boolean;
+  applied_at: string | null;
+  created_at: string;
+  referral_signup_id: string;
+}
+
+interface PaginatedSignups {
+  signups: ReferralSignupEntry[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+interface PaginatedRewards {
+  rewards: ReferralRewardEntry[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export function useAdminReferrals() {
   const fetchLeaderboard = useCallback(async (): Promise<
@@ -100,12 +157,52 @@ export function useAdminReferrals() {
       try {
         const data = await adminFetch(
           `/api/admin/referrals/grant-reward/${signupId}`,
-          {
-            method: "POST",
-          },
+          { method: "POST" },
         );
         if (data.ok) toast.success("Récompense accordée");
         else toast.error("Échec de la récompense");
+        return data.ok;
+      } catch (e) {
+        toast.error(`Erreur : ${e instanceof Error ? e.message : String(e)}`);
+        return false;
+      }
+    },
+    [],
+  );
+
+  const fetchSignups = useCallback(
+    async (page = 1): Promise<PaginatedSignups> => {
+      return adminFetch(
+        `/api/admin/referrals/signups?page=${page}&per_page=50`,
+      );
+    },
+    [],
+  );
+
+  const fetchRewards = useCallback(
+    async (page = 1): Promise<PaginatedRewards> => {
+      return adminFetch(
+        `/api/admin/referrals/rewards?page=${page}&per_page=50`,
+      );
+    },
+    [],
+  );
+
+  const linkManual = useCallback(
+    async (
+      referrerEmail: string,
+      referredEmail: string,
+    ): Promise<boolean> => {
+      try {
+        const data = await adminFetch("/api/admin/referrals/link-manual", {
+          method: "POST",
+          body: JSON.stringify({
+            referrer_email: referrerEmail,
+            referred_email: referredEmail,
+          }),
+        });
+        if (data.ok) toast.success(data.message || "Lien créé");
+        else toast.error("Échec du lien");
         return data.ok;
       } catch (e) {
         toast.error(`Erreur : ${e instanceof Error ? e.message : String(e)}`);
@@ -121,5 +218,8 @@ export function useAdminReferrals() {
     fetchConfig,
     updateConfig,
     grantReward,
+    fetchSignups,
+    fetchRewards,
+    linkManual,
   };
 }


### PR DESCRIPTION
## Summary
- **Admin parrainage** : refonte complète avec 4 onglets Tabs (Vue d'ensemble, Filleuls, Récompenses, Configuration)
- **Leaderboard enrichi** : plan du parrain, revenue généré, funnel clics→inscrits→conv., dernière activité
- **3 nouveaux endpoints** : GET signups (paginé), GET rewards (paginé), POST link-manual
- **Fix flow referral** : onboarding step 6 appelle POST /register immédiatement au lieu de stocker en cookie
- **Fix affichage user** : les tier cards affichent maintenant le nom du palier et la description de la récompense

## Test plan
- [ ] Se connecter en admin, aller sur /admin/referrals
- [ ] Vérifier les 4 onglets (Vue d'ensemble, Filleuls, Récompenses, Configuration)
- [ ] Tester le lien manuel dans l'onglet Filleuls (2 emails)
- [ ] Vérifier la page /referral côté user (noms paliers + descriptions visibles)
- [ ] Tester l'onboarding step 6 avec un code referral (input visible directement)