### PR TITLE
feat(i18n): email bienvenue auto + sync langue profil

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -419,6 +419,7 @@ async def invalidate_user_cache(request: Request, authorization: str | None = He
 class WelcomeRequest(BaseModel):
     email: str
     full_name: str = ""
+    language: str = "fr"
 
 
 @router.post("/api/auth/welcome")
@@ -428,7 +429,7 @@ async def send_welcome_email(request: Request, payload: WelcomeRequest):
     from src.services.admin_alerts import send_admin_alert
     from src.services.email import send_welcome
     try:
-        send_welcome(to_email=payload.email, full_name=payload.full_name)
+        send_welcome(to_email=payload.email, full_name=payload.full_name, language=payload.language)
     except Exception as e:
         logger.warning(f"Welcome email failed (non-blocking): {e}")
 

--- a/frontend-next/src/app/auth/callback/route.ts
+++ b/frontend-next/src/app/auth/callback/route.ts
@@ -51,6 +51,27 @@ export async function GET(request: NextRequest) {
       }
 
       const isNewUser = !data.user?.user_metadata?.onboarding_completed;
+
+      // Send welcome email for new users (fire-and-forget)
+      if (isNewUser && data.user?.email) {
+        const backendUrl =
+          process.env.NEXT_PUBLIC_API_URL ||
+          process.env.NEXT_PUBLIC_BACKEND_URL ||
+          "";
+        const locale = request.cookies.get("NEXT_LOCALE")?.value || "fr";
+        if (backendUrl) {
+          fetch(`${backendUrl}/api/auth/welcome`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: data.user.email,
+              full_name: data.user.user_metadata?.full_name || "",
+              language: locale,
+            }),
+          }).catch(() => {});
+        }
+      }
+
       let isAdmin = false;
       try {
         const { data: profile } = await supabase
@@ -104,6 +125,26 @@ export async function GET(request: NextRequest) {
 
       // OAuth / email confirmation flow: redirect to final destination
       const isNewUser = !data.user.user_metadata?.onboarding_completed;
+
+      // Send welcome email for new OAuth users (fire-and-forget)
+      if (isNewUser && data.user.email) {
+        const backendUrl =
+          process.env.NEXT_PUBLIC_API_URL ||
+          process.env.NEXT_PUBLIC_BACKEND_URL ||
+          "";
+        const locale = request.cookies.get("NEXT_LOCALE")?.value || "fr";
+        if (backendUrl) {
+          fetch(`${backendUrl}/api/auth/welcome`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: data.user.email,
+              full_name: data.user.user_metadata?.full_name || "",
+              language: locale,
+            }),
+          }).catch(() => {});
+        }
+      }
 
       // Check if user is admin
       let isAdmin = false;

--- a/frontend-next/src/components/profile/settings-section.tsx
+++ b/frontend-next/src/components/profile/settings-section.tsx
@@ -36,6 +36,7 @@ import {
 import { useDebounce } from "@/hooks/use-debounce";
 import { useRouter } from "next/navigation";
 import { useOptionalAuth } from "@/contexts/auth-context";
+import { useLocale } from "@/contexts/i18n-context";
 import { useTranslations } from "next-intl";
 
 interface SettingsSectionProps {
@@ -53,6 +54,7 @@ export function SettingsSection({
 }: SettingsSectionProps) {
   const router = useRouter();
   const auth = useOptionalAuth();
+  const { setLocale: setGlobalLocale } = useLocale();
   const t = useTranslations("profile");
 
   // State for settings
@@ -289,19 +291,23 @@ export function SettingsSection({
           </div>
         </div>
 
-        <Select value={language} onValueChange={setLanguage} disabled>
+        <Select
+          value={language}
+          onValueChange={(val) => {
+            setLanguage(val);
+            setGlobalLocale(val as "fr" | "en" | "es" | "pt");
+          }}
+        >
           <SelectTrigger id="language" className="max-w-xs">
             <SelectValue placeholder={t("settingsLanguagePlaceholder")} />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="fr">Français</SelectItem>
             <SelectItem value="en">English</SelectItem>
+            <SelectItem value="es">Español</SelectItem>
+            <SelectItem value="pt">Português</SelectItem>
           </SelectContent>
         </Select>
-
-        <p className="text-xs text-gray-500 bg-gray-50 border border-gray-200 rounded-lg p-3">
-          💡 {t("multilingualComingSoon")}
-        </p>
       </div>
 
       {/* Email Notifications */}

--- a/frontend-next/src/contexts/i18n-context.tsx
+++ b/frontend-next/src/contexts/i18n-context.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
 } from "react";
 import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
 
 // Supported locales (must match middleware.ts)
 export type Locale = "fr" | "en" | "es" | "pt";
@@ -58,6 +59,21 @@ export function I18nProvider({ children }: { children: ReactNode }) {
       setLocaleState(newLocale);
       setCookie(LOCALE_COOKIE_NAME, newLocale, 365); // 1 year expiry
       setCookie("LOCALE_MANUAL", "1", 365); // Flag: user chose manually, don't override with geo
+
+      // Sync to profiles.preferred_language (fire-and-forget)
+      const supabase = createClient();
+      supabase.auth.getUser().then(({ data }) => {
+        if (data.user) {
+          supabase
+            .from("profiles")
+            .update({
+              preferred_language: newLocale,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", data.user.id)
+            .then(() => {});
+        }
+      });
 
       // Full reload pour appliquer la traduction partout (y compris jobs, filtres, etc.)
       window.location.reload();


### PR DESCRIPTION
## Summary
- **Email de bienvenue** envoyé automatiquement après confirmation email et connexion Google (4 langues)
- **Sync langue** : le language switcher met à jour `profiles.preferred_language` en DB pour les emails
- **Dropdown profil** activé (était `disabled`) avec FR/EN/ES/PT, connecté au contexte i18n global
- **Détection IP** : la langue est détectée par géolocalisation IP (Vercel `x-vercel-ip-country`) par défaut

## Test plan
- [ ] Créer un compte par email → vérifier réception email de bienvenue dans la bonne langue
- [ ] Créer un compte par Google → vérifier réception email de bienvenue
- [ ] Changer la langue via le switcher navbar → vérifier que `profiles.preferred_language` est mis à jour en DB
- [ ] Aller dans Profil → Settings → vérifier que le dropdown langue est actif avec 4 options