### PR TITLE
fix(admin): bouton Renvoyer la facture envoyait PUT au lieu de POST

### DIFF
--- a/frontend-next/src/components/admin/users/user-actions-menu.tsx
+++ b/frontend-next/src/components/admin/users/user-actions-menu.tsx
@@ -65,8 +65,7 @@ async function adminPost(path: string, body?: object) {
   } = await supabase.auth.getSession();
   const token = session?.access_token;
   const res = await fetch(`${BACKEND_URL}${path}`, {
-    method:
-      path.includes("/email") && !path.includes("send-email") ? "PUT" : "POST",
+    method: path.endsWith("/email") ? "PUT" : "POST",
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- Fix du bouton "Renvoyer la facture" dans le menu actions admin qui envoyait une requête PUT au lieu de POST
- La condition `path.includes("/email")` matchait `resend-payment-email` par erreur → 405 Method Not Allowed
- Simplifié en `path.endsWith("/email")` pour cibler uniquement l'endpoint PUT `/users/{id}/email`

## Test plan
- [ ] Cliquer "Renvoyer la facture" dans le menu actions d'un user avec abonnement actif
- [ ] Vérifier dans Network tab que la requête part en POST
- [ ] Vérifier que le toast "Facture renvoyée à ..." s'affiche
- [ ] Vérifier que le changement d'email admin fonctionne toujours (PUT /email)