### PR TITLE
feat(email): facture PDF Stripe en pièce jointe

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -2502,6 +2502,7 @@ async def resend_payment_email(
 
     # Récupérer l'URL de la dernière facture Stripe
     invoice_url = None
+    invoice_pdf_url = None
     stripe_customer_id = sub.data.get("stripe_customer_id")
     if stripe_customer_id:
         try:
@@ -2509,6 +2510,7 @@ async def resend_payment_email(
             invoices = stripe_lib.Invoice.list(customer=stripe_customer_id, limit=1, status="paid")
             if invoices.data:
                 invoice_url = invoices.data[0].hosted_invoice_url or invoices.data[0].invoice_pdf
+                invoice_pdf_url = invoices.data[0].invoice_pdf
         except Exception as e:
             logger.warning(f"Failed to get Stripe invoice: {e}")
 
@@ -2518,6 +2520,7 @@ async def resend_payment_email(
         amount=amount,
         language=language,
         invoice_url=invoice_url,
+        invoice_pdf_url=invoice_pdf_url,
         billing_reason="subscription_create",
     )
     if not ok:

--- a/backend/src/services/email.py
+++ b/backend/src/services/email.py
@@ -8,6 +8,7 @@ Supports FR (default) and EN via the `language` parameter on user-facing functio
 import logging
 from datetime import datetime
 
+import httpx
 import resend
 
 from src.config.settings import settings
@@ -1174,6 +1175,7 @@ def send_payment_confirmation_email(
     amount: str,
     language: str = "fr",
     invoice_url: str | None = None,
+    invoice_pdf_url: str | None = None,
     billing_reason: str = "subscription_create",
 ) -> bool:
     """Send payment confirmation email after successful Stripe checkout or renewal."""
@@ -1237,12 +1239,29 @@ def send_payment_confirmation_email(
             </div>
         </body></html>
         """
-        resend.Emails.send({
+        email_payload: dict = {
             "from": settings.from_email,
             "to": [user_email],
             "subject": subject,
             "html": html_content,
-        })
+        }
+
+        # Attacher le PDF de la facture Stripe si disponible
+        if invoice_pdf_url:
+            try:
+                pdf_resp = httpx.get(invoice_pdf_url, timeout=15)
+                if pdf_resp.status_code == 200 and len(pdf_resp.content) > 0:
+                    email_payload["attachments"] = [{
+                        "filename": f"facture-huntzen-{today.replace('/', '-')}.pdf",
+                        "content": list(pdf_resp.content),
+                    }]
+                    logger.info(f"Invoice PDF attached ({len(pdf_resp.content)} bytes)")
+                else:
+                    logger.warning(f"Failed to download invoice PDF: HTTP {pdf_resp.status_code}")
+            except Exception as e:
+                logger.warning(f"Could not attach invoice PDF: {e}")
+
+        resend.Emails.send(email_payload)
         logger.info(f"Payment confirmation email sent to {user_email} (plan={plan_name}, reason={billing_reason})")
         return True
     except Exception as e:

--- a/backend/src/services/stripe.py
+++ b/backend/src/services/stripe.py
@@ -656,11 +656,13 @@ async def handle_checkout_completed(session: dict[str, Any]):
                     amount_display = f"{amount_cents / 100:.2f} EUR"
                     # Récupérer l'URL de facture Stripe
                     invoice_url = None
+                    invoice_pdf_url = None
                     try:
                         latest_invoice_id = stripe_subscription.get("latest_invoice")
                         if latest_invoice_id:
                             inv = stripe.Invoice.retrieve(latest_invoice_id)
                             invoice_url = inv.get("hosted_invoice_url") or inv.get("invoice_pdf")
+                            invoice_pdf_url = inv.get("invoice_pdf")
                     except Exception:
                         pass
                     send_payment_confirmation_email(
@@ -668,6 +670,7 @@ async def handle_checkout_completed(session: dict[str, Any]):
                         plan_name=plan_name,
                         amount=amount_display,
                         invoice_url=invoice_url,
+                        invoice_pdf_url=invoice_pdf_url,
                     )
         except Exception as email_err:
             logger.warning(f"[WEBHOOK] Payment confirmation email failed (non-fatal): {email_err}")
@@ -978,6 +981,7 @@ async def handle_invoice_paid(invoice: dict[str, Any]):
             if customer_email and customer_email != "inconnu" and amount > 0:
                 try:
                     invoice_url = invoice.get("hosted_invoice_url") or invoice.get("invoice_pdf")
+                    invoice_pdf_url = invoice.get("invoice_pdf")
                     # Recuperer le nom du plan depuis la DB puis fallback Stripe Product
                     plan_label = ""
                     if supabase_client:
@@ -1005,6 +1009,7 @@ async def handle_invoice_paid(invoice: dict[str, Any]):
                         plan_name=plan_label,
                         amount=f"{amount:.2f} {currency}",
                         invoice_url=invoice_url,
+                        invoice_pdf_url=invoice_pdf_url,
                         billing_reason=billing_reason,
                     )
                 except Exception as email_err:


### PR DESCRIPTION
## Summary
- La facture Stripe PDF est maintenant attachée directement dans l'email de confirmation de paiement
- Actif sur les 3 points d'envoi : bouton admin, webhook checkout.session.completed, webhook invoice.paid
- Le lien "Voir ma facture" reste présent en plus du PDF attaché
- Fallback silencieux si le PDF Stripe n'est pas disponible

## Test plan
- [ ] Depuis l'admin : cliquer "Renvoyer la facture" → vérifier que l'email contient le PDF en pièce jointe
- [ ] Vérifier qu'un nouveau paiement Stripe envoie automatiquement l'email avec PDF attaché
- [ ] Vérifier que si `invoice_pdf` est null côté Stripe, l'email s'envoie quand même (sans PJ)