### PR TITLE
fix(sidebar): add CV adapt and cover letter counters to daily usage

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -579,6 +579,18 @@
       "savedJobs": {
         "label": "saved"
       },
+      "recruiterSearch": {
+        "label": "recruiter searches"
+      },
+      "cvAdapt": {
+        "label": "CV adaptations"
+      },
+      "coverLetter": {
+        "label": "cover letters"
+      },
+      "coach": {
+        "label": "coach messages"
+      },
       "unlimited": "unlimited",
       "unlimitedShort": "Unlimited"
     },

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -544,7 +544,19 @@
       "unlimited": "ilimitadas",
       "unlimitedShort": "Ilimitado",
       "savedJobs": {
-        "label": "Copias de seguridad"
+        "label": "guardados"
+      },
+      "recruiterSearch": {
+        "label": "busquedas de reclutador"
+      },
+      "cvAdapt": {
+        "label": "adaptaciones CV"
+      },
+      "coverLetter": {
+        "label": "cartas de presentacion"
+      },
+      "coach": {
+        "label": "mensajes coach"
       }
     },
     "aria": {

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -737,6 +737,18 @@
       "savedJobs": {
         "label": "sauvegardes"
       },
+      "recruiterSearch": {
+        "label": "recherches recruteur"
+      },
+      "cvAdapt": {
+        "label": "adaptations CV"
+      },
+      "coverLetter": {
+        "label": "lettres de motivation"
+      },
+      "coach": {
+        "label": "messages coach"
+      },
       "unlimited": "illimitées",
       "unlimitedShort": "Illimité"
     },

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -544,7 +544,19 @@
       "unlimited": "ilimitadas",
       "unlimitedShort": "Ilimitado",
       "savedJobs": {
-        "label": "Cópias de segurança"
+        "label": "salvos"
+      },
+      "recruiterSearch": {
+        "label": "buscas de recrutador"
+      },
+      "cvAdapt": {
+        "label": "adaptacoes CV"
+      },
+      "coverLetter": {
+        "label": "cartas de apresentacao"
+      },
+      "coach": {
+        "label": "mensagens coach"
       }
     },
     "aria": {

--- a/frontend-next/src/components/freemium/usage-counter.tsx
+++ b/frontend-next/src/components/freemium/usage-counter.tsx
@@ -115,13 +115,13 @@ export function UsageCounter({
   showBar = true,
   compact = false,
 }: UsageCounterProps) {
-  const { getRemaining, limits, isFreePlan } = useSubscription();
+  const { getRemaining, limits, isFreePlan, quotas } = useSubscription();
   const tUsage = useTranslations("usageCounter");
 
   const remaining = getRemaining(feature);
   const config = featureConfig[feature];
 
-  // Get max for this feature
+  // Get max for this feature (from limits or directly from API quotas)
   let max: number;
   switch (feature) {
     case "job_search":
@@ -136,9 +136,21 @@ export function UsageCounter({
     case "assistant_messages":
       max = limits.assistant_messages_per_day;
       break;
-    case "recruiter_search":
-      max = 0;
+    case "recruiter_search": {
+      const q = quotas?.recruiter_search;
+      max = q ? (q.limit === -1 ? Infinity : q.limit) : 0;
       break;
+    }
+    case "cv_adapt": {
+      const q = quotas?.cv_adapt;
+      max = q ? (q.limit === -1 ? Infinity : q.limit) : 0;
+      break;
+    }
+    case "cover_letter": {
+      const q = quotas?.cover_letter;
+      max = q ? (q.limit === -1 ? Infinity : q.limit) : 0;
+      break;
+    }
     default:
       max = 0;
   }
@@ -288,6 +300,8 @@ export function UsageSummary({ className = "" }: UsageSummaryProps) {
             <UsageCounter feature="job_search" showBar />
             <UsageCounter feature="cv_analysis" showBar />
             <UsageCounter feature="assistant_messages" showBar />
+            <UsageCounter feature="cv_adapt" showBar />
+            <UsageCounter feature="cover_letter" showBar />
           </div>
           <div className="flex items-center gap-1.5 mt-2 mb-3 text-xs text-white/50">
             <Clock className="w-3 h-3" />

--- a/frontend-next/src/contexts/subscription-context.tsx
+++ b/frontend-next/src/contexts/subscription-context.tsx
@@ -59,6 +59,10 @@ interface SubscriptionContextType {
   // Limits
   limits: PlanLimits;
 
+  // Raw API quotas (for features not in PlanLimits)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  quotas: Record<string, any> | null;
+
   // Actions
   setPlan: (plan: PlanType, expiresAt?: string) => void;
 
@@ -472,6 +476,8 @@ export function SubscriptionProvider({ children }: { children: ReactNode }) {
       savedJobsLimit: apiData.saved_jobs_quota?.limit ?? -1,
 
       limits: limitsFromApi,
+
+      quotas: apiData.quotas ?? null,
 
       setPlan: freemium.setPlan, // KEEP local until Stripe integration
 


### PR DESCRIPTION
## Summary
- Ajoute les compteurs cv_adapt et cover_letter dans le UsageSummary de la sidebar
- Lit les limites depuis les quotas API pour les features hors PlanLimits
- Labels i18n ajoutes en fr/en/es/pt

## Test plan
- [ ] Sidebar > Utilisation du jour affiche 5 compteurs (recherches, analyses, messages, adaptations CV, lettres de motivation)
- [ ] Les compteurs s'incrementent correctement apres usage