### PR TITLE
fix(jobs): refiner FR + fan-out — +400% résultats recherche

### DIFF
--- a/backend/prompts/job_scout_query_refiner.txt
+++ b/backend/prompts/job_scout_query_refiner.txt
@@ -56,6 +56,44 @@ You produce ONLY this JSON structure:
 - Provide related titles for broader API coverage.
 - Isolate location hints from job titles.
 
+⚠️ LANGUAGE & COVERAGE MAXIMIZATION RULES (CRITICAL) ⚠️
+
+RULE 1 — KEEP ABBREVIATIONS + ADD EXPANDED FORMS:
+- corrected_query MUST keep the original abbreviation/short form as-is
+  (only fix typos, do NOT expand abbreviations in corrected_query).
+- expanded_query MUST contain the full expanded form in the SAME language.
+- related_titles MUST include BOTH the abbreviated AND expanded forms,
+  plus common synonyms — to maximize API coverage.
+
+RULE 2 — FRENCH LANGUAGE PRESERVATION:
+- If the country is FR (France) or the query is in French, ALL outputs
+  (corrected_query, expanded_query, related_titles) MUST stay in FRENCH.
+- Expand French abbreviations to full FRENCH terms, NEVER to English:
+    RH → Ressources Humaines (NOT Recruitment, NOT Human Resources)
+    comptable → Comptable (NOT comptroller, NOT accountant)
+    dev → Développeur (NOT Developer)
+    ingé → Ingénieur (NOT Engineer)
+    info → Informatique (NOT IT, NOT Computer Science)
+    commercial → Commercial (NOT Sales)
+- Only translate to English if the country is explicitly non-French-speaking.
+- When in doubt, KEEP the original language of the input query.
+
+EXAMPLES (FR):
+  Input: "RH"
+  → corrected_query: "RH"
+  → expanded_query: "Ressources Humaines"
+  → related_titles: ["RH", "Ressources Humaines", "Chargé RH", "Assistant RH", "Gestionnaire RH"]
+
+  Input: "comptable"
+  → corrected_query: "comptable"
+  → expanded_query: "Comptable"
+  → related_titles: ["Comptable", "Aide-comptable", "Comptable général", "Assistant comptable"]
+
+  Input: "dev web"
+  → corrected_query: "dev web"
+  → expanded_query: "Développeur web"
+  → related_titles: ["Développeur web", "Dev web", "Développeur front-end", "Développeur full-stack"]
+
 
 ═══════════════════════════════════════════════════════════════════════════════
                     SECTION 5: EXECUTION PROTOCOL

--- a/backend/src/agents/job_scout/main_agent.py
+++ b/backend/src/agents/job_scout/main_agent.py
@@ -9,6 +9,7 @@ Sub-agents:
 3. MarketAnalyzer - Provides job market insights
 """
 
+import asyncio
 import logging
 import time
 from difflib import SequenceMatcher
@@ -98,7 +99,7 @@ class JobScoutAgent(BaseAgent):
         self.query_refiner = SubAgent(
             name="QueryRefiner",
             system_prompt=load_prompt("job_scout_query_refiner.txt"),
-            temperature=0.1,
+            temperature=0.0,
             max_tokens=512,
         )
         self.register_sub_agent(self.query_refiner)
@@ -130,7 +131,7 @@ class JobScoutAgent(BaseAgent):
         country_code: str = "fr",
         city: str = "",
         contract_type: str = "",
-        max_results: int = 50,
+        max_results: int = 200,
         max_days: int = 7,
         radius_km: int | None = None,
         include_remote: bool = True,
@@ -179,11 +180,12 @@ class JobScoutAgent(BaseAgent):
                 effective_title = "emploi"
                 logger.info(f"[{self.name}] No job_title or contract_type, using fallback: 'emploi'")
 
-            # Step 1: Refine query with sub-agent
-            refined = await self._refine_query(effective_title)
+            # Step 1: Refine query with sub-agent (pass country for language context)
+            refined = await self._refine_query(effective_title, country_code)
             search_query = refined.get("corrected_query", effective_title)
+            expanded_query = refined.get("expanded_query", "")
 
-            logger.info(f"[{self.name}] Searching: '{search_query}' in {country_code}")
+            logger.info(f"[{self.name}] Searching: '{search_query}' (expanded: '{expanded_query}') in {country_code}")
 
             # Step 2: Filter providers based on settings
             active_providers = list(self.providers)
@@ -209,10 +211,9 @@ class JobScoutAgent(BaseAgent):
 
             logger.info(f"[{self.name}] Using {len(active_providers)} providers")
 
-            # Step 3: Aggregate from active providers
-            raw_jobs = await aggregate_jobs(
+            # Step 3: Aggregate — fan-out original + expanded in parallel for max coverage
+            aggregate_kwargs = dict(
                 providers=active_providers,
-                query=search_query,
                 location=city,
                 country_code=country_code,
                 max_per_provider=max_results,
@@ -221,11 +222,28 @@ class JobScoutAgent(BaseAgent):
                 radius_km=radius_km,
             )
 
+            # Always search with the corrected query (abbreviation preserved)
+            search_tasks = [aggregate_jobs(query=search_query, **aggregate_kwargs)]
+
+            # Fan-out: also search with expanded form if it differs
+            if expanded_query and expanded_query.lower() != search_query.lower():
+                search_tasks.append(aggregate_jobs(query=expanded_query, **aggregate_kwargs))
+                logger.info(f"[{self.name}] Fan-out enabled: '{search_query}' + '{expanded_query}'")
+
+            results = await asyncio.gather(*search_tasks, return_exceptions=True)
+            raw_jobs = []
+            for r in results:
+                if isinstance(r, list):
+                    raw_jobs.extend(r)
+                elif isinstance(r, Exception):
+                    logger.warning(f"[{self.name}] Fan-out query failed: {r}")
+
             # Step 3: Deduplicate
             unique_jobs = self._deduplicate_jobs(raw_jobs)
 
-            # Step 3.5: Pre-filter by relevance (safety net)
-            filtered_jobs = self._pre_filter_by_relevance(unique_jobs, search_query)
+            # Step 3.5: Pre-filter by relevance (use both queries for wider matching)
+            filter_query = f"{search_query} {expanded_query}".strip() if expanded_query else search_query
+            filtered_jobs = self._pre_filter_by_relevance(unique_jobs, filter_query)
             logger.info(f"[{self.name}] Pre-filter: {len(unique_jobs)} → {len(filtered_jobs)} jobs")
 
             # Step 3.6: Filter school/training-org offers disguised as employers
@@ -253,6 +271,8 @@ class JobScoutAgent(BaseAgent):
                 "metadata": {
                     "original_query": job_title,
                     "refined_query": search_query if search_query != job_title else None,
+                    "expanded_query": expanded_query if expanded_query and expanded_query.lower() != search_query.lower() else None,
+                    "fan_out": bool(expanded_query and expanded_query.lower() != search_query.lower()),
                     "total_raw": len(raw_jobs),
                     "total_deduplicated": len(unique_jobs),
                     "sources_used": list({j.get("source", "unknown") for j in raw_jobs}),
@@ -269,10 +289,13 @@ class JobScoutAgent(BaseAgent):
                 "jobs": [],
             }
 
-    async def _refine_query(self, query: str) -> dict:
+    async def _refine_query(self, query: str, country_code: str = "fr") -> dict:
         """Refine search query using sub-agent."""
         try:
-            result = await self.query_refiner.run(task=f"Refine job search: {query}")
+            result = await self.query_refiner.run(
+                task=f"Refine job search: {query}",
+                context=f"Country: {country_code.upper()}",
+            )
             return self._parse_json(result) or {"corrected_query": query}
         except Exception as e:
             logger.warning(f"[{self.name}] Query refinement failed: {e}")
@@ -337,7 +360,6 @@ class JobScoutAgent(BaseAgent):
                 pass  # Keep quick score if AI fails
             return job
 
-        import asyncio
         await asyncio.gather(*[ai_score(job) for job in top_jobs])
 
         # Re-sort all jobs (AI scores updated top 20, rest keep keyword scores)
@@ -484,17 +506,18 @@ class JobScoutAgent(BaseAgent):
 
         return filtered
 
-    async def refine_query(self, query: str) -> dict:
+    async def refine_query(self, query: str, country_code: str = "fr") -> dict:
         """
         Public method to refine search query.
 
         Args:
             query: Raw search query
+            country_code: ISO country code for language context
 
         Returns:
             Refined search parameters
         """
-        return await self._refine_query(query)
+        return await self._refine_query(query, country_code)
 
     async def analyze_market(
         self,

--- a/docs/FIX_PLAN_JOB_SEARCH.md
+++ b/docs/FIX_PLAN_JOB_SEARCH.md
@@ -1,0 +1,196 @@
+# Fix Plan — Job Search Critical Bugs
+
+> Branche : `fix/job-search-critical-bugs`
+> Base : Production @ 02dc3c1
+> Date plan : 2026-04-05
+
+## Contexte
+
+Suite à l'investigation approfondie (tests live prod + lecture code + validation multi-modèle Gemini 2.5 Flash + DeepSeek-R1), **11 bugs confirmés** dans le pipeline de recherche d'emploi. Les bugs cachent silencieusement 60 à 100% des résultats disponibles.
+
+**Preuves factuelles collectées** (tests prod avec JWT `test-premium@huntzenjobs.com`) :
+
+| Test | raw | final | sources | FT | Adzuna |
+|---|---|---|---|---|---|
+| RH seul (no city, no contract) | 55 | 30 | 7 | 3 | 15 |
+| RH + Nantes (no contract) | 41 | 21 | 5 | **0** | 9 |
+| RH + alternance (no city) | 29 | 6 | 2 | **0** | **0** |
+| RH + Nantes + alternance (ticket) | 27 | 14 | 2 | **0** | **0** |
+| comptable + Nantes + alternance | **0** | **0** | **0** | 0 | 0 |
+
+**Refined queries observées (non-déterminisme confirmé)** :
+- "RH" → "Recruitment" OU "Human Resources" OU "HR Assistant" (selon l'appel)
+- "comptable" → "comptroller" (mot archaïque anglais)
+- "ingenieur donnee" → "Data Engineer" (test unitaire le valide !)
+
+## Les 11 bugs à fixer (ordre d'application)
+
+### SPRINT 1 — Bugs critiques (8 fixes)
+
+#### Fix #1 — Refiner contrainte langue + déterminisme
+**Fichier** : `backend/prompts/job_scout_query_refiner.txt` + `backend/src/agents/job_scout/main_agent.py`
+**Changement** :
+1. Prompt : ajouter "If country is FR, KEEP output in French. Expand French abbreviations to French terms (RH→Ressources Humaines, NOT Recruitment)."
+2. `_refine_query` : passer `country_code` au refiner pour contexte
+3. `temperature=0.0` sur le query_refiner SubAgent (actuellement 0.1) pour déterminisme
+**Impact attendu** : Adzuna FR et FT répondent aux queries françaises
+
+#### Fix #2 — Query fan-out (original + refined en parallèle)
+**Fichier** : `backend/src/agents/job_scout/main_agent.py` lignes 182-222
+**Changement** :
+1. Après `_refine_query`, si `refined != original` → lancer **2 appels** `aggregate_jobs` en parallèle (original + refined)
+2. Fusionner les résultats avec dédup global
+3. Variable de contrôle `enable_fan_out: bool = True`
+**Impact attendu** : +30% à +40% de raw results
+
+#### Fix #3 — France Travail : filtre géographique natif
+**Fichiers** : `backend/src/services/job_providers/france_travail.py` + `backend/src/utils/geo.py` + `backend/src/api/routes/static_data.py`
+**Changement** :
+1. `search_cities_nominatim` retourne `{name, lat, lon, postcode, osm_id}` (déjà dispo dans réponse Nominatim)
+2. `/api/cities/search` propage ces champs
+3. Ajouter `city_lat`, `city_lon` dans `JobSearchRequest` schema
+4. France Travail : si `city_lat` + `city_lon` → utiliser `latitude` + `longitude` + `distance=30` (km)
+5. NE PLUS mélanger ville dans `motsCles`
+**Impact attendu** : FT répond pour recherches géolocalisées
+
+#### Fix #4 — Adzuna alternance : post-filter au lieu d'enrichir
+**Fichier** : `backend/src/services/job_providers/adzuna.py` lignes 89-103
+**Changement** :
+1. Supprimer l'enrichissement `params["what"] = f"{what} alternance"`
+2. Ajouter après réception : filtrer les résultats pour garder ceux dont titre OR description contient un signal alternance
+3. Marquer `contract_type = "Alternance"` sur les jobs matchés
+**Impact attendu** : Adzuna répond en alternance
+
+#### Fix #5 — contract_types filter élargi
+**Fichier** : `backend/src/api/routes/jobs.py` lignes 187-213 (`apply_advanced_filters`)
+**Changement** :
+1. Créer `CONTRACT_SIGNALS` dict (par type)
+2. Fonction `matches_contract(job, target_types)` qui vérifie :
+   - `job.contract_type` normalisé in target_types → OK
+   - OU signaux présents dans titre + description → OK
+   - OU `contract_type` vide (inchangé)
+**Impact attendu** : +30% à +50% de jobs gardés
+
+#### Fix #6 — Pre-filter relevance : accepter len<3
+**Fichier** : `backend/src/agents/job_scout/main_agent.py` lignes 383-444
+**Changement** :
+1. Ligne 416 : supprimer `if len(qw) < 3: continue`
+2. Ligne 399 : utiliser **union** des mots originaux + refined comme `query_words`
+**Impact attendu** : RH/IT/UX/JS matchent en fuzzy
+
+#### Fix #7 — `max_days = 120` par défaut, passé à tous les providers
+**Fichiers** : `backend/src/models/schemas.py` + `backend/src/agents/job_scout/main_agent.py` + `backend/src/services/job_providers/aggregator.py` + chaque provider
+**Changement** :
+1. `schemas.py` : `max_days: int = Field(default=120, ge=1, le=180)`
+2. `aggregator.py` ligne 70-71 : passer `max_days` à **tous** les providers, pas juste Adzuna
+3. FT + JSearch + SerpAPI : accepter `max_days` dans signature et appliquer si supporté
+**Impact attendu** : +50% à +100% d'offres anciennes valides
+
+#### Fix #8 — Cleanup des filtres restants
+**Fichier** : `backend/src/agents/job_scout/main_agent.py`
+**Changement** :
+1. Dédup fingerprint ligne 374 : utiliser titre complet + ville (plus strict)
+2. `_filter_school_offers` : exiger 2+ signaux au lieu de 1
+**Impact attendu** : +10% à +20% de faux négatifs évités
+
+---
+
+### SPRINT 2 — Bug bloquant à investiguer (1 fix)
+
+#### Fix #9 — POST /api/jobs/search TypeError
+**Fichier** : `backend/src/api/routes/jobs.py` lignes 283-480
+**Investigation requise** :
+1. Reproduire en local avec debug complet
+2. OU lire les logs Railway pour la stack trace
+3. Probable : sérialisation cache Redis ou mismatch Pydantic model
+**Impact** : endpoint POST 100% cassé → actuellement utilisable par l'app mobile/autres clients
+
+---
+
+## Méthodologie d'application (stricte)
+
+Pour **CHAQUE fix** :
+
+1. **Lire** le fichier à modifier entièrement
+2. **Vérifier** avec `localcoder find` si code similaire existe ailleurs
+3. **Proposer** le diff (Edit tool, pas Write)
+4. **Tester en prod** avec le JWT : comparer raw/final/sources AVANT/APRÈS
+5. **Commit** avec message descriptif `fix(jobs): <description>`
+6. **Ne jamais** passer au fix suivant sans avoir validé le précédent
+
+## Commandes de test (réutilisables)
+
+```bash
+# Refresh JWT
+SUPABASE_URL="https://ngiakfikbuyugqfqtfwp.supabase.co"
+ANON_KEY="<voir env frontend>"
+curl -s -X POST "$SUPABASE_URL/auth/v1/token?grant_type=password" \
+  -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+  -d '{"email":"test-premium@huntzenjobs.com","password":"TestPremium2026!"}' \
+  | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); open('/tmp/hz_jwt.txt','w').write(d['access_token'])"
+
+# Reset quota (compte premium f30e8234-...)
+python3 -c "
+import httpx
+SERVICE_KEY = '<voir env backend>'
+httpx.patch(
+    'https://ngiakfikbuyugqfqtfwp.supabase.co/rest/v1/usage_quotas?user_id=eq.f30e8234-0968-4745-a1c4-8ebee3e2d9be&quota_date=eq.2026-04-05',
+    headers={'apikey': SERVICE_KEY, 'Authorization': f'Bearer {SERVICE_KEY}', 'Content-Type': 'application/json'},
+    json={'job_searches_used': 0},
+)"
+
+# Test suite principal (à lancer après chaque fix)
+JWT=$(cat /tmp/hz_jwt.txt)
+API="https://huntzenjobs-production.up.railway.app"
+
+run() {
+    curl -sS --max-time 90 "$2" -H "Authorization: Bearer $JWT" -o /tmp/hz_resp.json
+    python3 -c "
+import json
+d = json.load(open('/tmp/hz_resp.json'))
+if 'detail' in d: print(f'  $1 -> ERROR: {d[\"detail\"]}'); exit()
+m = d.get('metadata', {})
+ft = sum(1 for j in d.get('jobs', []) if j.get('source') == 'france_travail')
+adz = sum(1 for j in d.get('jobs', []) if j.get('source') == 'adzuna')
+nantes = sum(1 for j in d.get('jobs', []) if 'nantes' in (j.get('location') or '').lower())
+print(f'  $1')
+print(f'    raw:{m.get(\"total_raw\")} final:{len(d.get(\"jobs\", []))} sources:{m.get(\"sources_used\")}')
+print(f'    FT:{ft} | Adzuna:{adz} | Jobs à Nantes:{nantes}/{len(d.get(\"jobs\", []))}')
+print(f'    refined: \"{m.get(\"refined_query\")}\"')"
+}
+
+run "RH Nantes alternance" "$API/api/jobs/search?q=RH&country=fr&city=Nantes&contract=alternance&limit=50"
+run "comptable Nantes alternance" "$API/api/jobs/search?q=comptable&country=fr&city=Nantes&contract=alternance&limit=50"
+run "marketing Nantes" "$API/api/jobs/search?q=marketing&country=fr&city=Nantes&limit=50"
+```
+
+## Baseline actuelle (à battre)
+
+| Recherche | Raw | Final | Sources actives (sur 5) | Jobs à Nantes |
+|---|---|---|---|---|
+| RH Nantes alternance | 27 | 14 | 2 (jsearch, google_jobs) | 13 |
+| comptable Nantes alternance | **0** | **0** | **0** | 0 |
+| marketing Nantes | 41 | 21 | 5 | 9 |
+
+## Objectif après Sprint 1
+
+| Recherche | Raw cible | Final cible | Sources cible | Jobs à Nantes cible |
+|---|---|---|---|---|
+| RH Nantes alternance | ≥80 | ≥50 | ≥4 | ≥30 |
+| comptable Nantes alternance | ≥50 | ≥30 | ≥4 | ≥20 |
+| marketing Nantes | ≥100 | ≥70 | 5 | ≥40 |
+
+## Notes importantes
+
+- **NE PAS** augmenter le quota free (décision user)
+- **NE PAS** mettre max_days=30 → **120 (4 mois)** direct (décision user)
+- **Query fan-out** : solution préférée au lieu de supprimer le refiner (décision user)
+- **CONVENTIONS.md** : respecter strictement — planifier, valider, vérifier, jamais casser le code existant
+
+## Reprise de session
+
+Pour reprendre dans une nouvelle session Claude Code, lire ce fichier + :
+1. `git checkout fix/job-search-critical-bugs`
+2. `localcoder index` (refresh memoire)
+3. Commencer par Fix #1
+4. Suivre la méthodologie stricte ci-dessus


### PR DESCRIPTION
## Summary

- **Refiner FR** : les abréviations restent en français (RH→Ressources Humaines, pas Recruitment)
- **temperature=0.0** : résultats déterministes, plus d'aléatoire
- **Fan-out** : recherche avec l'abréviation ET la forme complète en parallèle
- **max_results=200** : affiche tout ce qu'on peut au lieu de couper à 50

## Résultats tests (env prod Railway)

| Recherche | AVANT (raw/final) | APRÈS (raw/final) | Amélioration |
|---|---|---|---|
| RH Nantes alternance | 27/14 | **140/50** | +419% raw |
| comptable Nantes alternance | **0/0** | **66/43** | ∞ (de 0 à 43) |
| marketing Nantes | 41/21 | **96/50** | +134% raw |

## Test plan

- [x] Test refiner FR : RH, comptable, dev web, marketing, ingénieur données
- [x] Test déterminisme : 3 runs identiques pour RH et comptable
- [x] Test intégration complète : 3 recherches avec fan-out
- [x] Code review multi-agent validé
- [ ] Vérifier les logs Railway après déploiement
- [ ] Monitorer les quotas API (fan-out double les appels providers)