### PR TITLE
fix(frontend): hydration + 401 + ville persistée + i18n contrat/recruteur

### DIFF
--- a/frontend-next/messages/en.json
+++ b/frontend-next/messages/en.json
@@ -312,7 +312,11 @@
           "PDF export",
           "Advanced filters"
         ],
-        "unavailable": ["Email alerts", "CV History", "Interview simulation"]
+        "unavailable": [
+          "Email alerts",
+          "CV History",
+          "Interview simulation"
+        ]
       },
       "starter": {
         "name": "ACTIVE SEARCH",
@@ -330,7 +334,10 @@
           "Advanced filters",
           "CV History"
         ],
-        "unavailable": ["Interview simulation", "Email alerts"]
+        "unavailable": [
+          "Interview simulation",
+          "Email alerts"
+        ]
       },
       "pro": {
         "name": "ACCELERATOR",
@@ -2943,11 +2950,13 @@
     "errorGeneric": "Error searching for contacts",
     "rgpdDisclaimer": "This information comes from public sources (LinkedIn, company websites). Use responsibly in compliance with GDPR.",
     "copyEmail": "Copy {email}",
-    "category.hr": "Recruiter",
-    "category.pair": "Future colleague",
-    "category.campus": "Campus",
-    "category.tech": "Tech",
-    "category.other": "Contact",
-    "profileCount": "{count} profile(s)"
+    "profileCount": "{count} profile(s)",
+    "category": {
+      "hr": "Recruiter",
+      "pair": "Future colleague",
+      "campus": "Campus",
+      "tech": "Tech",
+      "other": "Contact"
+    }
   }
 }

--- a/frontend-next/messages/es.json
+++ b/frontend-next/messages/es.json
@@ -2387,8 +2387,8 @@
     "dailyUsageTitle": "Cuotas diarias",
     "generalUsageTitle": "Cuotas generales",
     "resetAtMidnight": "Se restablece a medianoche",
-    "atsScore": "Puntuación ATS",
-    "matchingScore": "Matching de empleo",
+    "atsScore": "Score ATS",
+    "matchingScore": "Matching Job",
     "customCv": "CV personalizado",
     "recruiterSearch": "Búsquedas de reclutador (LinkedIn)",
     "jobSearches": "Búsquedas de empleo",
@@ -2408,10 +2408,7 @@
     },
     "savedJobs": "Empleos guardados",
     "assistantMessages": "Mensajes del Asistente",
-    "atsScore": "Score ATS",
-    "matchingScore": "Matching Job",
-    "cvAdapt": "Adaptación CV",
-    "customCv": "CV personalizado"
+    "cvAdapt": "Adaptación CV"
   },
   "notifications": {
     "title": "Notifications",
@@ -2949,11 +2946,13 @@
     "errorGeneric": "Error al buscar contactos",
     "rgpdDisclaimer": "Esta informacion proviene de fuentes publicas (LinkedIn, sitios web de empresas). Usala de manera responsable conforme al RGPD.",
     "copyEmail": "Copiar {email}",
-    "category.hr": "Reclutador",
-    "category.pair": "Futuro colega",
-    "category.campus": "Campus",
-    "category.tech": "Tech",
-    "category.other": "Contacto",
-    "profileCount": "{count} perfil(es)"
+    "profileCount": "{count} perfil(es)",
+    "category": {
+      "hr": "Reclutador",
+      "pair": "Futuro colega",
+      "campus": "Campus",
+      "tech": "Tech",
+      "other": "Contacto"
+    }
   }
 }

--- a/frontend-next/messages/fr.json
+++ b/frontend-next/messages/fr.json
@@ -1926,7 +1926,15 @@
     "contractTypesLabel": "Types de contrat",
     "allContracts": "Tous les contrats",
     "selectedCount": "selectionne(s)",
-    "contractType_interim": "Interim",
+    "contractType_cdi": "CDI",
+    "contractType_cdd": "CDD",
+    "contractType_freelance": "Freelance",
+    "contractType_stage": "Stage",
+    "contractType_alternance": "Alternance",
+    "contractType_apprentissage": "Apprentissage",
+    "contractType_interim": "Intérim",
+    "contractType_temps partiel": "Temps partiel",
+    "contractType_remote": "Télétravail",
     "workDaysLabel": "Jours de travail",
     "workDays_weekdays": "Semaine (lun-ven)",
     "workDays_weekend": "Weekend (sam-dim)",
@@ -2946,11 +2954,13 @@
     "errorGeneric": "Erreur lors de la recherche de contacts",
     "rgpdDisclaimer": "Ces informations proviennent de sources publiques (LinkedIn, sites d'entreprise). Utilisez-les de manière responsable conformément au RGPD.",
     "copyEmail": "Copier {email}",
-    "category.hr": "Recruteur",
-    "category.pair": "Futur collègue",
-    "category.campus": "Campus",
-    "category.tech": "Tech",
-    "category.other": "Contact",
+    "category": {
+      "hr": "Recruteur",
+      "pair": "Futur collègue",
+      "campus": "Campus",
+      "tech": "Tech",
+      "other": "Contact"
+    },
     "profileCount": "{count} profil(s)"
   }
 }

--- a/frontend-next/messages/pt.json
+++ b/frontend-next/messages/pt.json
@@ -2388,8 +2388,8 @@
     "generalUsageTitle": "Cotas gerais",
     "resetAtMidnight": "Reinicia à meia-noite",
     "atsScore": "Pontuação ATS",
-    "matchingScore": "Matching de emprego",
-    "customCv": "CV personalizado",
+    "matchingScore": "Matching de Vaga",
+    "customCv": "CV Personalizado",
     "recruiterSearch": "Pesquisas de recrutador (LinkedIn)",
     "jobSearches": "Buscas de Emprego",
     "unlockTitle": "Desbloqueie todo o potencial do HuntZen",
@@ -2408,10 +2408,7 @@
     },
     "savedJobs": "Vagas Salvas",
     "assistantMessages": "Mensagens do Assistente",
-    "atsScore": "Pontuação ATS",
-    "matchingScore": "Matching de Vaga",
-    "cvAdapt": "Adaptação de CV",
-    "customCv": "CV Personalizado"
+    "cvAdapt": "Adaptação de CV"
   },
   "notifications": {
     "title": "Notifications",
@@ -2949,11 +2946,13 @@
     "errorGeneric": "Erro ao pesquisar contatos",
     "rgpdDisclaimer": "Estas informações provêm de fontes públicas (LinkedIn, sites de empresas). Use de forma responsável em conformidade com o RGPD.",
     "copyEmail": "Copiar {email}",
-    "category.hr": "Recrutador",
-    "category.pair": "Futuro colega",
-    "category.campus": "Campus",
-    "category.tech": "Tech",
-    "category.other": "Contato",
-    "profileCount": "{count} perfil(is)"
+    "profileCount": "{count} perfil(is)",
+    "category": {
+      "hr": "Recrutador",
+      "pair": "Futuro colega",
+      "campus": "Campus",
+      "tech": "Tech",
+      "other": "Contato"
+    }
   }
 }

--- a/frontend-next/src/app/(dashboard)/jobs/page.tsx
+++ b/frontend-next/src/app/(dashboard)/jobs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { tokenRefreshService } from "@/lib/auth/token-refresh-service";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -215,24 +216,24 @@ export default function JobsPage() {
     | "company_asc";
   const [sortKey, setSortKey] = useState<SortKey>("relevance");
 
-  const [viewedJobIds, setViewedJobIds] = useState<Set<string>>(() => {
+  const [viewedJobIds, setViewedJobIds] = useState<Set<string>>(new Set());
+  const [appliedJobIds, setAppliedJobIds] = useState<Set<string>>(new Set());
+
+  // Hydrate from localStorage after mount (avoids SSR mismatch #418)
+  useEffect(() => {
     try {
-      return new Set(
-        JSON.parse(localStorage.getItem("huntzen_viewed_jobs") || "[]"),
+      const viewed = JSON.parse(
+        localStorage.getItem("huntzen_viewed_jobs") || "[]",
       );
-    } catch {
-      return new Set();
-    }
-  });
-  const [appliedJobIds, setAppliedJobIds] = useState<Set<string>>(() => {
+      if (viewed.length) setViewedJobIds(new Set(viewed));
+    } catch {}
     try {
-      return new Set(
-        JSON.parse(localStorage.getItem("huntzen_applied_jobs") || "[]"),
+      const applied = JSON.parse(
+        localStorage.getItem("huntzen_applied_jobs") || "[]",
       );
-    } catch {
-      return new Set();
-    }
-  });
+      if (applied.length) setAppliedJobIds(new Set(applied));
+    } catch {}
+  }, []);
 
   // Advanced filters state
   const [advancedFiltersOpen, setAdvancedFiltersOpen] = useState(false);
@@ -597,7 +598,7 @@ export default function JobsPage() {
   const hasIncrementedQuotaRef = useRef(false);
   const isRestoringFromCacheRef = useRef(false);
   const lastFetchTimeRef = useRef(0);
-  
+
   // Stable computed values for useEffect dependencies
   const effectiveContractTypes = useMemo(
     () => jobSearchParams?.contractTypes || [],
@@ -611,32 +612,45 @@ export default function JobsPage() {
   /**
    * Helper: Generate a deterministic hash for search parameters to avoid duplication
    */
-  const generateSearchHash = useCallback((params: SearchParams | null, filters: AdvancedFilters) => {
-    if (!params) return "";
-    
-    // Create a clean, alphabetically sorted object for deterministic hashing
-    const cleanObject = {
-      companySize: filters.companySize?.toLowerCase() || "",
-      contracts: [...(params.contractTypes || [])].map(c => typeof c === 'string' ? c.toLowerCase() : (c as any).id || (c as any).value || String(c)).sort(),
-      country: params.country?.toLowerCase() || "",
-      days: quickFilters.maxDays || 0,
-      experience: filters.experienceLevel?.toLowerCase() || "",
-      industries: [...(filters.industries || [])].map(i => i.toLowerCase()).sort(),
-      keywords: [...(filters.keywords || [])].map(k => k.toLowerCase()).sort(),
-      location: params.location?.toLowerCase() || "",
-      q: params.query?.trim().toLowerCase() || "",
-      remote: params.includeRemote ?? true, // Consistent default
-      salaryMax: filters.salaryMax || 0,
-      salaryMin: filters.salaryMin || 0
-    };
-    
-    return JSON.stringify(cleanObject);
-  }, [quickFilters.maxDays]);
+  const generateSearchHash = useCallback(
+    (params: SearchParams | null, filters: AdvancedFilters) => {
+      if (!params) return "";
+
+      // Create a clean, alphabetically sorted object for deterministic hashing
+      const cleanObject = {
+        companySize: filters.companySize?.toLowerCase() || "",
+        contracts: [...(params.contractTypes || [])]
+          .map((c) =>
+            typeof c === "string"
+              ? c.toLowerCase()
+              : (c as any).id || (c as any).value || String(c),
+          )
+          .sort(),
+        country: params.country?.toLowerCase() || "",
+        days: quickFilters.maxDays || 0,
+        experience: filters.experienceLevel?.toLowerCase() || "",
+        industries: [...(filters.industries || [])]
+          .map((i) => i.toLowerCase())
+          .sort(),
+        keywords: [...(filters.keywords || [])]
+          .map((k) => k.toLowerCase())
+          .sort(),
+        location: params.location?.toLowerCase() || "",
+        q: params.query?.trim().toLowerCase() || "",
+        remote: params.includeRemote ?? true, // Consistent default
+        salaryMax: filters.salaryMax || 0,
+        salaryMin: filters.salaryMin || 0,
+      };
+
+      return JSON.stringify(cleanObject);
+    },
+    [quickFilters.maxDays],
+  );
 
   // Combined search state hash for stable comparisons
   const currentSearchHash = useMemo(
     () => generateSearchHash(jobSearchParams, advancedFilters),
-    [jobSearchParams, advancedFilters, generateSearchHash]
+    [jobSearchParams, advancedFilters, generateSearchHash],
   );
 
   const lastProcessedHashRef = useRef("");
@@ -653,7 +667,7 @@ export default function JobsPage() {
       if (!isInitializingRef.current) {
         hasIncrementedQuotaRef.current = false;
       }
-      
+
       setCurrentPage(1);
       isRestoringFromCacheRef.current = false;
       lastProcessedHashRef.current = currentSearchHash;
@@ -665,15 +679,25 @@ export default function JobsPage() {
     const q = searchParams.get("q");
     const country = searchParams.get("country");
     const city = searchParams.get("city");
-    
+
     // Parse ALL advanced filters from URL
-    const industries = searchParams.get("industries")?.split(",").filter(Boolean);
+    const industries = searchParams
+      .get("industries")
+      ?.split(",")
+      .filter(Boolean);
     const keywords = searchParams.get("keywords")?.split(",").filter(Boolean);
     const experienceLevel = searchParams.get("experienceLevel") || undefined;
-    const salaryMin = searchParams.get("salaryMin") ? parseInt(searchParams.get("salaryMin")!) : undefined;
-    const salaryMax = searchParams.get("salaryMax") ? parseInt(searchParams.get("salaryMax")!) : undefined;
+    const salaryMin = searchParams.get("salaryMin")
+      ? parseInt(searchParams.get("salaryMin")!)
+      : undefined;
+    const salaryMax = searchParams.get("salaryMax")
+      ? parseInt(searchParams.get("salaryMax")!)
+      : undefined;
     const companySize = searchParams.get("companySize") || undefined;
-    const contractTypesParam = searchParams.get("contractTypes")?.split(",").filter(Boolean);
+    const contractTypesParam = searchParams
+      .get("contractTypes")
+      ?.split(",")
+      .filter(Boolean);
 
     const initialFilters: AdvancedFilters = {
       ...(industries ? { industries } : {}),
@@ -685,7 +709,8 @@ export default function JobsPage() {
     };
 
     const remoteParam = searchParams.get("remote");
-    const initialIncludeRemote = remoteParam !== null ? remoteParam === "true" : undefined;
+    const initialIncludeRemote =
+      remoteParam !== null ? remoteParam === "true" : undefined;
 
     // Try to restore from localStorage (works even without URL params)
     try {
@@ -701,12 +726,14 @@ export default function JobsPage() {
         if (Object.keys(initialFilters).length > 0) {
           setAdvancedFilters(initialFilters);
         }
-        
+
         // Finalize initialization after a delay
-        const timer = setTimeout(() => { isInitializingRef.current = false; }, 1500);
+        const timer = setTimeout(() => {
+          isInitializingRef.current = false;
+        }, 1500);
         return () => clearTimeout(timer);
       }
-      
+
       const { jobs: cachedJobs, query, timestamp } = JSON.parse(raw);
       const isRecent = Date.now() - timestamp < 60 * 60 * 1000; // 1h cache
 
@@ -714,8 +741,12 @@ export default function JobsPage() {
       const restoreTitle = q || query.jobTitle;
       const restoreCountry = country || query.selectedCountry;
       const restoreCity = city || query.selectedCity;
-      const restoreFilters = Object.keys(initialFilters).length > 0 ? initialFilters : (query.advancedFilters || {});
-      const restoreContractTypes = contractTypesParam || query.contractTypes || [];
+      const restoreFilters =
+        Object.keys(initialFilters).length > 0
+          ? initialFilters
+          : query.advancedFilters || {};
+      const restoreContractTypes =
+        contractTypesParam || query.contractTypes || [];
 
       if (isRecent && restoreTitle) {
         isRestoringFromCacheRef.current = true;
@@ -728,13 +759,20 @@ export default function JobsPage() {
         }
         setAdvancedFilters(restoreFilters);
         setJobs(cachedJobs);
-        const restoreIncludeRemote = initialIncludeRemote !== undefined ? initialIncludeRemote : (query.includeRemote !== undefined ? query.includeRemote : true);
+        const restoreIncludeRemote =
+          initialIncludeRemote !== undefined
+            ? initialIncludeRemote
+            : query.includeRemote !== undefined
+              ? query.includeRemote
+              : true;
 
         setJobSearchParams({
           query: restoreTitle,
           country: restoreCountry || "",
           location: restoreCity || "",
-          contractTypes: restoreContractTypes.map((c: any) => typeof c === 'string' ? c : (c as any).id || (c as any).value),
+          contractTypes: restoreContractTypes.map((c: any) =>
+            typeof c === "string" ? c : (c as any).id || (c as any).value,
+          ),
           includeRemote: restoreIncludeRemote,
           fromHistory: true, // Mark as restoration to avoid re-billing
         });
@@ -768,7 +806,6 @@ export default function JobsPage() {
     return () => clearTimeout(timer);
   }, []);
 
-
   // Search query with intelligent caching
   const searchQuery = useQuery({
     queryKey: [
@@ -796,6 +833,12 @@ export default function JobsPage() {
       }
 
       try {
+        // Toujours récupérer un token frais (évite 401 sur 2ème recherche)
+        const token = await tokenRefreshService.getValidToken();
+        if (!token) {
+          throw new Error("Session expirée, veuillez vous reconnecter.");
+        }
+
         const data = await huntzenApi.searchJobs(
           {
             job_title: jobSearchParams.query,
@@ -815,7 +858,7 @@ export default function JobsPage() {
             salaryMax: advancedFilters.salaryMax,
             companySize: advancedFilters.companySize,
           },
-          auth?.session?.access_token,
+          token,
         );
 
         return data;
@@ -866,16 +909,24 @@ export default function JobsPage() {
       if (!billedHash) return;
 
       try {
-        const lastBilledHash = sessionStorage.getItem("huntzen_last_billed_search_hash");
+        const lastBilledHash = sessionStorage.getItem(
+          "huntzen_last_billed_search_hash",
+        );
         if (billedHash === lastBilledHash) {
-          console.log("[QUOTA] Deduplicated search (sessionStorage match):", billedHash);
+          console.log(
+            "[QUOTA] Deduplicated search (sessionStorage match):",
+            billedHash,
+          );
           hasIncrementedQuotaRef.current = true;
           return;
         }
       } catch (e) {}
 
       // If we reach here, it's a genuinely new search
-      console.log("[QUOTA] Incrementing job_search quota for hash:", billedHash);
+      console.log(
+        "[QUOTA] Incrementing job_search quota for hash:",
+        billedHash,
+      );
       // NO MORE MANUAL INCREMENT HERE — backend handles it automatically in the /search route.
       // We just refetch to sync the UI limits.
       refreshQuotas();
@@ -969,6 +1020,9 @@ export default function JobsPage() {
       filtered.unshift(entry);
       localStorage.setItem(historyKey, JSON.stringify(filtered.slice(0, 5)));
     } catch {}
+
+    // Vider les résultats précédents pour afficher le loading modal
+    setJobs([]);
 
     // Trigger search with caching
     setJobSearchParams(params);
@@ -1341,6 +1395,8 @@ export default function JobsPage() {
           {featureFlags.useJobsV2 ? (
             <SearchFormInline
               initialQuery={jobTitle || popularQuery}
+              initialCountry={selectedCountry}
+              initialLocation={selectedCity}
               initialIncludeRemote={jobSearchParams?.includeRemote}
               onSearch={handleSearch}
               isLoading={searchQuery.isFetching}
@@ -2180,7 +2236,7 @@ export default function JobsPage() {
                                     : "bg-white text-slate-600 border-slate-200 hover:border-[#00D9FF]",
                                 )}
                               >
-                                {t(`contractType_${ct}`, {
+                                {t(`contractType_${ct.toLowerCase()}`, {
                                   defaultMessage: ct,
                                 })}
                               </button>

--- a/frontend-next/src/components/jobs/search-form-inline.tsx
+++ b/frontend-next/src/components/jobs/search-form-inline.tsx
@@ -103,6 +103,8 @@ interface SearchFormInlineProps {
   isLoading?: boolean;
   disabled?: boolean;
   initialQuery?: string;
+  initialCountry?: string;
+  initialLocation?: string;
   initialIncludeRemote?: boolean;
 }
 
@@ -123,13 +125,15 @@ export function SearchFormInline({
   isLoading = false,
   disabled = false,
   initialQuery,
+  initialCountry,
+  initialLocation,
   initialIncludeRemote = true,
 }: SearchFormInlineProps) {
   const [query, setQuery] = useState(initialQuery ?? "");
-  const [location, setLocation] = useState("");
-  const [country, setCountry] = useState("");
+  const [location, setLocation] = useState(initialLocation ?? "");
+  const [country, setCountry] = useState(initialCountry ?? "");
   const [selectedCountryName, setSelectedCountryName] = useState("");
-  const [isCountryValid, setIsCountryValid] = useState(false);
+  const [isCountryValid, setIsCountryValid] = useState(!!initialCountry);
   const [selectedContracts, setSelectedContracts] = useState<string[]>([]);
   const [selectedWorkDays, setSelectedWorkDays] = useState<string[]>([]);
   const [selectedWorkSchedule, setSelectedWorkSchedule] = useState<string[]>(
@@ -281,12 +285,25 @@ export function SearchFormInline({
     setErrors({});
   };
 
-  // Sync initialQuery and initialIncludeRemote props
+  // Sync props when parent state changes
   useEffect(() => {
     if (initialQuery !== undefined && initialQuery !== "") {
       setQuery(initialQuery);
     }
   }, [initialQuery]);
+
+  useEffect(() => {
+    if (initialCountry !== undefined && initialCountry !== "") {
+      setCountry(initialCountry);
+      setIsCountryValid(true);
+    }
+  }, [initialCountry]);
+
+  useEffect(() => {
+    if (initialLocation !== undefined) {
+      setLocation(initialLocation);
+    }
+  }, [initialLocation]);
 
   useEffect(() => {
     if (initialIncludeRemote !== undefined) {


### PR DESCRIPTION
## Summary

### 4 bugs critiques frontend
- **React #418 hydration** : localStorage lu dans useEffect (pas useState)
- **401 sur 2ème recherche** : token frais via tokenRefreshService
- **Ville/pays effacés** : props initialCountry/initialLocation ajoutées
- **Loading card invisible** : jobs[] vidé au début de handleSearch

### i18n
- **Type de contrat** : `contractType_CDI` → `contractType_cdi` (minuscule)
- **Clés manquantes** : cdi, cdd, freelance, stage, alternance, intérim
- **Contact Finder badges** : `"category.hr"` → `{ category: { hr } }` (4 langues)

## Test plan
- [x] Build frontend OK (npm run build, zéro erreur)
- [x] TypeScript OK (1 erreur pré-existante dans test, pas liée)
- [x] Vérifié les 4 fichiers i18n (fr, en, es, pt)