### PR TITLE
fix(frontend): hydration #418 — useSubscriptionApi + sidebar

### DIFF
--- a/frontend-next/src/components/layout/sidebar.tsx
+++ b/frontend-next/src/components/layout/sidebar.tsx
@@ -44,7 +44,7 @@ import {
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 interface SidebarProps {
@@ -57,13 +57,16 @@ export function Sidebar({ className }: SidebarProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isUsageModalOpen, setIsUsageModalOpen] = useState(false);
   const [showLogoutDialog, setShowLogoutDialog] = useState(false);
-  const [isCandidaturesNew, setIsCandidaturesNew] = useState(() => {
+  const [isCandidaturesNew, setIsCandidaturesNew] = useState(false);
+
+  // Hydrate from localStorage after mount (avoids hydration #418)
+  useEffect(() => {
     try {
-      return !localStorage.getItem("huntzen_candidatures_visited");
-    } catch {
-      return false;
-    }
-  });
+      if (!localStorage.getItem("huntzen_candidatures_visited")) {
+        setIsCandidaturesNew(true);
+      }
+    } catch {}
+  }, []);
   const t = useTranslations("sidebar");
 
   // Use auth context as single source of truth

--- a/frontend-next/src/hooks/use-subscription-api.ts
+++ b/frontend-next/src/hooks/use-subscription-api.ts
@@ -133,21 +133,36 @@ function clearPersistentCache(): void {
 export function useSubscriptionApi(): SubscriptionApiData {
   const { session, loading: authLoading } = useAuth();
 
-  // Pre-populate state from persistent cache so users see their last known plan immediately
-  const [data, setData] = useState<Omit<SubscriptionApiData, "refetch">>(() => {
-    const cached = loadPersistentCache();
-    return {
-      user: cached?.user ?? null,
-      subscription: cached?.subscription ?? null,
-      quotas: cached?.quotas ?? null,
-      saved_jobs_quota: cached?.saved_jobs_quota ?? { used: 0, limit: -1 },
-      feature_overrides: cached?.feature_overrides ?? {},
-      plan_feature_flags: cached?.plan_feature_flags ?? {},
-      isLoading: !cached, // If cache exists, no loading state
-      error: null,
-      isFromCache: !!cached,
-    };
+  // Initialize with defaults (no localStorage during SSR to avoid hydration #418)
+  const [data, setData] = useState<Omit<SubscriptionApiData, "refetch">>({
+    user: null,
+    subscription: null,
+    quotas: null,
+    saved_jobs_quota: { used: 0, limit: -1 },
+    feature_overrides: {},
+    plan_feature_flags: {},
+    isLoading: true,
+    error: null,
+    isFromCache: false,
   });
+
+  // Hydrate from persistent cache after mount
+  useEffect(() => {
+    const cached = loadPersistentCache();
+    if (cached) {
+      setData({
+        user: cached.user ?? null,
+        subscription: cached.subscription ?? null,
+        quotas: cached.quotas ?? null,
+        saved_jobs_quota: cached.saved_jobs_quota ?? { used: 0, limit: -1 },
+        feature_overrides: cached.feature_overrides ?? {},
+        plan_feature_flags: cached.plan_feature_flags ?? {},
+        isLoading: false,
+        error: null,
+        isFromCache: true,
+      });
+    }
+  }, []);
 
   // Use ref to avoid recreating interval on every render
   const intervalRef = useRef<NodeJS.Timeout | null>(null);


### PR DESCRIPTION
## Summary

Deux sources restantes de hydration #418 trouvées et corrigées :

1. **useSubscriptionApi** — localStorage dans useState initializer. Affecte tout le dashboard via SubscriptionProvider.
2. **Sidebar** — localStorage pour le badge "Nouveau" sur Candidatures.

Fix : initialiser avec des défauts côté serveur, hydrater depuis localStorage dans useEffect.

## Test plan
- [x] Build frontend OK
- [x] Investigation exhaustive par agent (11 patterns vérifiés)