### PR TITLE
feat(jobs): Jooble + Le Forem — Belgique couverte + 6ème source mondiale

### DIFF
--- a/backend/src/agents/job_scout/main_agent.py
+++ b/backend/src/agents/job_scout/main_agent.py
@@ -20,7 +20,9 @@ from src.config.settings import settings
 from src.services.job_providers import (
     AdzunaProvider,
     FranceTravailProvider,
+    JoobleProvider,
     JSearchProvider,
+    LeForemProvider,
     RemoteOKProvider,
     SerpAPIProvider,
     aggregate_jobs,
@@ -80,16 +82,18 @@ class JobScoutAgent(BaseAgent):
         )
         super().__init__(config)
 
-        # Initialize providers
+        # Initialize providers (all countries)
         self.providers = [
             AdzunaProvider(),
             SerpAPIProvider(),
             JSearchProvider(),
             RemoteOKProvider(),
+            JoobleProvider(),
         ]
 
-        # France-only provider (activated conditionally in run())
+        # Country-specific providers (activated conditionally in run())
         self.france_travail = FranceTravailProvider()
+        self.le_forem = LeForemProvider()
 
         # Initialize sub-agents
         self._init_sub_agents()
@@ -190,10 +194,13 @@ class JobScoutAgent(BaseAgent):
             # Step 2: Filter providers based on settings
             active_providers = list(self.providers)
 
-            # Add France Travail only for French searches
+            # Add country-specific providers
             if country_code.lower() == "fr":
                 active_providers.append(self.france_travail)
                 logger.info(f"[{self.name}] France Travail activated (country=fr)")
+            elif country_code.lower() == "be":
+                active_providers.append(self.le_forem)
+                logger.info(f"[{self.name}] Le Forem activated (country=be)")
 
             # Remove RemoteOK if user doesn't want remote jobs
             if not include_remote:

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     rapidapi_key: SecretStr = Field(default=SecretStr(""), description="RapidAPI Key")
     france_travail_client_id: str = Field(default="", alias="CLIENT_ID", description="France Travail OAuth2 Client ID")
     france_travail_client_secret: str = Field(default="", alias="CLIENT_SECRET", description="France Travail OAuth2 Client Secret")
+    jooble_api_key: str = Field(default="", alias="JOOBLE_API_KEY", description="Jooble API Key (free)")
 
     # --------------------------------------------------------------------------
     # API Keys - Recruiter Finder (Hunter.io)

--- a/backend/src/services/job_providers/__init__.py
+++ b/backend/src/services/job_providers/__init__.py
@@ -8,7 +8,9 @@ from src.services.job_providers.adzuna import AdzunaProvider
 from src.services.job_providers.aggregator import aggregate_jobs
 from src.services.job_providers.base import BaseJobProvider
 from src.services.job_providers.france_travail import FranceTravailProvider
+from src.services.job_providers.jooble import JoobleProvider
 from src.services.job_providers.jsearch import JSearchProvider
+from src.services.job_providers.le_forem import LeForemProvider
 from src.services.job_providers.remoteok import RemoteOKProvider
 from src.services.job_providers.serpapi import SerpAPIProvider
 
@@ -19,6 +21,8 @@ __all__ = [
     "RemoteOKProvider",
     "JSearchProvider",
     "FranceTravailProvider",
+    "JoobleProvider",
+    "LeForemProvider",
     "aggregate_jobs",
 ]
 

--- a/backend/src/services/job_providers/jooble.py
+++ b/backend/src/services/job_providers/jooble.py
@@ -1,0 +1,149 @@
+"""
+Jooble Job Provider
+====================
+Aggregator covering 70+ countries.
+https://jooble.org/api/about
+
+Features:
+- Worldwide coverage (aggregates Indeed, LinkedIn, StepStone, etc.)
+- Free API key
+- POST-based REST API
+- Radius search support
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from src.config.settings import settings
+from src.services.job_providers.base import (
+    BaseJobProvider,
+    handle_provider_errors,
+    normalize_contract_type,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class JoobleProvider(BaseJobProvider):
+    """
+    Jooble job aggregator — 70+ countries, free API.
+
+    Aggregates from Indeed, LinkedIn, Glassdoor, StepStone and many more.
+    Particularly strong for Belgium, Luxembourg, and other countries
+    not well covered by Adzuna.
+    """
+
+    name = "jooble"
+    supported_countries = set()  # All countries
+
+    BASE_URL = "https://jooble.org/api"
+
+    @handle_provider_errors
+    async def search(
+        self,
+        query: str,
+        location: str = "",
+        country_code: str = "fr",
+        max_results: int = 50,
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        """Search Jooble for jobs worldwide."""
+        api_key = getattr(settings, "jooble_api_key", None) or ""
+        if not api_key:
+            logger.debug(f"[{self.name}] Missing Jooble API key")
+            return []
+
+        url = f"{self.BASE_URL}/{api_key}"
+
+        # Jooble (jooble.org) est anglophone — ajouter le pays en anglais à la location
+        country_names = {
+            "fr": "France", "be": "Belgium", "lu": "Luxembourg",
+            "ch": "Switzerland", "de": "Germany", "nl": "Netherlands",
+            "gb": "United Kingdom", "us": "United States", "ca": "Canada",
+            "es": "Spain", "it": "Italy", "pt": "Portugal",
+        }
+        country_name = country_names.get(country_code.lower(), "")
+        jooble_location = f"{location}, {country_name}" if location and country_name else location or country_name
+
+        body: dict[str, Any] = {
+            "keywords": query,
+            "location": jooble_location,
+            "page": 1,
+            "companysearch": False,
+        }
+
+        # Radius si fourni (valeurs acceptées : 0, 4, 8, 16, 26, 40, 80)
+        radius_km = kwargs.get("radius_km")
+        if radius_km:
+            # Mapper vers les valeurs Jooble acceptées
+            jooble_radii = [0, 4, 8, 16, 26, 40, 80]
+            body["radius"] = str(min(jooble_radii, key=lambda x: abs(x - radius_km)))
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                url,
+                json=body,
+                headers={"Content-Type": "application/json"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        raw_jobs = data.get("jobs", [])
+        jobs = [self._normalize_jooble_job(item) for item in raw_jobs[:max_results]]
+
+        total = data.get("totalCount", len(jobs))
+        logger.info(f"[{self.name}] Found {len(jobs)} jobs for '{query}' in {location or country_code} (total: {total})")
+        return jobs
+
+    def _normalize_jooble_job(self, item: dict) -> dict[str, Any]:
+        """Normalize a Jooble job to the standard format."""
+        job_id = item.get("id", "")
+
+        # Type de contrat depuis le champ "type"
+        raw_type = item.get("type", "")
+        contract = self._normalize_type(raw_type)
+
+        # Description (Jooble fournit un "snippet")
+        snippet = item.get("snippet", "") or ""
+        # Nettoyer les tags HTML basiques
+        import re
+        description = re.sub(r"<[^>]+>", "", snippet).strip()
+
+        return {
+            "id": f"jooble_{job_id}",
+            "title": item.get("title", ""),
+            "company": item.get("company", ""),
+            "location": item.get("location", ""),
+            "description": description[:500] if description else "",
+            "url": item.get("link", ""),
+            "salary": item.get("salary") or None,
+            "contract_type": contract,
+            "source": self.name,
+            "posted_date": item.get("updated"),
+            "url_is_direct": False,
+        }
+
+    @staticmethod
+    def _normalize_type(raw_type: str) -> str:
+        """Normalize Jooble job type to standard contract type."""
+        if not raw_type:
+            return ""
+        raw = raw_type.lower().strip()
+        type_map = {
+            "full-time": "CDI",
+            "full time": "CDI",
+            "permanent": "CDI",
+            "part-time": "Temps partiel",
+            "part time": "Temps partiel",
+            "contract": "CDD",
+            "temporary": "CDD",
+            "internship": "Stage",
+            "intern": "Stage",
+            "freelance": "Freelance",
+        }
+        mapped = type_map.get(raw)
+        if mapped:
+            return mapped
+        return normalize_contract_type(raw_type)

--- a/backend/src/services/job_providers/le_forem.py
+++ b/backend/src/services/job_providers/le_forem.py
@@ -1,0 +1,152 @@
+"""
+Le Forem Job Provider
+======================
+Open Data API from the Walloon public employment service.
+https://leforem-digitalwallonia.opendatasoft.com/
+
+Features:
+- Belgium only (Wallonia + aggregates VDAB/Actiris)
+- No API key required (public Open Data)
+- ~25,000 active listings
+- GPS coordinates included
+- Contract type, employer, education level available
+"""
+
+import logging
+from typing import Any
+
+import httpx
+
+from src.services.job_providers.base import (
+    BaseJobProvider,
+    handle_provider_errors,
+    normalize_contract_type,
+)
+
+logger = logging.getLogger(__name__)
+
+# Mapping des types de contrat Le Forem → format normalisé
+_FOREM_CONTRACT_MAP = {
+    "Durée indéterminée": "CDI",
+    "Durée déterminée": "CDD",
+    "Intérim": "Interim",
+    "Indépendant": "Freelance",
+    "ACS": "CDD",
+    "Convention premier emploi": "Alternance",
+    "PFI": "Stage",
+}
+
+
+class LeForemProvider(BaseJobProvider):
+    """
+    Le Forem (Wallonia, Belgium) Open Data provider.
+
+    Uses the OpenDataSoft Explore API v2.1 — free, no API key needed.
+    Covers Wallonia and aggregates VDAB (Flanders) + Actiris (Brussels).
+    """
+
+    name = "le_forem"
+    supported_countries = {"be"}
+
+    BASE_URL = "https://leforem-digitalwallonia.opendatasoft.com/api/explore/v2.1/catalog/datasets/offres-d-emploi-forem/records"
+
+    @handle_provider_errors
+    async def search(
+        self,
+        query: str,
+        location: str = "",
+        country_code: str = "be",
+        max_results: int = 50,
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        """Search Le Forem Open Data for Belgian jobs."""
+        if country_code.lower() != "be":
+            return []
+
+        params: dict[str, str | int] = {
+            "limit": min(max_results, 100),
+            "offset": 0,
+            "select": "numerooffreforem,titreoffre,nomemployeur,typecontrat,lieuxtravaillocalite,lieuxtravailcodepostal,regimetravail,url,datedebutdiffusion,metier",
+        }
+
+        # Recherche dans le titre OU le métier (plus précis que full-text global)
+        where_clauses = [f'(search(titreoffre, "{query}") OR search(metier, "{query}"))']
+
+        # Filtre par ville si fournie
+        if location:
+            where_clauses.append(f'search(lieuxtravaillocalite, "{location.upper()}")')
+
+        params["where"] = " AND ".join(where_clauses)
+
+        # Filtre par type de contrat
+        contract_type = kwargs.get("contract_type", "")
+        if contract_type:
+            forem_type = self._map_contract_to_forem(contract_type)
+            if forem_type:
+                where = params.get("where", "")
+                contract_filter = f'typecontrat="{forem_type}"'
+                params["where"] = f"{where} AND {contract_filter}" if where else contract_filter
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(self.BASE_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+
+        results = data.get("results", [])
+        jobs = [self._normalize_forem_job(item) for item in results]
+
+        logger.info(f"[{self.name}] Found {len(jobs)} jobs for '{query}' in {location or 'Belgium'} (total: {data.get('total_count', 0)})")
+        return jobs
+
+    def _normalize_forem_job(self, item: dict) -> dict[str, Any]:
+        """Normalize a Le Forem job to the standard format."""
+        job_id = item.get("numerooffreforem", "")
+
+        # Location : prendre la première ville de la liste
+        localities = item.get("lieuxtravaillocalite") or []
+        postal_codes = item.get("lieuxtravailcodepostal") or []
+        location = ""
+        if localities:
+            city = localities[0].title()  # "LIEGE" → "Liege"
+            if postal_codes:
+                location = f"{postal_codes[0]} - {city}"
+            else:
+                location = city
+
+        # Type de contrat
+        raw_contract = item.get("typecontrat", "")
+        contract = _FOREM_CONTRACT_MAP.get(raw_contract, "")
+        if not contract and raw_contract:
+            contract = normalize_contract_type(raw_contract)
+
+        # Régime → temps partiel
+        regime = item.get("regimetravail", "")
+        if "partiel" in regime.lower() and not contract:
+            contract = "Temps partiel"
+
+        return {
+            "id": f"forem_{job_id}",
+            "title": item.get("titreoffre", ""),
+            "company": item.get("nomemployeur", "Employeur confidentiel"),
+            "location": location,
+            "description": item.get("metier", ""),
+            "url": item.get("url", ""),
+            "salary": None,
+            "contract_type": contract,
+            "source": self.name,
+            "posted_date": item.get("datedebutdiffusion"),
+            "url_is_direct": True,
+        }
+
+    @staticmethod
+    def _map_contract_to_forem(contract_type: str) -> str | None:
+        """Map normalized contract type to Le Forem values."""
+        mapping = {
+            "cdi": "Durée indéterminée",
+            "cdd": "Durée déterminée",
+            "interim": "Intérim",
+            "freelance": "Indépendant",
+            "alternance": "Convention premier emploi",
+            "apprentissage": "Convention premier emploi",
+        }
+        return mapping.get(contract_type.lower().strip())


### PR DESCRIPTION
## Summary

### Jooble — 6ème source (tous pays)
- Agrégateur mondial (70+ pays) : Indeed, LinkedIn, StepStone, etc.
- API gratuite, clé API requise (JOOBLE_API_KEY dans Railway)
- Location enrichie avec nom de pays pour le domaine anglophone

### Le Forem — 7ème source (Belgique)
- Open Data Wallonie (25K offres), gratuit, pas de clé API
- Recherche ciblée titre + métier (évite les faux positifs full-text)
- Activé automatiquement quand country_code=be

## Résultats

| Recherche | Avant | Après |
|---|---|---|
| comptable Bruxelles | 0 | **43** |
| marketing Namur | 0 | **18** |
| développeur Bruxelles | 0 | **5** |
| RH Nantes (FR) | 46 | **71** (pas de régression) |

## Test plan
- [x] Le Forem provider testé: 4 villes BE
- [x] Jooble provider testé: FR, BE, GB
- [x] Pipeline complet testé: 5 recherches (4 BE + 1 FR)
- [x] Syntaxe validée tous fichiers
- [x] Build frontend OK