### PR TITLE
fix(jobs): pre-filter faux positifs + encodage RemoteOK

### DIFF
--- a/backend/src/agents/job_scout/main_agent.py
+++ b/backend/src/agents/job_scout/main_agent.py
@@ -444,9 +444,14 @@ class JobScoutAgent(BaseAgent):
                 continue
 
             # Check 2: Fuzzy match (partial word match like "boulang" in "boulangerie")
+            # Min 3 chars for substring match to avoid "de" matching "developer"
             has_fuzzy = False
             for qw in query_words:
+                if len(qw) < 3:
+                    continue
                 for tw in title_words:
+                    if len(tw) < 3:
+                        continue
                     if qw in tw or tw in qw:
                         has_fuzzy = True
                         break

--- a/backend/src/services/job_providers/remoteok.py
+++ b/backend/src/services/job_providers/remoteok.py
@@ -95,6 +95,8 @@ class RemoteOKProvider(BaseJobProvider):
             description = BeautifulSoup(raw_desc, "html.parser").get_text(
                 separator="\n", strip=True
             )
+            # Fix encoding artifacts (Â, Ã, etc.)
+            description = description.replace("Â", "").replace("\xa0", " ").strip()
         else:
             description = None
         url = item.get("url")


### PR DESCRIPTION
Fix: 'Senior front end developer' dans recherche infirmier (fuzzy 'de' in 'developer'). Fix: caractères Â dans descriptions RemoteOK.