### PR TITLE
fix(frontend): badge source HuntZen → labels utiles

### DIFF
--- a/frontend-next/src/lib/utils/job-source-formatter.ts
+++ b/frontend-next/src/lib/utils/job-source-formatter.ts
@@ -4,37 +4,43 @@
  */
 
 const SOURCE_MAPPING: Record<string, string> = {
-  // API sources - mask with HuntZen brand
-  'adzuna': 'HuntZen',
-  'google_jobs': 'HuntZen',
-  'linkedin': 'Réseau Professionnel',
-  'indeed': 'HuntZen',
-  'monster': 'HuntZen',
-  'apec': 'Site Emploi Cadres',
-  'pole_emploi': 'Service Public Emploi',
-  'welcometothejungle': 'Plateforme Startup',
-  'glassdoor': 'Site Entreprises',
-}
+  adzuna: "Offre vérifiée",
+  google_jobs: "Offre vérifiée",
+  linkedin: "Réseau Pro",
+  indeed: "Offre vérifiée",
+  monster: "Offre vérifiée",
+  apec: "Emploi Cadres",
+  pole_emploi: "France Travail",
+  france_travail: "France Travail",
+  welcometothejungle: "Startup",
+  glassdoor: "Offre vérifiée",
+  jsearch: "Offre vérifiée",
+  remoteok: "Remote",
+  careerjet: "Offre vérifiée",
+  jooble: "Offre vérifiée",
+  le_forem: "Le Forem",
+  ziprecruiter: "Offre vérifiée",
+};
 
 /**
  * Format job source for display
  * Converts internal API source names to user-friendly labels
  */
 export function formatJobSource(source: string): string {
-  if (!source) return 'Source non spécifiée'
+  if (!source) return "Source non spécifiée";
 
   // Check if we have a mapping for this source
-  const lowerSource = source.toLowerCase().replace(/[_\s-]/g, '')
+  const lowerSource = source.toLowerCase().replace(/[_\s-]/g, "");
 
   for (const [key, value] of Object.entries(SOURCE_MAPPING)) {
-    const lowerKey = key.toLowerCase().replace(/[_\s-]/g, '')
+    const lowerKey = key.toLowerCase().replace(/[_\s-]/g, "");
     if (lowerSource.includes(lowerKey) || lowerKey.includes(lowerSource)) {
-      return value
+      return value;
     }
   }
 
-  // If no mapping found, return HuntZen brand
-  return 'HuntZen'
+  // If no mapping found, return generic label
+  return "Offre vérifiée";
 }
 
 /**
@@ -42,15 +48,17 @@ export function formatJobSource(source: string): string {
  */
 export function getSourceColor(source: string): string {
   const colors = [
-    'bg-blue-500',
-    'bg-green-500',
-    'bg-purple-500',
-    'bg-orange-500',
-    'bg-pink-500',
-    'bg-indigo-500',
-  ]
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-purple-500",
+    "bg-orange-500",
+    "bg-pink-500",
+    "bg-indigo-500",
+  ];
 
   // Use source hash to get consistent color
-  const hash = source.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
-  return colors[hash % colors.length]
+  const hash = source
+    .split("")
+    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  return colors[hash % colors.length];
 }


### PR DESCRIPTION
Badge 'HuntZen' remplacé par 'Offre vérifiée', 'France Travail', 'Le Forem', 'Réseau Pro', 'Remote' selon la source.