### PR TITLE
feat: add international event search functionality via SerpAPI

### DIFF
--- a/backend/src/api/routes/events.py
+++ b/backend/src/api/routes/events.py
@@ -7,30 +7,30 @@ Endpoints for searching job fairs and employment events.
 from fastapi import APIRouter, Query
 
 from src.services.events.provider import search_job_fairs
+from src.services.events.serpapi import SUPPORTED_COUNTRIES
 
 router = APIRouter()
 
 
 @router.get("/search")
 async def search_events(
-    region: str = Query(default="", description="Filter by region"),
+    region: str = Query(default="", description="Filter by region (France only)"),
     sector: str = Query(default="", description="Filter by sector"),
     public: str = Query(default="", description="Filter by target public"),
     event_type: str = Query(default="", description="Filter by event type"),
-    format_type: str = Query(default="", description="Filter by format (physique/virtuel)")
+    format_type: str = Query(default="", description="Filter by format (physique/virtuel)"),
+    country: str = Query(default="", description="Country for international events (e.g. Germany, India)"),
 ):
-    """
-    Search for job fairs and professional events.
-    """
+    """Search for job fairs and professional events."""
     result = await search_job_fairs(
         region=region,
         sector=sector,
         public=public,
         event_type=event_type,
         format_type=format_type,
-        include_mock=False
+        country=country,
+        include_mock=False,
     )
-    # Add missing fields expected by frontend
     return {
         **result,
         "message": "Search completed successfully",
@@ -40,41 +40,34 @@ async def search_events(
             "public": public,
             "event_type": event_type,
             "format_type": format_type,
-        }
+            "country": country,
+        },
     }
 
 
 @router.post("/search")
 async def search_events_post(data: dict):
-    """
-    Search for professional events (POST version).
-    """
-    region = data.get("region", "")
-    sector = data.get("sector", "")
-    public = data.get("public", "")
-    event_type = data.get("event_type", "")
-    format_type = data.get("format_type", "")
-
+    """Search for professional events (POST version)."""
     result = await search_job_fairs(
-        region=region,
-        sector=sector,
-        public=public,
-        event_type=event_type,
-        format_type=format_type,
-        include_mock=False
+        region=data.get("region", ""),
+        sector=data.get("sector", ""),
+        public=data.get("public", ""),
+        event_type=data.get("event_type", ""),
+        format_type=data.get("format_type", ""),
+        country=data.get("country", ""),
+        include_mock=False,
     )
-    # Add missing fields expected by frontend
     return {
         **result,
         "message": "Search completed successfully",
-        "filters_applied": {
-            "region": region,
-            "sector": sector,
-            "public": public,
-            "event_type": event_type,
-            "format_type": format_type,
-        }
+        "filters_applied": {k: data.get(k, "") for k in ("region", "sector", "public", "event_type", "format_type", "country")},
     }
+
+
+@router.get("/countries")
+async def get_countries():
+    """Get list of supported countries for international event search."""
+    return {"success": True, "countries": SUPPORTED_COUNTRIES, "count": len(SUPPORTED_COUNTRIES)}
 
 
 @router.get("/regions")

--- a/backend/src/services/events/provider.py
+++ b/backend/src/services/events/provider.py
@@ -666,6 +666,7 @@ async def search_job_fairs(
     public: str = "",
     event_type: str = "",
     format_type: str = "",
+    country: str = "",
     include_mock: bool = False
 ) -> dict[str, Any]:
     """Aggregate professional events from multiple sources."""
@@ -698,6 +699,32 @@ async def search_job_fairs(
     public = PUBLIC_MAP.get(public.lower().strip(), public) if public else ""
     format_type = FORMAT_MAP.get(format_type.lower().strip(), format_type) if format_type else ""
     sector = SECTOR_MAP.get(sector.lower().strip(), sector) if sector else ""
+
+    # International mode: use SerpAPI for the requested country
+    if country and country.lower() != "france":
+        from src.services.events.serpapi import fetch_events_for_country
+        international = await fetch_events_for_country(country)
+        filtered_intl = international
+
+        today = datetime.now().strftime("%Y-%m-%d")
+        filtered_intl = [e for e in filtered_intl if (e.get("date_start") or "") >= today]
+
+        if sector and sector != "all":
+            filtered_intl = [e for e in filtered_intl if e.get("sector") in (sector, "all")]
+        if public and public != "all":
+            filtered_intl = [e for e in filtered_intl if e.get("public") in (public, "all")]
+        if event_type:
+            filtered_intl = [e for e in filtered_intl if e.get("event_type") == event_type]
+        if format_type:
+            filtered_intl = [e for e in filtered_intl if e.get("format") == format_type]
+
+        filtered_intl.sort(key=lambda e: e.get("date_start", ""))
+        return {
+            "success": True,
+            "events": filtered_intl,
+            "count": len(filtered_intl),
+            "sources": ["serpapi"],
+        }
 
     tasks = [
         ("france_travail", scrape_france_travail_events(region, sector)),

--- a/backend/src/services/events/serpapi.py
+++ b/backend/src/services/events/serpapi.py
@@ -1,0 +1,155 @@
+"""
+International Events via SerpAPI Google Events
+================================================
+Fetches career fairs and student events worldwide.
+Results are cached 12h per country to minimize API usage.
+"""
+
+import logging
+from datetime import datetime
+
+import httpx
+
+from src.config.settings import settings
+from src.utils.cache import redis_cache
+
+logger = logging.getLogger(__name__)
+
+# Country → localized query term
+COUNTRY_QUERIES: dict[str, str] = {
+    "United States": "student career fair",
+    "United Kingdom": "student career fair",
+    "Canada": "student career fair",
+    "Australia": "student career fair",
+    "Germany": "career fair student",
+    "Netherlands": "career fair student",
+    "Belgium": "forum emploi étudiant",
+    "Spain": "feria empleo estudiante",
+    "Italy": "career fair studenti",
+    "India": "education career fair student",
+    "Japan": "career fair student",
+    "Singapore": "career fair student",
+    "UAE": "career fair student",
+    "South Africa": "student career fair",
+    "Brazil": "feira de carreira estudante",
+    "Morocco": "forum emploi étudiant",
+    "France": "salon étudiant emploi",
+}
+
+SUPPORTED_COUNTRIES = sorted(COUNTRY_QUERIES.keys())
+
+
+@redis_cache(ttl=43200, prefix="events_int")
+async def fetch_events_for_country(country: str) -> list[dict]:
+    """
+    Fetch upcoming career/student events for a given country via SerpAPI.
+    Cached 12h per country to avoid redundant API calls.
+    """
+    query_term = COUNTRY_QUERIES.get(country, "career fair student")
+    api_key = settings.get_serpapi_key()
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                "https://serpapi.com/search.json",
+                params={
+                    "engine": "google_events",
+                    "q": f"{query_term} {country}",
+                    "hl": "en",
+                    "api_key": api_key,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as e:
+        logger.error(f"[Events] SerpAPI error for {country}: {e}")
+        return []
+
+    today = datetime.now()
+    events: list[dict] = []
+
+    for item in data.get("events_results", []):
+        try:
+            start_date_raw = item.get("date", {}).get("start_date", "")
+            if not start_date_raw:
+                continue
+
+            parsed = datetime.strptime(start_date_raw, "%b %d").replace(year=today.year)
+            if parsed < today:
+                continue
+
+            address = item.get("address", [])
+            city = address[-1] if len(address) > 1 else (address[0] if address else country)
+            venue = item.get("venue", {})
+            organizer = venue.get("name", "") if isinstance(venue, dict) else ""
+
+            events.append({
+                "title": item.get("title", ""),
+                "event_type": _classify_event_type(item.get("title", "")),
+                "public": _classify_public(item.get("title", "")),
+                "sector": _classify_sector(item.get("title", "")),
+                "level": "all",
+                "date_start": parsed.strftime("%Y-%m-%d"),
+                "date_end": None,
+                "time_start": None,
+                "time_end": item.get("date", {}).get("when"),
+                "city": city,
+                "region": country,
+                "address": ", ".join(address) if address else None,
+                "format": "virtual" if _is_virtual(item.get("title", "")) else "physical",
+                "organizer": organizer,
+                "description": None,
+                "url": item.get("link", ""),
+                "source": "serpapi",
+                "registration_url": None,
+                "is_free": None,
+                "companies_count": None,
+            })
+        except Exception as e:
+            logger.debug(f"[Events] SerpAPI parse error ({country}): {e}")
+            continue
+
+    logger.info(f"[Events] SerpAPI {country}: {len(events)} events")
+    return events
+
+
+def _classify_event_type(title: str) -> str:
+    t = title.lower()
+    if any(k in t for k in ["job dating", "jobdating"]):
+        return "job_dating"
+    if any(k in t for k in ["webinar", "online", "virtual", "en ligne", "visio"]):
+        return "webinar"
+    if "forum" in t:
+        return "forum"
+    return "salon"
+
+
+def _classify_public(title: str) -> str:
+    t = title.lower()
+    if any(k in t for k in ["student", "étudiant", "graduate", "college", "university", "youth", "alternance", "stage"]):
+        return "students"
+    if any(k in t for k in ["senior", "reconversion", "+45", "+50"]):
+        return "seniors"
+    if any(k in t for k in ["professional", "cadre", "manager", "executive"]):
+        return "pros"
+    return "all"
+
+
+def _classify_sector(title: str) -> str:
+    t = title.lower()
+    if any(k in t for k in ["tech", "it", "digital", "data", "cyber", "software", "numérique"]):
+        return "tech"
+    if any(k in t for k in ["health", "medical", "santé", "nursing", "pharma"]):
+        return "health"
+    if any(k in t for k in ["finance", "banking", "banque", "accounting", "insurance"]):
+        return "finance"
+    if any(k in t for k in ["engineering", "industrie", "manufacturing", "aerospace"]):
+        return "industry"
+    if any(k in t for k in ["retail", "commerce", "sales", "vente"]):
+        return "retail"
+    return "all"
+
+
+def _is_virtual(title: str) -> bool:
+    t = title.lower()
+    return any(k in t for k in ["online", "virtual", "webinar", "en ligne", "visio", "remote"])


### PR DESCRIPTION
What was added

backend/src/services/events/serpapi.py (new)

Fetches career/student events via SerpAPI Google Events engine
17 countries supported with localized queries per country
Redis cache 12h per country — no redundant API calls
hl=en forced for consistent date parsing
backend/src/services/events/provider.py

Added country param to search_job_fairs()
If country ≠ France → SerpAPI path, FR scrapers untouched
backend/src/api/routes/events.py

GET /events/search?country=Germany — new country param
POST /events/search — idem
GET /events/countries — returns list of 17 supported countries
Frontend input needed

Add a country selector on the events search form
Values to use: call GET /events/countries to populate the list
Pass as country= query param (string, e.g. "Germany", "India")
If empty → existing FR behavior, no change
Countries available
Australia, Belgium, Brazil, Canada, France, Germany, India, Italy, Japan, Morocco, Netherlands, Singapore, South Africa, Spain, UAE, United Kingdom, United States