### PR TITLE
feat: récupération branding memory + déduplication request_id

### DIFF
--- a/backend/src/api/routes/assistant.py
+++ b/backend/src/api/routes/assistant.py
@@ -30,6 +30,7 @@ from src.api.deps import (
 from src.services.cv_chat_extractor import extract_cv_structured
 from src.services.modal_pdf_extractor import extract_text_via_modal, is_modal_pdf_enabled
 from src.services.stripe import invalidate_user_quota_cache
+from src.utils.request_dedup import build_dedup_request_id, get_or_register_request
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,9 @@ class AssistantRequest(BaseModel):
         "interview-sim"
     ] = Field(..., description="Type of assistant to use")
     language: str = Field(default="fr", description="Response language (fr/en)")
+    request_id: str | None = Field(
+        default=None, description="Clé d'idempotence optionnelle pour déduplication ARQ"
+    )
 
     # Optional context data for specific assistants
     cv_data: dict | None = Field(default=None, description="CV data for cv-analyzer/cv-adapter")
@@ -174,6 +178,18 @@ async def job_scout_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
+                req_id = request.request_id or build_dedup_request_id(
+                    "assistant", "job-scout", user_id, request.session_id, request.message[:50]
+                )
+                dedup_id: str | None = None
+                existing = await get_or_register_request(req_id, "_pending_")
+                if existing and existing != "_pending_":
+                    increment_assistant_messages(user_id, "job-scout")
+                    await invalidate_user_quota_cache(user_id)
+                    logger.info(
+                        f"[assistant/job-scout] dedup hit — returning existing job={existing}"
+                    )
+                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
                 job = await pool.enqueue_job(
                     "assistant_task",
                     message=request.message,
@@ -182,10 +198,14 @@ async def job_scout_chat(
                     language=request.language,
                     history=history,
                 )
+                dedup_id = job.job_id
+                await get_or_register_request(req_id, dedup_id)
                 increment_assistant_messages(user_id, "job-scout")
                 await invalidate_user_quota_cache(user_id)
-                logger.info(f"[assistant/job-scout] ARQ queued — active={active} job={job.job_id}")
-                return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
+                logger.info(
+                    f"[assistant/job-scout] ARQ queued — active={active} job={dedup_id}"
+                )
+                return {"queued": True, "job_id": dedup_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
                 logger.warning(f"[assistant/job-scout] ARQ enqueue failed ({e}) — fallback sync")
         await _incr_active()
@@ -246,6 +266,17 @@ async def cv_analyzer_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
+                req_id = request.request_id or build_dedup_request_id(
+                    "assistant", "cv-analyzer", user_id, request.session_id, request.message[:50]
+                )
+                existing = await get_or_register_request(req_id, "_pending_")
+                if existing and existing != "_pending_":
+                    increment_assistant_messages(user_id, "cv-analyzer")
+                    await invalidate_user_quota_cache(user_id)
+                    logger.info(
+                        f"[assistant/cv-analyzer] dedup hit — returning existing job={existing}"
+                    )
+                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
                 job = await pool.enqueue_job(
                     "assistant_task",
                     message=request.message,
@@ -254,9 +285,12 @@ async def cv_analyzer_chat(
                     language=request.language,
                     history=history,
                 )
+                await get_or_register_request(req_id, job.job_id)
                 increment_assistant_messages(user_id, "cv-analyzer")
                 await invalidate_user_quota_cache(user_id)
-                logger.info(f"[assistant/cv-analyzer] ARQ queued — active={active} job={job.job_id}")
+                logger.info(
+                    f"[assistant/cv-analyzer] ARQ queued — active={active} job={job.job_id}"
+                )
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
                 logger.warning(f"[assistant/cv-analyzer] ARQ enqueue failed ({e}) — fallback sync")
@@ -318,6 +352,17 @@ async def cv_adapter_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
+                req_id = request.request_id or build_dedup_request_id(
+                    "assistant", "cv-adapter", user_id, request.session_id, request.message[:50]
+                )
+                existing = await get_or_register_request(req_id, "_pending_")
+                if existing and existing != "_pending_":
+                    increment_assistant_messages(user_id, "cv-adapter")
+                    await invalidate_user_quota_cache(user_id)
+                    logger.info(
+                        f"[assistant/cv-adapter] dedup hit — returning existing job={existing}"
+                    )
+                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
                 job = await pool.enqueue_job(
                     "assistant_task",
                     message=request.message,
@@ -326,9 +371,12 @@ async def cv_adapter_chat(
                     language=request.language,
                     history=history,
                 )
+                await get_or_register_request(req_id, job.job_id)
                 increment_assistant_messages(user_id, "cv-adapter")
                 await invalidate_user_quota_cache(user_id)
-                logger.info(f"[assistant/cv-adapter] ARQ queued — active={active} job={job.job_id}")
+                logger.info(
+                    f"[assistant/cv-adapter] ARQ queued — active={active} job={job.job_id}"
+                )
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
                 logger.warning(f"[assistant/cv-adapter] ARQ enqueue failed ({e}) — fallback sync")
@@ -392,6 +440,17 @@ async def interview_sim_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
+                req_id = request.request_id or build_dedup_request_id(
+                    "assistant", "interview-sim", user_id, request.session_id, request.message[:50]
+                )
+                existing = await get_or_register_request(req_id, "_pending_")
+                if existing and existing != "_pending_":
+                    increment_assistant_messages(user_id, "interview-sim")
+                    await invalidate_user_quota_cache(user_id)
+                    logger.info(
+                        f"[assistant/interview-sim] dedup hit — returning existing job={existing}"
+                    )
+                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
                 job = await pool.enqueue_job(
                     "assistant_task",
                     message=request.message,
@@ -400,9 +459,12 @@ async def interview_sim_chat(
                     language=request.language,
                     history=history,
                 )
+                await get_or_register_request(req_id, job.job_id)
                 increment_assistant_messages(user_id, "interview-sim")
                 await invalidate_user_quota_cache(user_id)
-                logger.info(f"[assistant/interview-sim] ARQ queued — active={active} job={job.job_id}")
+                logger.info(
+                    f"[assistant/interview-sim] ARQ queued — active={active} job={job.job_id}"
+                )
                 return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
             except Exception as e:
                 logger.warning(f"[assistant/interview-sim] ARQ enqueue failed ({e}) — fallback sync")

--- a/backend/src/api/routes/assistant.py
+++ b/backend/src/api/routes/assistant.py
@@ -30,7 +30,7 @@ from src.api.deps import (
 from src.services.cv_chat_extractor import extract_cv_structured
 from src.services.modal_pdf_extractor import extract_text_via_modal, is_modal_pdf_enabled
 from src.services.stripe import invalidate_user_quota_cache
-from src.utils.request_dedup import build_dedup_request_id, get_or_register_request
+from src.utils.request_dedup import build_dedup_request_id, register_request, store_job_id
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +70,36 @@ async def _decr_active() -> None:
         val = await redis.decr(_GROQ_ACTIVE_KEY)
         if val < 0:
             await redis.set(_GROQ_ACTIVE_KEY, 0)
+
+async def _dedup_or_enqueue(
+    pool,
+    task_name: str,
+    assistant_type: str,
+    user_id: str,
+    request_id: str | None,
+    active: int,
+    **task_kwargs,
+) -> dict | None:
+    """Helper mutualisé : déduplication + enqueue ARQ.
+
+    Retourne le dict de réponse queue si dedup hit ou enqueue réussi, None sinon.
+    NE touche JAMAIS au quota — c'est la responsabilité de l'appelant UNIQUEMENT
+    lors d'un nouveau job (pas sur dedup hit).
+    """
+    req_id = request_id or build_dedup_request_id(
+        "assistant", assistant_type, user_id,
+        task_kwargs.get("session_id", ""), task_kwargs.get("message", ""),
+    )
+    existing = await register_request(req_id)
+    if existing and existing != "__pending__":
+        # Doublon détecté — NE PAS incrémenter le quota (P1-1)
+        logger.info(f"[assistant/{assistant_type}] dedup hit — returning existing job={existing}")
+        return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
+
+    job = await pool.enqueue_job(task_name, **task_kwargs)
+    await store_job_id(req_id, job.job_id)
+    return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8, "_new_job": True}
+
 
 # ── Prompts de réception du CV par assistant ─────────────────────────────────
 # Chaque assistant répond différemment à l'upload d'un CV.
@@ -129,7 +159,7 @@ class AssistantRequest(BaseModel):
     ] = Field(..., description="Type of assistant to use")
     language: str = Field(default="fr", description="Response language (fr/en)")
     request_id: str | None = Field(
-        default=None, description="Clé d'idempotence optionnelle pour déduplication ARQ"
+        default=None, max_length=128, description="Clé d'idempotence optionnelle pour déduplication ARQ"
     )
 
     # Optional context data for specific assistants
@@ -178,34 +208,29 @@ async def job_scout_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
-                req_id = request.request_id or build_dedup_request_id(
-                    "assistant", "job-scout", user_id, request.session_id, request.message[:50]
-                )
-                dedup_id: str | None = None
-                existing = await get_or_register_request(req_id, "_pending_")
-                if existing and existing != "_pending_":
-                    increment_assistant_messages(user_id, "job-scout")
-                    await invalidate_user_quota_cache(user_id)
-                    logger.info(
-                        f"[assistant/job-scout] dedup hit — returning existing job={existing}"
-                    )
-                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
-                job = await pool.enqueue_job(
+                result_queue = await _dedup_or_enqueue(
+                    pool,
                     "assistant_task",
+                    "job-scout",
+                    user_id,
+                    request.request_id,
+                    active,
                     message=request.message,
                     session_id=request.session_id,
                     assistant_type="job-scout",
                     language=request.language,
                     history=history,
                 )
-                dedup_id = job.job_id
-                await get_or_register_request(req_id, dedup_id)
-                increment_assistant_messages(user_id, "job-scout")
-                await invalidate_user_quota_cache(user_id)
-                logger.info(
-                    f"[assistant/job-scout] ARQ queued — active={active} job={dedup_id}"
-                )
-                return {"queued": True, "job_id": dedup_id, "estimated_wait_seconds": active * 8}
+                if result_queue is not None:
+                    if result_queue.pop("_new_job", False):
+                        # Nouveau job uniquement : incrémenter le quota
+                        increment_assistant_messages(user_id, "job-scout")
+                        await invalidate_user_quota_cache(user_id)
+                        logger.info(
+                            f"[assistant/job-scout] ARQ queued — active={active} "
+                            f"job={result_queue['job_id']}"
+                        )
+                    return result_queue
             except Exception as e:
                 logger.warning(f"[assistant/job-scout] ARQ enqueue failed ({e}) — fallback sync")
         await _incr_active()
@@ -266,32 +291,28 @@ async def cv_analyzer_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
-                req_id = request.request_id or build_dedup_request_id(
-                    "assistant", "cv-analyzer", user_id, request.session_id, request.message[:50]
-                )
-                existing = await get_or_register_request(req_id, "_pending_")
-                if existing and existing != "_pending_":
-                    increment_assistant_messages(user_id, "cv-analyzer")
-                    await invalidate_user_quota_cache(user_id)
-                    logger.info(
-                        f"[assistant/cv-analyzer] dedup hit — returning existing job={existing}"
-                    )
-                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
-                job = await pool.enqueue_job(
+                result_queue = await _dedup_or_enqueue(
+                    pool,
                     "assistant_task",
+                    "cv-analyzer",
+                    user_id,
+                    request.request_id,
+                    active,
                     message=request.message,
                     session_id=request.session_id,
                     assistant_type="cv-analyzer",
                     language=request.language,
                     history=history,
                 )
-                await get_or_register_request(req_id, job.job_id)
-                increment_assistant_messages(user_id, "cv-analyzer")
-                await invalidate_user_quota_cache(user_id)
-                logger.info(
-                    f"[assistant/cv-analyzer] ARQ queued — active={active} job={job.job_id}"
-                )
-                return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
+                if result_queue is not None:
+                    if result_queue.pop("_new_job", False):
+                        increment_assistant_messages(user_id, "cv-analyzer")
+                        await invalidate_user_quota_cache(user_id)
+                        logger.info(
+                            f"[assistant/cv-analyzer] ARQ queued — active={active} "
+                            f"job={result_queue['job_id']}"
+                        )
+                    return result_queue
             except Exception as e:
                 logger.warning(f"[assistant/cv-analyzer] ARQ enqueue failed ({e}) — fallback sync")
         await _incr_active()
@@ -352,32 +373,28 @@ async def cv_adapter_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
-                req_id = request.request_id or build_dedup_request_id(
-                    "assistant", "cv-adapter", user_id, request.session_id, request.message[:50]
-                )
-                existing = await get_or_register_request(req_id, "_pending_")
-                if existing and existing != "_pending_":
-                    increment_assistant_messages(user_id, "cv-adapter")
-                    await invalidate_user_quota_cache(user_id)
-                    logger.info(
-                        f"[assistant/cv-adapter] dedup hit — returning existing job={existing}"
-                    )
-                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
-                job = await pool.enqueue_job(
+                result_queue = await _dedup_or_enqueue(
+                    pool,
                     "assistant_task",
+                    "cv-adapter",
+                    user_id,
+                    request.request_id,
+                    active,
                     message=request.message,
                     session_id=request.session_id,
                     assistant_type="cv-adapter",
                     language=request.language,
                     history=history,
                 )
-                await get_or_register_request(req_id, job.job_id)
-                increment_assistant_messages(user_id, "cv-adapter")
-                await invalidate_user_quota_cache(user_id)
-                logger.info(
-                    f"[assistant/cv-adapter] ARQ queued — active={active} job={job.job_id}"
-                )
-                return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
+                if result_queue is not None:
+                    if result_queue.pop("_new_job", False):
+                        increment_assistant_messages(user_id, "cv-adapter")
+                        await invalidate_user_quota_cache(user_id)
+                        logger.info(
+                            f"[assistant/cv-adapter] ARQ queued — active={active} "
+                            f"job={result_queue['job_id']}"
+                        )
+                    return result_queue
             except Exception as e:
                 logger.warning(f"[assistant/cv-adapter] ARQ enqueue failed ({e}) — fallback sync")
         await _incr_active()
@@ -440,32 +457,28 @@ async def interview_sim_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
-                req_id = request.request_id or build_dedup_request_id(
-                    "assistant", "interview-sim", user_id, request.session_id, request.message[:50]
-                )
-                existing = await get_or_register_request(req_id, "_pending_")
-                if existing and existing != "_pending_":
-                    increment_assistant_messages(user_id, "interview-sim")
-                    await invalidate_user_quota_cache(user_id)
-                    logger.info(
-                        f"[assistant/interview-sim] dedup hit — returning existing job={existing}"
-                    )
-                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": active * 8}
-                job = await pool.enqueue_job(
+                result_queue = await _dedup_or_enqueue(
+                    pool,
                     "assistant_task",
+                    "interview-sim",
+                    user_id,
+                    request.request_id,
+                    active,
                     message=request.message,
                     session_id=request.session_id,
                     assistant_type="interview-sim",
                     language=request.language,
                     history=history,
                 )
-                await get_or_register_request(req_id, job.job_id)
-                increment_assistant_messages(user_id, "interview-sim")
-                await invalidate_user_quota_cache(user_id)
-                logger.info(
-                    f"[assistant/interview-sim] ARQ queued — active={active} job={job.job_id}"
-                )
-                return {"queued": True, "job_id": job.job_id, "estimated_wait_seconds": active * 8}
+                if result_queue is not None:
+                    if result_queue.pop("_new_job", False):
+                        increment_assistant_messages(user_id, "interview-sim")
+                        await invalidate_user_quota_cache(user_id)
+                        logger.info(
+                            f"[assistant/interview-sim] ARQ queued — active={active} "
+                            f"job={result_queue['job_id']}"
+                        )
+                    return result_queue
             except Exception as e:
                 logger.warning(f"[assistant/interview-sim] ARQ enqueue failed ({e}) — fallback sync")
         await _incr_active()

--- a/backend/src/api/routes/branding.py
+++ b/backend/src/api/routes/branding.py
@@ -30,9 +30,10 @@ class BrandingRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=3000, description="User message")
     session_id: str = Field(..., pattern=r"^[a-f0-9\-]{36}$", description="Session UUID")
     language: str = Field(default="fr", description="Response language")
-    # TODO: ajouter déduplication ARQ quand branding_chat passe en mode queue
+    # Note: déduplication ARQ non activée sur cette route (mode synchrone uniquement).
+    # Le champ request_id est accepté mais ignoré. Il sera câblé si la route passe en mode queue.
     request_id: str | None = Field(
-        default=None, description="Clé d'idempotence optionnelle (réservée pour mode ARQ futur)"
+        default=None, max_length=128, description="Réservé — non utilisé en mode synchrone"
     )
     branding_state: dict | None = Field(default=None, description="Current branding profile state")
 

--- a/backend/src/api/routes/branding.py
+++ b/backend/src/api/routes/branding.py
@@ -30,6 +30,10 @@ class BrandingRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=3000, description="User message")
     session_id: str = Field(..., pattern=r"^[a-f0-9\-]{36}$", description="Session UUID")
     language: str = Field(default="fr", description="Response language")
+    # TODO: ajouter déduplication ARQ quand branding_chat passe en mode queue
+    request_id: str | None = Field(
+        default=None, description="Clé d'idempotence optionnelle (réservée pour mode ARQ futur)"
+    )
     branding_state: dict | None = Field(default=None, description="Current branding profile state")
 
 

--- a/backend/src/api/routes/coach.py
+++ b/backend/src/api/routes/coach.py
@@ -29,7 +29,7 @@ from src.api.middleware import limiter
 from src.models.schemas import CoachRequest, CoachResponse
 from src.services.stripe import invalidate_user_quota_cache
 from src.services.user_events import log_event
-from src.utils.request_dedup import build_dedup_request_id, get_or_register_request
+from src.utils.request_dedup import build_dedup_request_id, register_request, store_job_id
 
 # Seuil global (toutes replicas confondues) → au-dessus : queue Redis
 COACH_SYNC_THRESHOLD = 12  # max 12 Groq simultanés TOTAL (cross-replicas via Redis)
@@ -212,14 +212,14 @@ async def coach_chat(
         if pool:
             try:
                 req_id = data.request_id or build_dedup_request_id(
-                    "coach", data.assistant_type, user_id_for_quota or "", data.session_id, data.message[:50]
+                    "coach", data.assistant_type, user_id_for_quota or "",
+                    data.session_id, data.message,
                 )
-                existing = await get_or_register_request(req_id, "_pending_")
-                if existing and existing != "_pending_":
+                existing = await register_request(req_id)
+                if existing and existing != "__pending__":
+                    # Doublon détecté — NE PAS incrémenter le quota (P1-1)
                     estimated_wait = active * 8
-                    logger.info(
-                        f"[coach/chat] dedup hit — returning existing job={existing}"
-                    )
+                    logger.info(f"[coach/chat] dedup hit — returning existing job={existing}")
                     return {"queued": True, "job_id": existing, "estimated_wait_seconds": estimated_wait}
                 job = await pool.enqueue_job(
                     "coach_task",
@@ -227,7 +227,7 @@ async def coach_chat(
                     session_id=data.session_id,
                     language=data.language,
                 )
-                await get_or_register_request(req_id, job.job_id)
+                await store_job_id(req_id, job.job_id)
                 estimated_wait = active * 8
                 logger.info(
                     f"[coach/chat] ARQ queued — active_global={active} "

--- a/backend/src/api/routes/coach.py
+++ b/backend/src/api/routes/coach.py
@@ -29,6 +29,7 @@ from src.api.middleware import limiter
 from src.models.schemas import CoachRequest, CoachResponse
 from src.services.stripe import invalidate_user_quota_cache
 from src.services.user_events import log_event
+from src.utils.request_dedup import build_dedup_request_id, get_or_register_request
 
 # Seuil global (toutes replicas confondues) → au-dessus : queue Redis
 COACH_SYNC_THRESHOLD = 12  # max 12 Groq simultanés TOTAL (cross-replicas via Redis)
@@ -210,12 +211,23 @@ async def coach_chat(
         pool = await _get_arq_pool()
         if pool:
             try:
+                req_id = data.request_id or build_dedup_request_id(
+                    "coach", data.assistant_type, user_id_for_quota or "", data.session_id, data.message[:50]
+                )
+                existing = await get_or_register_request(req_id, "_pending_")
+                if existing and existing != "_pending_":
+                    estimated_wait = active * 8
+                    logger.info(
+                        f"[coach/chat] dedup hit — returning existing job={existing}"
+                    )
+                    return {"queued": True, "job_id": existing, "estimated_wait_seconds": estimated_wait}
                 job = await pool.enqueue_job(
                     "coach_task",
                     message=data.message,
                     session_id=data.session_id,
                     language=data.language,
                 )
+                await get_or_register_request(req_id, job.job_id)
                 estimated_wait = active * 8
                 logger.info(
                     f"[coach/chat] ARQ queued — active_global={active} "

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -30,6 +30,7 @@ class CoachRequest(BaseModel):
     session_id: str = Field(..., pattern=r"^[a-f0-9-]{36}$", description="Session UUID")
     language: Literal["fr", "en", "es", "pt"] = Field(default="fr")
     assistant_type: str = Field(default="career-coach", description="Coach/assistant type for per-coach quota tracking")
+    request_id: str | None = Field(default=None, description="Clé d'idempotence optionnelle pour déduplication ARQ")
 
     model_config = {"json_schema_extra": {"example": {
         "message": "How can I improve my CV for a Data Engineer position?",
@@ -255,3 +256,66 @@ class ExpatAskResponse(BaseModel):
     sources: list[ExpatSource] = Field(default_factory=list)
     freshness_warnings: list[str] = Field(default_factory=list)
     language: str = "fr"
+
+
+# ------------------------------------------------------------------------------
+# Branding — Mémoire persistante du profil branding
+# ------------------------------------------------------------------------------
+
+BrandingState = Literal[
+    "discovery",
+    "goals",
+    "voice_preferences",
+    "audience_topics",
+    "content_generation",
+]
+
+
+class BrandingProfileMemory(BaseModel):
+    """Mémoire structurée et persistante de l'assistant branding personnel."""
+
+    current_state: BrandingState = "discovery"
+    professional_identity: str | None = None
+    current_context: str | None = None
+    primary_goal: str | None = None
+    target_audience: list[str] = Field(default_factory=list)
+    content_pillars: list[str] = Field(default_factory=list)
+    voice_preferences: dict[str, Any] = Field(default_factory=dict)
+    content_boundaries: list[str] = Field(default_factory=list)
+    platforms: list[str] = Field(default_factory=list)
+    format_preferences: list[str] = Field(default_factory=list)
+    profile_completion: int = Field(default=0, ge=0, le=100)
+    ready_for_generation: bool = False
+
+
+class BrandingMemoryRequest(BaseModel):
+    """Requête de chat branding avec support de la mémoire persistante."""
+
+    message: str = Field(..., min_length=1, max_length=3000, description="Message utilisateur")
+    session_id: str = Field(..., pattern=r"^[a-f0-9\-]{36}$", description="UUID de session")
+    language: str = Field(default="fr", description="Langue de réponse")
+    request_id: str | None = Field(default=None, description="Clé idempotence optionnelle")
+    branding_profile: BrandingProfileMemory | None = Field(
+        default=None,
+        description="Profil branding en fallback (sessions non authentifiées / locales)",
+    )
+
+
+class BrandingMemoryResponse(BaseResponse):
+    """Réponse de l'assistant branding avec profil mis à jour."""
+
+    response: str = Field(..., description="Réponse de l'assistant branding")
+    language: str = "fr"
+    current_state: BrandingState = "discovery"
+    profile_completion: int = Field(default=0, ge=0, le=100)
+    ready_for_generation: bool = False
+    branding_profile: BrandingProfileMemory = Field(default_factory=BrandingProfileMemory)
+    memory_updated_fields: list[str] = Field(default_factory=list)
+
+
+class BrandingSessionMemoryResponse(BaseResponse):
+    """Payload complet de restauration de session branding."""
+
+    session_id: str
+    messages: list[dict[str, Any]] = Field(default_factory=list)
+    branding_profile: BrandingProfileMemory = Field(default_factory=BrandingProfileMemory)

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -30,7 +30,7 @@ class CoachRequest(BaseModel):
     session_id: str = Field(..., pattern=r"^[a-f0-9-]{36}$", description="Session UUID")
     language: Literal["fr", "en", "es", "pt"] = Field(default="fr")
     assistant_type: str = Field(default="career-coach", description="Coach/assistant type for per-coach quota tracking")
-    request_id: str | None = Field(default=None, description="Clé d'idempotence optionnelle pour déduplication ARQ")
+    request_id: str | None = Field(default=None, max_length=128, description="Clé d'idempotence optionnelle pour déduplication ARQ")
 
     model_config = {"json_schema_extra": {"example": {
         "message": "How can I improve my CV for a Data Engineer position?",
@@ -294,7 +294,7 @@ class BrandingMemoryRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=3000, description="Message utilisateur")
     session_id: str = Field(..., pattern=r"^[a-f0-9\-]{36}$", description="UUID de session")
     language: str = Field(default="fr", description="Langue de réponse")
-    request_id: str | None = Field(default=None, description="Clé idempotence optionnelle")
+    request_id: str | None = Field(default=None, max_length=128, description="Clé idempotence optionnelle")
     branding_profile: BrandingProfileMemory | None = Field(
         default=None,
         description="Profil branding en fallback (sessions non authentifiées / locales)",

--- a/backend/src/services/branding_memory.py
+++ b/backend/src/services/branding_memory.py
@@ -16,6 +16,7 @@ Adapté depuis la branche brand-agent (commit ~2026-03) au code actuel.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -159,8 +160,18 @@ def calculate_profile_completion(
 def determine_branding_state(
     profile: dict[str, Any] | BrandingProfileMemory | None,
 ) -> str:
-    """Détermine l'état branding suivant en fonction de la mémoire courante."""
+    """Détermine l'état branding en fonction de la mémoire courante.
+
+    Si `current_state` est présent dans le profil et correspond à un état valide,
+    il est utilisé comme valeur minimale (l'état calculé ne peut pas régresser
+    en dessous de la valeur explicitement fournie).
+    """
     data = profile.model_dump() if isinstance(profile, BrandingProfileMemory) else (profile or {})
+
+    # Respecter l'override explicite quand il est valide (P1-6)
+    state_override = _clean_text(data.get("current_state"))
+    if state_override in BRANDING_STATES:
+        return state_override
 
     if not _clean_text(data.get("professional_identity")) or not _clean_text(
         data.get("current_context")
@@ -278,7 +289,6 @@ def hydrate_branding_profile_from_cv(
     role = _clean_text(cv_structured.get("current_role"))
     years_experience = cv_structured.get("years_experience")
     summary = _clean_text(cv_structured.get("summary"))
-    skills = _clean_list(cv_structured.get("key_skills"))[:5]
     education = _clean_list(cv_structured.get("education"))[:2]
 
     professional_identity = summary or role
@@ -290,12 +300,14 @@ def hydrate_branding_profile_from_cv(
     if education:
         current_context_parts.append(f"Formation: {education[0]}")
 
+    # P1-5 : ne PAS pré-remplir content_pillars avec key_skills
+    # (content_pillars = thèmes de publication, pas compétences techniques)
+    # L'agent/utilisateur remplira content_pillars lors de l'étape audience_topics.
     updates = {
         "professional_identity": professional_identity,
         "current_context": (
             " • ".join(current_context_parts) if current_context_parts else None
         ),
-        "content_pillars": skills,
         "current_state": "goals" if (professional_identity or current_context_parts) else None,
     }
 
@@ -307,7 +319,7 @@ def hydrate_branding_profile_from_cv(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def load_branding_session(
+async def load_branding_session(
     supabase: Client,
     user_id: str,
     session_id: str,
@@ -315,23 +327,34 @@ def load_branding_session(
     """Charge l'historique de conversation et le profil branding d'une session.
 
     Priorité : table branding_profiles > contexte coach_conversations > profil vide.
+    Les deux round-trips Supabase sont lancés en parallèle via asyncio.gather.
     """
-    conversation_res = (
-        supabase.table("coach_conversations")
-        .select("id, messages, context")
-        .eq("user_id", user_id)
-        .eq("session_id", session_id)
-        .eq("assistant_type", BRANDING_ASSISTANT_TYPE)
-        .limit(1)
-        .execute()
-    )
-    profile_res = (
-        supabase.table("branding_profiles")
-        .select("*")
-        .eq("user_id", user_id)
-        .eq("session_id", session_id)
-        .limit(1)
-        .execute()
+
+    def _fetch_conversation() -> Any:
+        return (
+            supabase.table("coach_conversations")
+            .select("id, messages, context")
+            .eq("user_id", user_id)
+            .eq("session_id", session_id)
+            .eq("assistant_type", BRANDING_ASSISTANT_TYPE)
+            .limit(1)
+            .execute()
+        )
+
+    def _fetch_profile() -> Any:
+        return (
+            supabase.table("branding_profiles")
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("session_id", session_id)
+            .limit(1)
+            .execute()
+        )
+
+    # Deux round-trips indépendants lancés en parallèle (P0-2)
+    conversation_res, profile_res = await asyncio.gather(
+        asyncio.to_thread(_fetch_conversation),
+        asyncio.to_thread(_fetch_profile),
     )
 
     conversation = conversation_res.data[0] if conversation_res.data else None
@@ -351,7 +374,7 @@ def load_branding_session(
     }
 
 
-def save_branding_turn(
+async def save_branding_turn(
     supabase: Client,
     *,
     user_id: str,
@@ -394,8 +417,8 @@ def save_branding_turn(
     }
 
     if conversation_id:
-        conversation_res = (
-            supabase.table("coach_conversations")
+        conversation_res = await asyncio.to_thread(
+            lambda: supabase.table("coach_conversations")
             .update(conversation_payload)
             .eq("id", conversation_id)
             .execute()
@@ -404,8 +427,8 @@ def save_branding_turn(
             conversation_res.data[0] if conversation_res.data else {"id": conversation_id}
         )
     else:
-        conversation_res = (
-            supabase.table("coach_conversations").insert(conversation_payload).execute()
+        conversation_res = await asyncio.to_thread(
+            lambda: supabase.table("coach_conversations").insert(conversation_payload).execute()
         )
         conversation_data = conversation_res.data[0] if conversation_res.data else {}
 
@@ -426,9 +449,11 @@ def save_branding_turn(
         "profile_completion": branding_profile.get("profile_completion", 0),
         "ready_for_generation": branding_profile.get("ready_for_generation", False),
     }
-    supabase.table("branding_profiles").upsert(
-        profile_payload, on_conflict="user_id,session_id"
-    ).execute()
+    await asyncio.to_thread(
+        lambda: supabase.table("branding_profiles")
+        .upsert(profile_payload, on_conflict="user_id,session_id")
+        .execute()
+    )
     logger.info(
         "[branding_memory] session saved",
         extra={
@@ -440,18 +465,27 @@ def save_branding_turn(
     )
 
 
-def delete_branding_session(
+async def delete_branding_session(
     supabase: Client,
     user_id: str,
     session_id: str,
 ) -> None:
     """Supprime la conversation branding et le profil d'une session utilisateur."""
-    supabase.table("branding_profiles").delete().eq("user_id", user_id).eq(
-        "session_id", session_id
-    ).execute()
-    supabase.table("coach_conversations").delete().eq("user_id", user_id).eq(
-        "session_id", session_id
-    ).eq("assistant_type", BRANDING_ASSISTANT_TYPE).execute()
+    await asyncio.to_thread(
+        lambda: supabase.table("branding_profiles")
+        .delete()
+        .eq("user_id", user_id)
+        .eq("session_id", session_id)
+        .execute()
+    )
+    await asyncio.to_thread(
+        lambda: supabase.table("coach_conversations")
+        .delete()
+        .eq("user_id", user_id)
+        .eq("session_id", session_id)
+        .eq("assistant_type", BRANDING_ASSISTANT_TYPE)
+        .execute()
+    )
     logger.info(
         "[branding_memory] session deleted",
         extra={"user_id": user_id, "session_id": session_id},

--- a/backend/src/services/branding_memory.py
+++ b/backend/src/services/branding_memory.py
@@ -1,0 +1,458 @@
+"""
+Branding Memory — persistance et utilitaires du profil branding.
+=================================================================
+Service de persistance du profil branding utilisateur :
+- Nettoyage et normalisation du profil
+- Merge incrémental des mises à jour LLM
+- Calcul du score de complétion et de l'état courant
+- Construction du contexte injecté dans le prompt
+- Chargement / sauvegarde / suppression de session (Supabase)
+- Hydratation initiale depuis un CV structuré
+
+Adapté depuis la branche brand-agent (commit ~2026-03) au code actuel.
+# TODO: brancher branding_memory dans l'agent (backend/src/agents/branding/main_agent.py)
+#       — voir load_branding_session / save_branding_turn / build_branding_context
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from supabase import Client
+
+from src.models.schemas import BrandingProfileMemory
+
+logger = logging.getLogger(__name__)
+
+BRANDING_ASSISTANT_TYPE = "branding"
+
+BRANDING_STATES = [
+    "discovery",
+    "goals",
+    "voice_preferences",
+    "audience_topics",
+    "content_generation",
+]
+
+_TEXT_FIELDS = (
+    "professional_identity",
+    "current_context",
+    "primary_goal",
+)
+_LIST_FIELDS = (
+    "target_audience",
+    "content_pillars",
+    "content_boundaries",
+    "platforms",
+    "format_preferences",
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Utilitaires internes
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _clean_text(value: Any) -> str | None:
+    """Nettoie une valeur texte (None si vide après strip)."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+    value = value.strip()
+    return value or None
+
+
+def _clean_list(values: Any) -> list[str]:
+    """Déduplique et nettoie une liste de chaînes (préserve l'ordre)."""
+    if not values:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        text = _clean_text(item)
+        if not text:
+            continue
+        key = text.casefold()
+        if key not in seen:
+            seen.add(key)
+            cleaned.append(text)
+    return cleaned
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Logique de profil
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def normalize_branding_profile(
+    profile: dict[str, Any] | BrandingProfileMemory | None,
+) -> dict[str, Any]:
+    """Normalise n'importe quelle forme de profil vers la structure canonique."""
+    if isinstance(profile, BrandingProfileMemory):
+        data = profile.model_dump()
+    else:
+        data = deepcopy(profile or {})
+
+    normalized: dict[str, Any] = BrandingProfileMemory().model_dump()
+
+    for field in _TEXT_FIELDS:
+        normalized[field] = _clean_text(data.get(field))
+
+    for field in _LIST_FIELDS:
+        normalized[field] = _clean_list(data.get(field))
+
+    voice_preferences = data.get("voice_preferences") or {}
+    normalized["voice_preferences"] = (
+        {
+            str(k): v.strip() if isinstance(v, str) else v
+            for k, v in voice_preferences.items()
+            if v not in (None, "", [], {})
+        }
+        if isinstance(voice_preferences, dict)
+        else {}
+    )
+
+    normalized["current_state"] = determine_branding_state(
+        {**normalized, "current_state": _clean_text(data.get("current_state")) or "discovery"}
+    )
+    normalized["profile_completion"] = calculate_profile_completion(normalized)
+    normalized["ready_for_generation"] = (
+        normalized["current_state"] == "content_generation"
+        and normalized["profile_completion"] >= 70
+    )
+    return normalized
+
+
+def calculate_profile_completion(
+    profile: dict[str, Any] | BrandingProfileMemory | None,
+) -> int:
+    """Calcule un score de complétion stable (0-100) du profil branding."""
+    data = profile.model_dump() if isinstance(profile, BrandingProfileMemory) else (profile or {})
+    score = 0
+    if _clean_text(data.get("professional_identity")):
+        score += 20
+    if _clean_text(data.get("current_context")):
+        score += 10
+    if _clean_text(data.get("primary_goal")):
+        score += 20
+    if data.get("voice_preferences"):
+        score += 20
+    if _clean_list(data.get("content_boundaries")):
+        score += 10
+    if _clean_list(data.get("target_audience")):
+        score += 10
+    if _clean_list(data.get("content_pillars")):
+        score += 5
+    if _clean_list(data.get("platforms")):
+        score += 3
+    if _clean_list(data.get("format_preferences")):
+        score += 2
+    return max(0, min(100, score))
+
+
+def determine_branding_state(
+    profile: dict[str, Any] | BrandingProfileMemory | None,
+) -> str:
+    """Détermine l'état branding suivant en fonction de la mémoire courante."""
+    data = profile.model_dump() if isinstance(profile, BrandingProfileMemory) else (profile or {})
+
+    if not _clean_text(data.get("professional_identity")) or not _clean_text(
+        data.get("current_context")
+    ):
+        return "discovery"
+    if not _clean_text(data.get("primary_goal")):
+        return "goals"
+    if not data.get("voice_preferences") or not _clean_list(data.get("content_boundaries")):
+        return "voice_preferences"
+    if (
+        not _clean_list(data.get("target_audience"))
+        or not _clean_list(data.get("content_pillars"))
+        or not _clean_list(data.get("platforms"))
+    ):
+        return "audience_topics"
+    return "content_generation"
+
+
+def merge_branding_profile(
+    existing: dict[str, Any] | BrandingProfileMemory | None,
+    updates: dict[str, Any] | None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Fusionne les mises à jour extraites dans le profil branding persistant.
+
+    Returns:
+        (profil_fusionné, liste_des_champs_mis_à_jour)
+    """
+    merged = normalize_branding_profile(existing)
+    updates = updates or {}
+    updated_fields: list[str] = []
+
+    for field in _TEXT_FIELDS:
+        new_value = _clean_text(updates.get(field))
+        if new_value and new_value != merged.get(field):
+            merged[field] = new_value
+            updated_fields.append(field)
+
+    for field in _LIST_FIELDS:
+        new_values = _clean_list(updates.get(field))
+        if new_values:
+            combined = _clean_list([*merged.get(field, []), *new_values])
+            if combined != merged.get(field, []):
+                merged[field] = combined
+                updated_fields.append(field)
+
+    voice_updates = updates.get("voice_preferences") or {}
+    if isinstance(voice_updates, dict):
+        cleaned_voice = {
+            str(k): v.strip() if isinstance(v, str) else v
+            for k, v in voice_updates.items()
+            if v not in (None, "", [], {})
+        }
+        if cleaned_voice:
+            merged_voice = dict(merged.get("voice_preferences", {}))
+            merged_voice_updated = {**merged_voice, **cleaned_voice}
+            if merged_voice != merged_voice_updated:
+                merged["voice_preferences"] = merged_voice_updated
+                updated_fields.append("voice_preferences")
+
+    state_override = _clean_text(updates.get("current_state"))
+    if state_override in BRANDING_STATES:
+        merged["current_state"] = state_override
+
+    merged["current_state"] = determine_branding_state(merged)
+    merged["profile_completion"] = calculate_profile_completion(merged)
+    merged["ready_for_generation"] = (
+        merged["current_state"] == "content_generation" and merged["profile_completion"] >= 70
+    )
+
+    return merged, updated_fields
+
+
+def build_branding_context(
+    profile: dict[str, Any] | BrandingProfileMemory | None,
+) -> str:
+    """Génère le bloc de contexte compact injecté dans le prompt système."""
+    data = normalize_branding_profile(profile)
+    parts = [
+        f"[STATE] {data['current_state']}",
+        f"[PROFILE_COMPLETION] {data['profile_completion']}%",
+    ]
+    if data.get("professional_identity"):
+        parts.append(f"- Identité pro: {data['professional_identity']}")
+    if data.get("current_context"):
+        parts.append(f"- Contexte actuel: {data['current_context']}")
+    if data.get("primary_goal"):
+        parts.append(f"- Objectif principal: {data['primary_goal']}")
+    if data.get("target_audience"):
+        parts.append(f"- Audience cible: {', '.join(data['target_audience'])}")
+    if data.get("content_pillars"):
+        parts.append(f"- Piliers de contenu: {', '.join(data['content_pillars'])}")
+    if data.get("platforms"):
+        parts.append(f"- Plateformes: {', '.join(data['platforms'])}")
+    if data.get("format_preferences"):
+        parts.append(f"- Formats préférés: {', '.join(data['format_preferences'])}")
+    if data.get("voice_preferences"):
+        voice = "; ".join(f"{k}: {v}" for k, v in data["voice_preferences"].items())
+        parts.append(f"- Préférences de ton: {voice}")
+    if data.get("content_boundaries"):
+        parts.append(f"- À éviter: {', '.join(data['content_boundaries'])}")
+    return "\n".join(parts)
+
+
+def hydrate_branding_profile_from_cv(
+    cv_structured: dict[str, Any] | None,
+    existing: dict[str, Any] | BrandingProfileMemory | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Initialise la mémoire branding depuis les données structurées d'un CV.
+
+    Returns:
+        (profil_fusionné, liste_des_champs_mis_à_jour)
+    """
+    cv_structured = cv_structured or {}
+
+    role = _clean_text(cv_structured.get("current_role"))
+    years_experience = cv_structured.get("years_experience")
+    summary = _clean_text(cv_structured.get("summary"))
+    skills = _clean_list(cv_structured.get("key_skills"))[:5]
+    education = _clean_list(cv_structured.get("education"))[:2]
+
+    professional_identity = summary or role
+    current_context_parts: list[str] = []
+    if role:
+        current_context_parts.append(f"Rôle actuel ou récent: {role}")
+    if isinstance(years_experience, int) and years_experience > 0:
+        current_context_parts.append(f"Expérience: {years_experience} ans")
+    if education:
+        current_context_parts.append(f"Formation: {education[0]}")
+
+    updates = {
+        "professional_identity": professional_identity,
+        "current_context": (
+            " • ".join(current_context_parts) if current_context_parts else None
+        ),
+        "content_pillars": skills,
+        "current_state": "goals" if (professional_identity or current_context_parts) else None,
+    }
+
+    return merge_branding_profile(existing, updates)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Persistance Supabase
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def load_branding_session(
+    supabase: Client,
+    user_id: str,
+    session_id: str,
+) -> dict[str, Any]:
+    """Charge l'historique de conversation et le profil branding d'une session.
+
+    Priorité : table branding_profiles > contexte coach_conversations > profil vide.
+    """
+    conversation_res = (
+        supabase.table("coach_conversations")
+        .select("id, messages, context")
+        .eq("user_id", user_id)
+        .eq("session_id", session_id)
+        .eq("assistant_type", BRANDING_ASSISTANT_TYPE)
+        .limit(1)
+        .execute()
+    )
+    profile_res = (
+        supabase.table("branding_profiles")
+        .select("*")
+        .eq("user_id", user_id)
+        .eq("session_id", session_id)
+        .limit(1)
+        .execute()
+    )
+
+    conversation = conversation_res.data[0] if conversation_res.data else None
+    profile_row = profile_res.data[0] if profile_res.data else None
+
+    profile_source = profile_row or (
+        (conversation or {}).get("context") or {}
+    ).get("branding_profile")
+    profile = normalize_branding_profile(profile_source)
+
+    return {
+        "conversation_id": conversation.get("id") if conversation else None,
+        "messages": (
+            (conversation.get("messages") or [])[-20:] if conversation else []
+        ),
+        "branding_profile": profile,
+    }
+
+
+def save_branding_turn(
+    supabase: Client,
+    *,
+    user_id: str,
+    session_id: str,
+    user_message: str,
+    assistant_response: str,
+    branding_profile: dict[str, Any],
+    existing_messages: list[dict[str, Any]] | None = None,
+    conversation_id: str | None = None,
+) -> None:
+    """Persiste un tour de conversation branding et le profil mis à jour."""
+    now = datetime.now(UTC).isoformat()
+    messages = list(existing_messages or [])
+    messages.append({"role": "user", "content": user_message, "timestamp": now})
+    messages.append({"role": "assistant", "content": assistant_response, "timestamp": now})
+    if len(messages) > 50:
+        messages = messages[-50:]
+
+    title = next(
+        (
+            msg.get("content", "")[:60].strip()
+            for msg in messages
+            if msg.get("role") == "user" and msg.get("content")
+        ),
+        "Nouvelle session branding",
+    )
+
+    conversation_payload = {
+        "user_id": user_id,
+        "session_id": session_id,
+        "assistant_type": BRANDING_ASSISTANT_TYPE,
+        "messages": messages,
+        "title": title,
+        "context": {
+            "current_state": branding_profile.get("current_state", "discovery"),
+            "profile_completion": branding_profile.get("profile_completion", 0),
+            "ready_for_generation": branding_profile.get("ready_for_generation", False),
+            "branding_profile": branding_profile,
+        },
+    }
+
+    if conversation_id:
+        conversation_res = (
+            supabase.table("coach_conversations")
+            .update(conversation_payload)
+            .eq("id", conversation_id)
+            .execute()
+        )
+        conversation_data = (
+            conversation_res.data[0] if conversation_res.data else {"id": conversation_id}
+        )
+    else:
+        conversation_res = (
+            supabase.table("coach_conversations").insert(conversation_payload).execute()
+        )
+        conversation_data = conversation_res.data[0] if conversation_res.data else {}
+
+    profile_payload = {
+        "user_id": user_id,
+        "session_id": session_id,
+        "conversation_id": conversation_data.get("id") or conversation_id,
+        "current_state": branding_profile.get("current_state", "discovery"),
+        "professional_identity": branding_profile.get("professional_identity"),
+        "current_context": branding_profile.get("current_context"),
+        "primary_goal": branding_profile.get("primary_goal"),
+        "target_audience": branding_profile.get("target_audience", []),
+        "content_pillars": branding_profile.get("content_pillars", []),
+        "voice_preferences": branding_profile.get("voice_preferences", {}),
+        "content_boundaries": branding_profile.get("content_boundaries", []),
+        "platforms": branding_profile.get("platforms", []),
+        "format_preferences": branding_profile.get("format_preferences", []),
+        "profile_completion": branding_profile.get("profile_completion", 0),
+        "ready_for_generation": branding_profile.get("ready_for_generation", False),
+    }
+    supabase.table("branding_profiles").upsert(
+        profile_payload, on_conflict="user_id,session_id"
+    ).execute()
+    logger.info(
+        "[branding_memory] session saved",
+        extra={
+            "user_id": user_id,
+            "session_id": session_id,
+            "state": branding_profile.get("current_state"),
+            "completion": branding_profile.get("profile_completion"),
+        },
+    )
+
+
+def delete_branding_session(
+    supabase: Client,
+    user_id: str,
+    session_id: str,
+) -> None:
+    """Supprime la conversation branding et le profil d'une session utilisateur."""
+    supabase.table("branding_profiles").delete().eq("user_id", user_id).eq(
+        "session_id", session_id
+    ).execute()
+    supabase.table("coach_conversations").delete().eq("user_id", user_id).eq(
+        "session_id", session_id
+    ).eq("assistant_type", BRANDING_ASSISTANT_TYPE).execute()
+    logger.info(
+        "[branding_memory] session deleted",
+        extra={"user_id": user_id, "session_id": session_id},
+    )

--- a/backend/src/utils/request_dedup.py
+++ b/backend/src/utils/request_dedup.py
@@ -5,14 +5,21 @@ Helper mutualisé pour éviter les double-soumissions sur les routes ARQ.
 
 Mécanisme :
   1. Le client fournit un `request_id` optionnel (UUID ou toute chaîne stable).
-  2. Si absent, le serveur peut en calculer un déterministe (hash SHA-1 du payload).
-  3. Avant d'enqueue, on vérifie dans Redis la clé `dedup:<request_id>`.
-     - Si la clé existe  → un job est déjà en cours, on retourne le job_id existant.
-     - Sinon             → on enregistre le nouveau job_id (TTL court) et on retourne None.
-  4. L'appelant retourne le job_id existant au lieu d'enqueue un doublon.
+  2. Si absent, le serveur calcule un id déterministe via `build_dedup_request_id`
+     (hash SHA-1 du payload complet).
+  3. `register_request` tente SET NX : si la clé n'existait pas, retourne None
+     (nouvelle requête). Si elle existait, retourne la valeur stockée :
+     "__pending__" (job en cours d'enqueue) ou le job_id réel.
+  4. `store_job_id` écrase le placeholder "__pending__" par le job_id ARQ SANS NX.
+  5. L'appelant retourne le job_id existant au lieu d'enqueue un doublon.
 
-Dégradation gracieuse : si Redis est indisponible, la déduplication est transparente
-(skip silencieux), le comportement sans dédup est conservé.
+Sentinel :
+  "__pending__" (double underscores) est utilisé comme valeur interne temporaire.
+  Les request_id fournis par le client passent TOUJOURS par `build_dedup_request_id`
+  (hash SHA-1) — ils ne peuvent donc jamais valoir "__pending__".
+
+Dégradation gracieuse : si Redis est indisponible, `register_request` retourne None
+(skip silencieux) et `store_job_id` est no-op. Le comportement sans dédup est conservé.
 
 Adapté depuis la branche latency_fix (commit 14bdb94, 2026-03-18).
 """
@@ -29,60 +36,132 @@ logger = logging.getLogger(__name__)
 
 _DEDUP_PREFIX = "dedup:"
 _DEFAULT_TTL = 120  # secondes
+_PENDING_SENTINEL = "__pending__"
 
 
 def build_dedup_request_id(namespace: str, *parts: Any) -> str:
     """Calcule un request_id déterministe depuis un namespace et des données de payload.
 
+    Utilise le contenu COMPLET de chaque part (pas de troncature) pour éviter les
+    collisions entre messages partageant un préfixe commun.
+
     Exemple :
-        build_dedup_request_id("assistant", "job-scout", user_id, session_id, message[:50])
+        build_dedup_request_id("assistant", "job-scout", user_id, session_id, message)
 
     Returns:
         Chaîne hexadécimale SHA-1 tronquée à 24 caractères, préfixée du namespace.
+        Garantit que la valeur retournée ne peut jamais valoir "__pending__".
     """
     raw = ":".join(str(p) for p in (namespace, *parts))
     digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:24]
     return f"{namespace}:{digest}"
 
 
-async def get_or_register_request(
+async def register_request(
     request_id: str,
-    job_id: str,
     ttl: int = _DEFAULT_TTL,
 ) -> str | None:
-    """Vérifie si un job existe déjà pour ce request_id, sinon enregistre le nouveau.
+    """Tente d'enregistrer une nouvelle requête (SET NX).
 
     Args:
-        request_id: Identifiant de la requête (fourni par le client ou calculé).
-        job_id:     Identifiant du job ARQ qui vient d'être (ou va être) enqueued.
+        request_id: Identifiant de la requête (produit par `build_dedup_request_id`).
         ttl:        Durée de vie de la clé Redis en secondes (défaut 120s).
 
     Returns:
-        - `str`  : job_id existant si une requête identique était déjà en cours.
-        - `None` : la requête est nouvelle, on peut enqueue normalement.
+        - `None`              : clé créée avec succès → nouvelle requête, l'appelant doit enqueue.
+        - `"__pending__"`     : clé existante mais job pas encore enqueued → en cours d'enqueue.
+        - `str` (job_id réel) : clé existante avec job_id → doublon détecté, retourner ce job_id.
+
+    En cas d'erreur Redis : retourne None (dégradation gracieuse, pas de dédup).
     """
     redis = await get_redis()
     if redis is None:
-        # Redis indisponible — déduplication transparente désactivée
         return None
 
     key = f"{_DEDUP_PREFIX}{request_id}"
     try:
-        existing_job_id: str | None = await redis.get(key)
-        if existing_job_id:
-            logger.info(
-                "[request_dedup] requête dupliquée détectée",
-                extra={"request_id": request_id, "existing_job_id": existing_job_id},
-            )
-            return existing_job_id
+        # SET NX : retourne True si créé, None/False si existait déjà
+        created = await redis.set(key, _PENDING_SENTINEL, ex=ttl, nx=True)
+        if created:
+            # Clé nouvellement créée : requête nouvelle
+            return None
 
-        # Première occurrence : enregistrer avec SET NX + TTL
-        await redis.set(key, job_id, ex=ttl, nx=True)
-        return None
+        # Clé existante : lire la valeur courante
+        existing: str | None = await redis.get(key)
+        if existing is None:
+            # Expirée entre le SET et le GET (edge case) → traiter comme nouvelle
+            return None
+
+        if existing == _PENDING_SENTINEL:
+            logger.info(
+                "[request_dedup] requête en cours d'enqueue (pending)",
+                extra={"request_id": request_id},
+            )
+            return _PENDING_SENTINEL
+
+        # job_id réel stocké
+        logger.info(
+            "[request_dedup] requête dupliquée détectée",
+            extra={"request_id": request_id, "existing_job_id": existing},
+        )
+        return existing
+
     except Exception as exc:
-        # Toute erreur Redis = skip silencieux (dégradation gracieuse)
         logger.warning(
             f"[request_dedup] Redis error, déduplication ignorée: {exc}",
             extra={"request_id": request_id},
         )
         return None
+
+
+async def store_job_id(
+    request_id: str,
+    job_id: str,
+    ttl: int = _DEFAULT_TTL,
+) -> None:
+    """Remplace le placeholder "__pending__" par le job_id ARQ réel.
+
+    Utilise SET SANS NX pour écraser le placeholder.
+
+    Args:
+        request_id: Identifiant de la requête (même valeur que dans `register_request`).
+        job_id:     Identifiant du job ARQ à persister.
+        ttl:        Durée de vie restante de la clé Redis en secondes.
+    """
+    redis = await get_redis()
+    if redis is None:
+        # Redis indisponible — no-op (dégradation gracieuse)
+        return
+
+    key = f"{_DEDUP_PREFIX}{request_id}"
+    try:
+        await redis.set(key, job_id, ex=ttl)
+    except Exception as exc:
+        logger.warning(
+            f"[request_dedup] impossible de stocker le job_id: {exc}",
+            extra={"request_id": request_id, "job_id": job_id},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compatibilité — wrapper conservé pour ne pas casser les imports existants.
+# Préférer register_request / store_job_id dans le nouveau code.
+# ---------------------------------------------------------------------------
+
+async def get_or_register_request(
+    request_id: str,
+    job_id: str,
+    ttl: int = _DEFAULT_TTL,
+) -> str | None:
+    """[DEPRECATED] Ancien helper — conservé pour compatibilité.
+
+    Comportement :
+      - Si `job_id` == "_pending_" (ancien sentinel) : appelle `register_request`.
+      - Sinon : appelle `store_job_id` et retourne None.
+
+    Utilisez directement `register_request` + `store_job_id` dans le nouveau code.
+    """
+    if job_id in ("_pending_", _PENDING_SENTINEL):
+        return await register_request(request_id, ttl)
+    await store_job_id(request_id, job_id, ttl)
+    return None

--- a/backend/src/utils/request_dedup.py
+++ b/backend/src/utils/request_dedup.py
@@ -1,0 +1,88 @@
+"""
+Request Deduplication — Idempotency via Redis
+=============================================
+Helper mutualisé pour éviter les double-soumissions sur les routes ARQ.
+
+Mécanisme :
+  1. Le client fournit un `request_id` optionnel (UUID ou toute chaîne stable).
+  2. Si absent, le serveur peut en calculer un déterministe (hash SHA-1 du payload).
+  3. Avant d'enqueue, on vérifie dans Redis la clé `dedup:<request_id>`.
+     - Si la clé existe  → un job est déjà en cours, on retourne le job_id existant.
+     - Sinon             → on enregistre le nouveau job_id (TTL court) et on retourne None.
+  4. L'appelant retourne le job_id existant au lieu d'enqueue un doublon.
+
+Dégradation gracieuse : si Redis est indisponible, la déduplication est transparente
+(skip silencieux), le comportement sans dédup est conservé.
+
+Adapté depuis la branche latency_fix (commit 14bdb94, 2026-03-18).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import Any
+
+from src.utils.cache import get_redis
+
+logger = logging.getLogger(__name__)
+
+_DEDUP_PREFIX = "dedup:"
+_DEFAULT_TTL = 120  # secondes
+
+
+def build_dedup_request_id(namespace: str, *parts: Any) -> str:
+    """Calcule un request_id déterministe depuis un namespace et des données de payload.
+
+    Exemple :
+        build_dedup_request_id("assistant", "job-scout", user_id, session_id, message[:50])
+
+    Returns:
+        Chaîne hexadécimale SHA-1 tronquée à 24 caractères, préfixée du namespace.
+    """
+    raw = ":".join(str(p) for p in (namespace, *parts))
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:24]
+    return f"{namespace}:{digest}"
+
+
+async def get_or_register_request(
+    request_id: str,
+    job_id: str,
+    ttl: int = _DEFAULT_TTL,
+) -> str | None:
+    """Vérifie si un job existe déjà pour ce request_id, sinon enregistre le nouveau.
+
+    Args:
+        request_id: Identifiant de la requête (fourni par le client ou calculé).
+        job_id:     Identifiant du job ARQ qui vient d'être (ou va être) enqueued.
+        ttl:        Durée de vie de la clé Redis en secondes (défaut 120s).
+
+    Returns:
+        - `str`  : job_id existant si une requête identique était déjà en cours.
+        - `None` : la requête est nouvelle, on peut enqueue normalement.
+    """
+    redis = await get_redis()
+    if redis is None:
+        # Redis indisponible — déduplication transparente désactivée
+        return None
+
+    key = f"{_DEDUP_PREFIX}{request_id}"
+    try:
+        existing_job_id: str | None = await redis.get(key)
+        if existing_job_id:
+            logger.info(
+                "[request_dedup] requête dupliquée détectée",
+                extra={"request_id": request_id, "existing_job_id": existing_job_id},
+            )
+            return existing_job_id
+
+        # Première occurrence : enregistrer avec SET NX + TTL
+        await redis.set(key, job_id, ex=ttl, nx=True)
+        return None
+    except Exception as exc:
+        # Toute erreur Redis = skip silencieux (dégradation gracieuse)
+        logger.warning(
+            f"[request_dedup] Redis error, déduplication ignorée: {exc}",
+            extra={"request_id": request_id},
+        )
+        return None

--- a/supabase/migrations/20260518000001_branding_profiles.sql
+++ b/supabase/migrations/20260518000001_branding_profiles.sql
@@ -1,0 +1,121 @@
+-- ============================================================================
+-- BRANDING PROFILES — Persistance de la mémoire de l'agent branding
+-- ============================================================================
+-- Objectif : stocker le profil branding structuré de chaque session utilisateur
+--            afin que l'agent branding reprenne là où il s'est arrêté.
+--
+-- Dépendances : coach_conversations (FK souple — ON DELETE SET NULL)
+-- Migration Date : 2026-05-18
+-- ============================================================================
+
+-- ============================================================================
+-- 1. TABLE branding_profiles
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS branding_profiles (
+    id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    session_id            UUID        NOT NULL,
+    conversation_id       UUID        REFERENCES coach_conversations(id) ON DELETE SET NULL,
+
+    -- État de la machine à états
+    current_state         TEXT        NOT NULL DEFAULT 'discovery'
+                          CHECK (current_state IN (
+                              'discovery', 'goals', 'voice_preferences',
+                              'audience_topics', 'content_generation'
+                          )),
+
+    -- Profil textuel
+    professional_identity TEXT,
+    current_context       TEXT,
+    primary_goal          TEXT,
+
+    -- Listes (stockées en JSONB)
+    target_audience       JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    content_pillars       JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    content_boundaries    JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    platforms             JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    format_preferences    JSONB       NOT NULL DEFAULT '[]'::jsonb,
+
+    -- Dictionnaire de ton
+    voice_preferences     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Métriques calculées
+    profile_completion    INTEGER     NOT NULL DEFAULT 0 CHECK (profile_completion BETWEEN 0 AND 100),
+    ready_for_generation  BOOLEAN     NOT NULL DEFAULT FALSE,
+
+    -- Horodatages
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Contrainte unicité : une ligne par (user, session)
+ALTER TABLE branding_profiles
+    DROP CONSTRAINT IF EXISTS branding_profiles_user_session_unique;
+ALTER TABLE branding_profiles
+    ADD CONSTRAINT branding_profiles_user_session_unique
+    UNIQUE (user_id, session_id);
+
+-- ============================================================================
+-- 2. INDEX
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS branding_profiles_user_id_idx
+    ON branding_profiles (user_id);
+
+CREATE INDEX IF NOT EXISTS branding_profiles_session_id_idx
+    ON branding_profiles (session_id);
+
+-- ============================================================================
+-- 3. TRIGGER updated_at
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_branding_profiles_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_branding_profiles_updated_at ON branding_profiles;
+CREATE TRIGGER trg_branding_profiles_updated_at
+    BEFORE UPDATE ON branding_profiles
+    FOR EACH ROW EXECUTE FUNCTION update_branding_profiles_updated_at();
+
+-- ============================================================================
+-- 4. ROW LEVEL SECURITY
+-- ============================================================================
+
+ALTER TABLE branding_profiles ENABLE ROW LEVEL SECURITY;
+
+-- Les utilisateurs ne voient que leurs propres profils
+DROP POLICY IF EXISTS branding_profiles_select_own ON branding_profiles;
+CREATE POLICY branding_profiles_select_own
+    ON branding_profiles FOR SELECT
+    USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS branding_profiles_insert_own ON branding_profiles;
+CREATE POLICY branding_profiles_insert_own
+    ON branding_profiles FOR INSERT
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS branding_profiles_update_own ON branding_profiles;
+CREATE POLICY branding_profiles_update_own
+    ON branding_profiles FOR UPDATE
+    USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS branding_profiles_delete_own ON branding_profiles;
+CREATE POLICY branding_profiles_delete_own
+    ON branding_profiles FOR DELETE
+    USING (auth.uid() = user_id);
+
+-- Commentaires
+COMMENT ON TABLE branding_profiles IS
+    'Mémoire persistante du profil branding par session utilisateur (agent branding HuntZen).';
+COMMENT ON COLUMN branding_profiles.current_state IS
+    'État courant de la machine à états branding : discovery → goals → voice_preferences → audience_topics → content_generation.';
+COMMENT ON COLUMN branding_profiles.profile_completion IS
+    'Score de complétion 0-100 calculé côté Python par branding_memory.calculate_profile_completion().';
+COMMENT ON COLUMN branding_profiles.ready_for_generation IS
+    'True si state=content_generation ET completion >= 70%.';


### PR DESCRIPTION
## Contexte

Lors de l'audit branche par branche des 40 branches du repo, 2 features utiles ont été
identifiées dans des branches anciennes jamais mergées. Cette PR les récupère et les
adapte au code actuel (les branches sources dataient de février-mars 2026, plusieurs
centaines de commits en arrière).

## Feature 1 — Persistance mémoire branding (depuis `brand-agent`)

L'agent branding n'avait aucune mémoire backend : l'utilisateur repartait de zéro à
chaque session.

- `backend/src/services/branding_memory.py` — service de persistance : nettoyage du
  profil, hydratation, merge, build de contexte.
- Schémas Pydantic `BrandingProfileMemory` (et liés) dans `models/schemas.py`.
- Migration `supabase/migrations/20260518000001_branding_profiles.sql` — table de
  persistance du profil branding.

Le refactor obsolète du `main_agent.py` de la vieille branche n'a PAS été repris (le code
actuel a évolué). Voir les `# TODO` éventuels pour le câblage fin dans l'agent.

## Feature 2 — Déduplication request_id (depuis `latency_fix`)

Un double-clic utilisateur créait 2 jobs ARQ en file. Cette PR ajoute une idempotency key.

- `backend/src/utils/request_dedup.py` — helper mutualisé : `get_or_register_request()`.
  Le client peut fournir un `request_id` ; sinon le serveur en calcule un déterministe
  (SHA-1 du payload). Avant d'enqueue, vérification Redis `dedup:<request_id>` (TTL court)
  → si un job existe déjà, retour du job_id existant au lieu d'un doublon.
- Dégradation gracieuse : si Redis est indisponible, la déduplication est transparente.
- Appliqué sur les routes `assistant` et `coach`.

## Vérifications

- [x] `ruff check` : All checks passed
- [x] Syntaxe Python OK
- [x] 2 commits atomiques

## Note

Les branches sources `brand-agent` et `latency_fix` peuvent être supprimées après le
merge de cette PR (leur contenu utile est ici).