### PR TITLE
docs: fix broken internal links and tree inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ huntzen_jobsearch/
 │   │   ├── services/          # External Services
 │   │   │   ├── job_providers/ # Adzuna, SerpAPI, RemoteOK
 │   │   │   ├── events/        # Tech events scraper
-│   │   │   └── pdf/           # CV parsing (IBM Docling)
+│   │   │   ├── pdf_generator.py        # CV PDF generation (WeasyPrint)
+│   │   │   └── modal_pdf_extractor.py  # CV extraction via Modal Labs
 │   │   │
 │   │   ├── models/            # Pydantic Schemas
 │   │   ├── config/            # Settings & Configuration
@@ -113,9 +114,9 @@ huntzen_jobsearch/
 │   │   │   ├── jobs/         # Job search & listings
 │   │   │   └── coach/        # Career coach chat
 │   │   │
+│   │   ├── hooks/            # React hooks customs
 │   │   ├── lib/              # Libraries & Utilities
 │   │   │   ├── security/     # Rate limiting, monitoring
-│   │   │   ├── hooks/        # React hooks
 │   │   │   └── utils/        # Helper functions
 │   │   │
 │   │   └── types/            # TypeScript type definitions

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -37,7 +37,7 @@ Modèle : freemium + premium (Stripe). Multi-langues : fr, en, es, pt.
 1. Lire [`docs/setup/docker.md`](setup/docker.md) — section "Démarrage rapide"
 2. Cloner, configurer `.env` (copier `.env.example`), lancer `npm run dev`
 3. Vérifier que `http://localhost:3000` charge et que `http://localhost:8000/docs` affiche Swagger
-4. Lire [`docs/setup/contributing.md`](setup/contributing.md) — sections "Workflow Git" et "Conventions"
+4. Lire [`CONTRIBUTING.md`](../CONTRIBUTING.md) — sections "Workflow Git" et "Conventions"
 
 ### ⏱ 1 journée — Être autonome sur sa première PR
 1. Lire complètement [`CONTRIBUTING.md`](../CONTRIBUTING.md) — règles projet et workflow Git
@@ -65,7 +65,7 @@ Modèle : freemium + premium (Stripe). Multi-langues : fr, en, es, pt.
 | [`CONTRIBUTING.md`](../CONTRIBUTING.md) | Workflow Git, conventions, ouverture de PR | Tout nouveau dev |
 | [`docs/architecture/overview.md`](architecture/overview.md) | Vue d'ensemble technique (17 sections) | Tout nouveau dev |
 | [`docs/setup/docker.md`](setup/docker.md) | Lancer le stack en local | Avant 1ère exécution |
-| [`docs/setup/contributing.md`](setup/contributing.md) | Workflow Git, conventions, PR | Avant 1ère PR |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | Workflow Git, conventions, PR | Avant 1ère PR |
 | [`docs/audit/MAP.md`](audit/MAP.md) | **Cartographie exhaustive du code** (composants, endpoints, tables) | Avant créer/modifier |
 
 ### 🟡 Tier 2 — RÉFÉRENCE (consulter selon le besoin)
@@ -114,7 +114,7 @@ Modèle : freemium + premium (Stripe). Multi-langues : fr, en, es, pt.
 | Quelle variable d'env utiliser | `.env.example` (134 vars) + `docs/RUNBOOK.md` §6 |
 | Pourquoi telle décision a été prise | `docs/audit/MAP.md` ou `docs/audit/subagents/` |
 | Quels comptes existent (Stripe, Supabase, etc.) | `docs/COMPTES_PASSATION.md` |
-| Comment ouvrir une PR | `docs/setup/contributing.md` |
+| Comment ouvrir une PR | `CONTRIBUTING.md` (racine) |
 | Convention de code TypeScript / Python | `frontend-next/AGENTS.md` ou `backend/AGENTS.md` |
 | Architecture des agents IA | `docs/architecture/overview.md` §4 (5 chatbots) + `backend/AGENTS.md` |
 | Schéma base de données | `docs/audit/MAP.md` §4 + `supabase/migrations/` |

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -474,7 +474,7 @@ UPSTASH_REDIS_REST_TOKEN=your_token_here
 
 ## Déploiement en production
 
-Pour déployer en production, voir [DEPLOYMENT.md](./DEPLOYMENT.md).
+Pour déployer en production, voir [DEPLOYMENT.md](../../DEPLOYMENT.md).
 
 **Stack de production :**
 - Frontend : Vercel
@@ -491,7 +491,7 @@ En cas de problème :
 1. Vérifier les logs : `docker compose logs -f`
 2. Vérifier le fichier `.env`
 3. Rebuild sans cache : `docker compose build --no-cache`
-4. Consulter [contributing.md](contributing.md)
+4. Consulter [CONTRIBUTING.md](../../CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
## Résumé

Audit cohérence post-restructure. Petits fixes uniquement.

## Changements

- `docs/ONBOARDING.md` : 3 liens vers `setup/contributing.md` corrigés vers `../CONTRIBUTING.md`
- `docs/setup/docker.md` : 2 liens relatifs incorrects fixés
- `README.md` : arborescence backend `services/pdf/` remplacée par les fichiers réels, frontend `lib/hooks/` remonté à `src/hooks/`

Aucun changement de contenu sémantique. 0 lien cassé après ces fixes.