### PR TITLE
docs: document all project URLs and frontend routes

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -255,7 +255,8 @@ Workflow : `feat/...` → PR vers `Pre-production` → validation → merge vers
 - **Dashboard Stripe** : paiements + webhooks
 - **Dashboard Upstash** : Redis cache + queue
 
-Comptes/accès → voir `docs/COMPTES_PASSATION.md`.
+Liste complète des URLs du projet → voir [`RUNBOOK.md`](RUNBOOK.md) section 1bis.
+Comptes/accès → voir [`COMPTES_PASSATION.md`](COMPTES_PASSATION.md).
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -12,6 +12,42 @@ Guide pratique pour exploiter, surveiller, dépanner. Complète [`architecture/o
 | Base de données | `ngiakfikbuyugqfqtfwp.supabase.co` | Supabase | n/a |
 | Redis | Upstash + Railway interne | Upstash + Railway | n/a |
 
+## 1bis. Toutes les URLs du projet
+
+### Public
+
+| Quoi | URL |
+|---|---|
+| Site (prod) | https://huntzenjobs.com (redirige vers `www.`) |
+| API backend (prod) | https://huntzenjobs-production.up.railway.app |
+| Documentation API (Swagger) | https://huntzenjobs-production.up.railway.app/docs |
+| Staging (Pre-production) | Déployé sur Vercel depuis la branche `Pre-production`. Pas forcément à jour. Utilise le même backend Railway que la prod. URL à retrouver dans le dashboard Vercel. |
+
+### Diagnostic et santé
+
+| Quoi | URL |
+|---|---|
+| Health check backend | https://huntzenjobs-production.up.railway.app/health |
+| Version déployée backend | https://huntzenjobs-production.up.railway.app/api/auth/test-debug |
+| Ping santé | https://huntzenjobs-production.up.railway.app/api/health/ping |
+
+### Code et déploiement
+
+| Quoi | URL |
+|---|---|
+| Dépôt GitHub | https://github.com/huntzenjobs/HuntzenJobs |
+| Issues | https://github.com/huntzenjobs/HuntzenJobs/issues |
+| Dashboard Railway | https://railway.app |
+| Dashboard Vercel | https://vercel.com |
+
+### Dashboards des services
+
+Les URLs de tous les services tiers (Supabase, Stripe, Groq, Sentry, Resend, etc.) sont dans [`COMPTES_PASSATION.md`](COMPTES_PASSATION.md).
+
+### Pages du site
+
+La liste complète des pages déployées (publiques, app, admin, paiement, SEO) est dans [`architecture/overview.md`](architecture/overview.md) section 14bis. Quelques pages utiles pour vérifier la prod : `/` (home), `/pricing`, `/jobs`, `/login`, `/admin`.
+
 ## 2. Comptes et propriété
 
 | Plateforme | Compte propriétaire | Où récupérer les credentials |

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -437,33 +437,91 @@ Toutes les pages déployées, base `https://huntzenjobs.com`. Les pages dans le 
 
 ### Pages publiques (marketing et légal)
 
-`/` · `/about` · `/faq` · `/pricing` · `/temoignages` · `/contact` · `/legal` · `/privacy` · `/terms`
+| Page | Rôle |
+|---|---|
+| `/` | Page d'accueil, présentation du produit et entrée vers l'inscription |
+| `/about` | À propos de HuntZen |
+| `/faq` | Questions fréquentes |
+| `/pricing` | Grille tarifaire (Free, Starter, Pro, Premium) |
+| `/temoignages` | Témoignages utilisateurs |
+| `/contact` | Formulaire de contact |
+| `/legal` | Mentions légales |
+| `/privacy` | Politique de confidentialité |
+| `/terms` | Conditions générales d'utilisation |
 
 ### Authentification
 
-`/login` · `/signup` · `/forgot-password` · `/reset-password` · `/auth/recovery` · `/onboarding`
+| Page | Rôle |
+|---|---|
+| `/login` | Connexion |
+| `/signup` | Inscription |
+| `/forgot-password` | Demande de réinitialisation du mot de passe |
+| `/reset-password` | Saisie du nouveau mot de passe |
+| `/auth/recovery` | Callback de récupération de compte (lien email) |
+| `/onboarding` | Parcours d'accueil après inscription |
 
 ### Application
 
-`/jobs` · `/saved-jobs` · `/candidatures` · `/cv-analysis` · `/documents` · `/assistant` · `/expat` · `/profile` · `/referral` · `/salons` · `/recruiter-finder` · `/recruiter-contact` · `/recruiter-contact/success`
+| Page | Rôle | Login requis |
+|---|---|---|
+| `/jobs` | Recherche d'offres d'emploi (multi-providers) | Non (SEO) |
+| `/saved-jobs` | Offres sauvegardées | Oui |
+| `/candidatures` | Suivi des candidatures | Oui (groupe dashboard) |
+| `/cv-analysis` | Analyse de CV (ATS, score) | Non (SEO) |
+| `/documents` | Gestion des documents (CV, lettres) | Oui (groupe dashboard) |
+| `/assistant` | Hub des assistants IA (coach, branding, etc.) | Non (SEO) |
+| `/expat` | Guide d'expatriation par pays | Oui (groupe dashboard) |
+| `/profile` | Profil utilisateur et abonnement | Oui |
+| `/referral` | Programme de parrainage | Oui |
+| `/salons` | Salons et forums emploi | Non (SEO) |
+| `/recruiter-finder` | Recherche de recruteurs | Oui (groupe dashboard) |
+| `/recruiter-contact` | Achat d'un contact recruteur (Stripe) | Oui (groupe dashboard) |
+| `/recruiter-contact/success` | Confirmation après paiement du contact | Oui (groupe dashboard) |
 
-Protégées par le middleware (login requis) : `/profile`, `/saved-jobs`, `/referral`. Les autres (`/jobs`, `/cv-analysis`, `/salons`, `/assistant`) restent accessibles publiquement pour le SEO.
+Note : `/profile`, `/saved-jobs` et `/referral` sont protégées par le middleware. Les autres pages du groupe dashboard exigent une connexion via leur layout serveur, sauf celles laissées publiques pour le SEO (`/jobs`, `/cv-analysis`, `/salons`, `/assistant`).
 
 ### Admin (compte admin requis)
 
-`/admin` · `/admin/dashboard` · `/admin/analytics` · `/admin/users` · `/admin/coaches` · `/admin/coupons` · `/admin/live` · `/admin/logs` · `/admin/notifications` · `/admin/plans` · `/admin/prompts` · `/admin/recruiter-requests` · `/admin/referrals` · `/admin/segments` · `/admin/stress` · `/admin/suggestions` · `/admin/support`
+| Page | Rôle |
+|---|---|
+| `/admin` | Entrée du panel admin |
+| `/admin/dashboard` | Vue d'ensemble (métriques clés) |
+| `/admin/analytics` | Statistiques détaillées |
+| `/admin/users` | Gestion des utilisateurs |
+| `/admin/coaches` | Configuration des coachs IA |
+| `/admin/coupons` | Codes promo et coupons |
+| `/admin/live` | Activité temps réel |
+| `/admin/logs` | Journaux et événements |
+| `/admin/notifications` | Envoi de notifications |
+| `/admin/plans` | Édition des plans (limites, prix, features) |
+| `/admin/prompts` | Édition des prompts IA |
+| `/admin/recruiter-requests` | Demandes de contact recruteur à traiter |
+| `/admin/referrals` | Suivi du parrainage |
+| `/admin/segments` | Segments d'utilisateurs |
+| `/admin/stress` | Dashboard de stress testing |
+| `/admin/suggestions` | Suggestions utilisateurs |
+| `/admin/support` | Support et tickets |
 
 ### Paiement
 
-`/payment/success` · `/payment/cancel`
+| Page | Rôle |
+|---|---|
+| `/payment/success` | Retour Stripe après paiement réussi |
+| `/payment/cancel` | Retour Stripe après annulation |
 
 ### SEO dynamiques (générées)
 
-`/emploi-{ville}` · `/emploi-{secteur}` — pages générées dynamiquement par ville et par secteur (voir `frontend-next/src/app/sitemap.ts`).
+| Page | Rôle |
+|---|---|
+| `/emploi-{ville}` | Landing page emploi par ville (générée, voir `sitemap.ts`) |
+| `/emploi-{secteur}` | Landing page emploi par secteur (générée) |
 
 ### Système
 
-`/maintenance` · `/offline`
+| Page | Rôle |
+|---|---|
+| `/maintenance` | Page affichée pendant une maintenance |
+| `/offline` | Page de repli hors ligne (PWA service worker) |
 
 ---
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -431,6 +431,42 @@ La plateforme supporte 4 langues : français (défaut), anglais, espagnol, portu
 
 ---
 
+## 14bis. Pages du site (routes frontend)
+
+Toutes les pages déployées, base `https://huntzenjobs.com`. Les pages dans le route group `(dashboard)` n'ont pas de préfixe `/dashboard` dans l'URL (les parenthèses sont un groupe de routes Next.js, pas un segment d'URL).
+
+### Pages publiques (marketing et légal)
+
+`/` · `/about` · `/faq` · `/pricing` · `/temoignages` · `/contact` · `/legal` · `/privacy` · `/terms`
+
+### Authentification
+
+`/login` · `/signup` · `/forgot-password` · `/reset-password` · `/auth/recovery` · `/onboarding`
+
+### Application
+
+`/jobs` · `/saved-jobs` · `/candidatures` · `/cv-analysis` · `/documents` · `/assistant` · `/expat` · `/profile` · `/referral` · `/salons` · `/recruiter-finder` · `/recruiter-contact` · `/recruiter-contact/success`
+
+Protégées par le middleware (login requis) : `/profile`, `/saved-jobs`, `/referral`. Les autres (`/jobs`, `/cv-analysis`, `/salons`, `/assistant`) restent accessibles publiquement pour le SEO.
+
+### Admin (compte admin requis)
+
+`/admin` · `/admin/dashboard` · `/admin/analytics` · `/admin/users` · `/admin/coaches` · `/admin/coupons` · `/admin/live` · `/admin/logs` · `/admin/notifications` · `/admin/plans` · `/admin/prompts` · `/admin/recruiter-requests` · `/admin/referrals` · `/admin/segments` · `/admin/stress` · `/admin/suggestions` · `/admin/support`
+
+### Paiement
+
+`/payment/success` · `/payment/cancel`
+
+### SEO dynamiques (générées)
+
+`/emploi-{ville}` · `/emploi-{secteur}` — pages générées dynamiquement par ville et par secteur (voir `frontend-next/src/app/sitemap.ts`).
+
+### Système
+
+`/maintenance` · `/offline`
+
+---
+
 ## 15. Historique de développement
 
 | Phase | Période | Réalisations principales |


### PR DESCRIPTION
## Résumé

Documentation des URLs et pages du projet.

## Changements

- overview.md section 14bis : liste de toutes les pages déployées (publiques, auth, application, admin, paiement, SEO, système), chacune avec une description de son rôle et le login requis pour les pages app
- RUNBOOK.md section 1bis : URLs publiques, diagnostic, code/déploiement, avec note sur le staging Pre-production (Vercel, même backend Railway que la prod)
- ONBOARDING.md : renvois vers ces sections